### PR TITLE
Fix quote calculation endpoint

### DIFF
--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -246,18 +246,16 @@ def confirm_quote_and_create_booking(
 
 @router.post("/quotes/calculate", response_model=schemas.QuoteCalculationResponse)
 def calculate_quote_endpoint(
-    *,
-    base_fee: Decimal,
-    distance_km: float,
-    provider_id: int | None = None,
-    accommodation_cost: Decimal | None = None,
+    params: schemas.QuoteCalculationParams,
     db: Session = Depends(get_db),
 ):
     """Return a quick quote estimation used during booking flow."""
     provider = None
-    if provider_id is not None:
-        provider = db.query(models.SoundProvider).filter(models.SoundProvider.id == provider_id).first()
+    if params.provider_id is not None:
+        provider = db.query(models.SoundProvider).filter(models.SoundProvider.id == params.provider_id).first()
         if not provider:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
-    breakdown = calculate_quote_breakdown(base_fee, distance_km, provider, accommodation_cost)
+    breakdown = calculate_quote_breakdown(
+        params.base_fee, params.distance_km, provider, params.accommodation_cost
+    )
     return breakdown

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -23,6 +23,7 @@ from .request_quote import (
     QuoteUpdateByClient,
     QuoteResponse,
     QuoteCalculationResponse,
+    QuoteCalculationParams,
 )
 from .message import MessageCreate, MessageResponse
 
@@ -58,6 +59,7 @@ __all__ = [
     "QuoteUpdateByClient",
     "QuoteResponse",
     "QuoteCalculationResponse",
+    "QuoteCalculationParams",
     "MessageCreate",
     "MessageResponse",
     "SoundProviderBase",

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -95,3 +95,13 @@ class QuoteCalculationResponse(BaseModel):
     provider_cost: Decimal
     accommodation_cost: Decimal
     total: Decimal
+
+
+class QuoteCalculationParams(BaseModel):
+    """Schema for the /quotes/calculate request body."""
+
+    base_fee: Decimal
+    distance_km: float
+    provider_id: Optional[int] = None
+    accommodation_cost: Optional[Decimal] = None
+


### PR DESCRIPTION
## Summary
- support JSON body for quick quote calculation
- expose new schema in `schemas.__init__`
- add schema `QuoteCalculationParams`

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840441edc24832ea2b1084582e8d5c5