### PR TITLE
Add detailed quote breakdown API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ The frontend expects the backend to be running on `http://localhost:8000`.
 
 ## New Features
 
-This version introduces basic management of sound providers and an API for quick quote calculations that factor in travel distance, optional provider fees, and accommodation costs.  Routers are mounted under `/api/v1/sound-providers` and `/api/v1/quotes/calculate`.
+This version introduces basic management of sound providers and an API for quick quote calculations that factor in travel distance, optional provider fees, and accommodation costs. Routers are mounted under `/api/v1/sound-providers` and `/api/v1/quotes/calculate`.
+
+The quote calculation endpoint now returns a full cost breakdown:
+
+```json
+{
+  "base_fee": 100.0,
+  "travel_cost": 20.0,
+  "provider_cost": 150.0,
+  "accommodation_cost": 50.0,
+  "total": 320.0
+}
+```
 
 ## Sound Provider API
 

--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -5,7 +5,7 @@ from typing import List
 from .. import crud, models, schemas
 from .dependencies import get_db, get_current_user, get_current_active_client, get_current_active_artist
 from ..crud.crud_booking import create_booking_from_quote # Will be created later
-from ..services.booking_quote import calculate_quote
+from ..services.booking_quote import calculate_quote_breakdown, calculate_quote
 from decimal import Decimal
 
 router = APIRouter(
@@ -244,7 +244,7 @@ def confirm_quote_and_create_booking(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create booking after quote confirmation.")
 
 
-@router.post("/calculate", response_model=dict)
+@router.post("/calculate", response_model=schemas.QuoteCalculationResponse)
 def calculate_quote_endpoint(
     *,
     base_fee: Decimal,
@@ -259,5 +259,5 @@ def calculate_quote_endpoint(
         provider = db.query(models.SoundProvider).filter(models.SoundProvider.id == provider_id).first()
         if not provider:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
-    quote = calculate_quote(base_fee, distance_km, provider, accommodation_cost)
-    return {"total": quote}
+    breakdown = calculate_quote_breakdown(base_fee, distance_km, provider, accommodation_cost)
+    return breakdown

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -83,4 +83,14 @@ class QuoteResponse(QuoteBase):
     }
 
 # Update BookingRequestResponse to include quotes after QuoteResponse is defined
-BookingRequestResponse.model_rebuild() 
+BookingRequestResponse.model_rebuild()
+
+
+class QuoteCalculationResponse(BaseModel):
+    """Schema for detailed quote calculations used by the quick quote API."""
+
+    base_fee: Decimal
+    travel_cost: Decimal
+    provider_cost: Decimal
+    accommodation_cost: Decimal
+    total: Decimal

--- a/backend/app/services/booking_quote.py
+++ b/backend/app/services/booking_quote.py
@@ -1,7 +1,7 @@
 """Utilities to calculate comprehensive booking quotes."""
 
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, Dict
 
 from ..models import SoundProvider, ArtistProfile
 
@@ -22,9 +22,32 @@ def calculate_quote(
 ) -> Decimal:
     """Aggregate various cost components into a final quote."""
 
-    total = base_fee + calculate_travel_cost(distance_km)
-    if provider and provider.price_per_event:
-        total += provider.price_per_event
-    if accommodation_cost:
-        total += accommodation_cost
-    return total.quantize(Decimal("0.01"))
+    breakdown = calculate_quote_breakdown(
+        base_fee, distance_km, provider, accommodation_cost
+    )
+    return breakdown["total"]
+
+
+def calculate_quote_breakdown(
+    base_fee: Decimal,
+    distance_km: float,
+    provider: Optional[SoundProvider] = None,
+    accommodation_cost: Optional[Decimal] = None,
+) -> Dict[str, Decimal]:
+    """Return a detailed cost breakdown including the grand total."""
+
+    travel_cost = calculate_travel_cost(distance_km)
+    provider_cost = (
+        provider.price_per_event if provider and provider.price_per_event else Decimal("0.00")
+    )
+    accommodation = accommodation_cost or Decimal("0.00")
+
+    total = base_fee + travel_cost + provider_cost + accommodation
+
+    return {
+        "base_fee": base_fee.quantize(Decimal("0.01")),
+        "travel_cost": travel_cost.quantize(Decimal("0.01")),
+        "provider_cost": provider_cost.quantize(Decimal("0.01")),
+        "accommodation_cost": accommodation.quantize(Decimal("0.01")),
+        "total": total.quantize(Decimal("0.01")),
+    }


### PR DESCRIPTION
## Summary
- return cost breakdown from quote calculations
- expose `calculate_quote_breakdown` service
- document the new `/quotes/calculate` response format

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q email_validator`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684030746cf8832e8e7149a89a7f0381