### PR TITLE
Refactor booking wizard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file documents the key automation, agent modules, and service components in
 
 | Agent Name                       | Description                                                               | Code Location                                                                       | How it Works / When Triggered                  |
 | -------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- |
-| **Booking Request Agent**        | Handles booking form data, booking flow logic, and business rules         | backend/app/api/api_booking_request.py, frontend/components/BookingForm.tsx       | When user submits or updates a booking request |
+| **Booking Request Agent**        | Handles booking wizard data, booking flow logic, and business rules         | backend/app/api/api_booking_request.py, frontend/components/booking/BookingWizard.tsx       | When user submits or updates a booking request |
 | **Provider Matching Agent**      | Matches user with artist’s preferred sound/accommodation providers        | backend/app/crud/crud_service.py, backend/app/api/api_service.py                  | Invoked during booking and quote steps         |
 | **Travel & Accommodation Agent** | Calculates travel needs, handles accommodation logic and user prompts     | backend/app/api/api_booking_request.py, frontend/components/AccommodationStep.tsx | Called if event is outside radius/needs travel |
 | **Quote Generator**              | Gathers performance, provider, travel, and accommodation costs for client | backend/app/api/api_quote.py, frontend/components/QuoteSummary.tsx                 | Runs after all booking info is entered         |
@@ -17,7 +17,7 @@ This file documents the key automation, agent modules, and service components in
 | **Chat Agent**                   | Manages client-artist/support chat, delivers new message notifications    | backend/app/api/api_chat.py, frontend/components/Chat.tsx                          | Always-on for active bookings                  |
 | **Availability Agent**           | Handles real-time artist/service availability checks                      | backend/app/api/v1/api_artist.py, frontend/components/booking/BookingWizard.tsx                | On date/service selection, booking start       |
 | **Form State Agent**             | Maintains progress, handles multi-step UX, restores unfinished bookings   | frontend/components/booking/BookingWizard.tsx, frontend/contexts/BookingContext.tsx         | Throughout user session                        |
-| **Validation Agent**             | Validates all user input (dates, contact info, logic rules)               | frontend/components/BookingForm.tsx, backend/app/schemas/                           | At every form step and backend endpoint        |
+| **Validation Agent**             | Validates all user input (dates, contact info, logic rules)               | frontend/components/booking/BookingWizard.tsx, backend/app/schemas/                           | At every form step and backend endpoint        |
 
 ---
 
@@ -26,7 +26,7 @@ This file documents the key automation, agent modules, and service components in
 ### 1. Booking Request Agent
 
 * **Purpose:** Orchestrates multi-step booking—receives event details, stores booking-in-progress, validates required info.
-* **Frontend:** `BookingForm.tsx` manages state, collects data, sends to backend.
+* **Frontend:** `BookingWizard.tsx` manages state, collects data, sends to backend.
 * **Backend:** `api_booking_request.py` parses, validates, persists booking requests, and triggers downstream agents.
 
 ### 2. Provider Matching Agent
@@ -94,7 +94,7 @@ This file documents the key automation, agent modules, and service components in
 
 ## Last Updated
 
-2024-06-04
+2024-06-06
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
         "@hookform/resolvers": "^3.3.2",
+        "@react-google-maps/api": "^2.19.1",
         "axios": "^1.6.2",
         "date-fns": "^2.30.0",
         "next": "14.0.3",
@@ -143,6 +144,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
       }
     },
     "node_modules/@headlessui/react": {
@@ -519,6 +536,36 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.6.tgz",
+      "integrity": "sha512-frxkSHWbd36ayyxrEVopSCDSgJUT1tVKXvQld2IyzU3UnDuqqNA3AZE4/fCdqQb2/zBQx3nrWnZB1wBXDcrjcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.16.8",
+        "@googlemaps/markerclusterer": "2.5.3",
+        "@react-google-maps/infobox": "2.20.0",
+        "@react-google-maps/marker-clusterer": "2.20.0",
+        "@types/google.maps": "3.58.1",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
+      "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
+      "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -573,6 +620,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2473,8 +2526,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3062,6 +3114,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -3581,6 +3642,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5230,6 +5297,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
     "react-image-crop": "^11.0.10",
-    "yup": "^1.3.2"
+    "yup": "^1.3.2",
+    "@react-google-maps/api": "^2.19.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -1,150 +1,154 @@
 'use client';
 import { useEffect, useState } from 'react';
-import Calendar from 'react-calendar';
-import 'react-calendar/dist/Calendar.css';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
 import { format } from 'date-fns';
-import { useBooking } from '@/contexts/BookingContext';
-import { getArtistAvailability, createBookingRequest } from '@/lib/api';
+import {
+  getArtistAvailability,
+  createBookingRequest,
+  updateBookingRequest,
+  getArtist,
+} from '@/lib/api';
 import { BookingRequestCreate } from '@/types';
+import { useBooking, EventDetails } from '@/contexts/BookingContext';
+import DateTimeStep from './steps/DateTimeStep';
+import LocationStep from './steps/LocationStep';
+import GuestsStep from './steps/GuestsStep';
+import VenueStep from './steps/VenueStep';
+import NotesStep from './steps/NotesStep';
+import SummarySidebar from './SummarySidebar';
 
 const steps = ['Date & Time', 'Location', 'Attendees', 'Venue Type', 'Notes'];
 
+const schema = yup.object({
+  date: yup.date().required().min(new Date(), 'Pick a future date'),
+  time: yup.string().required('Time is required'),
+  location: yup.string().required('Location is required'),
+  guests: yup.number().min(1).required(),
+  venueType: yup.string().required(),
+  notes: yup.string().optional(),
+});
+
 export default function BookingWizard({ artistId }: { artistId: number }) {
-  const { step, setStep, details, setDetails } = useBooking();
+  const { step, setStep, details, setDetails, requestId, setRequestId } = useBooking();
   const [unavailable, setUnavailable] = useState<string[]>([]);
+  const [artistLocation, setArtistLocation] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<EventDetails>({
+    defaultValues: details,
+    resolver: yupResolver(schema),
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    const sub = watch((v) => setDetails(v as EventDetails));
+    return () => sub.unsubscribe();
+  }, [watch, setDetails]);
+
   useEffect(() => {
     if (!artistId) return;
     getArtistAvailability(artistId)
       .then((res) => setUnavailable(res.data.unavailable_dates))
       .catch(() => setUnavailable([]));
+    getArtist(artistId)
+      .then((res) => setArtistLocation(res.data.location || null))
+      .catch(() => setArtistLocation(null));
   }, [artistId]);
 
-  const next = () => setStep(step + 1);
+  const next = handleSubmit(() => setStep(step + 1));
   const prev = () => setStep(step - 1);
 
-  const saveDraft = async () => {
+  const saveDraft = handleSubmit(async (vals) => {
     const payload: BookingRequestCreate = {
       artist_id: artistId,
-      proposed_datetime_1: details.date && details.time ? new Date(
-        `${format(details.date, 'yyyy-MM-dd')}T${details.time}`
-      ).toISOString() : undefined,
-      message: details.notes,
+      proposed_datetime_1:
+        vals.date && vals.time
+          ? new Date(`${format(vals.date, 'yyyy-MM-dd')}T${vals.time}`).toISOString()
+          : undefined,
+      message: vals.notes,
       status: 'draft',
     };
     try {
-      await createBookingRequest(payload);
+      if (requestId) {
+        await updateBookingRequest(requestId, payload);
+      } else {
+        const res = await createBookingRequest(payload);
+        setRequestId(res.data.id);
+      }
       setError(null);
       alert('Draft saved');
-    } catch (e: any) {
+    } catch (e) {
       setError('Failed to save draft');
+    }
+  });
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return <DateTimeStep control={control} unavailable={unavailable} watch={watch} />;
+      case 1:
+        return (
+          <LocationStep
+            control={control}
+            artistLocation={artistLocation || undefined}
+            setWarning={setWarning}
+          />
+        );
+      case 2:
+        return <GuestsStep control={control} />;
+      case 3:
+        return <VenueStep control={control} />;
+      default:
+        return <NotesStep control={control} />;
     }
   };
 
-  const tileDisabled = ({ date }: { date: Date }) => {
-    const day = format(date, 'yyyy-MM-dd');
-    return unavailable.includes(day) || date < new Date();
-  };
-
   return (
-    <div className="space-y-4">
-      <div className="flex">
-        {steps.map((label, i) => (
-          <div
-            key={label}
-            className={`flex-1 text-center p-2 text-sm ${
-              i === step ? 'bg-indigo-600 text-white' : 'bg-gray-200'
-            }`}
-          >
-            {label}
-          </div>
-        ))}
-      </div>
-
-      {step === 0 && (
-        <div className="space-y-4">
-          <Calendar value={details.date} onChange={(d) => setDetails({ ...details, date: d as Date })} tileDisabled={tileDisabled} />
-          {details.date && (
-            <input
-              type="time"
-              value={details.time || ''}
-              onChange={(e) => setDetails({ ...details, time: e.target.value })}
-              className="border p-2 rounded w-full"
-            />
+    <div className="lg:flex lg:space-x-4">
+      <div className="flex-1 space-y-4">
+        <div className="flex" aria-label="Progress">
+          {steps.map((label, i) => (
+            <div
+              key={label}
+              className={`flex-1 text-center p-2 text-sm ${i === step ? 'bg-indigo-600 text-white' : 'bg-gray-200'}`}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+        {renderStep()}
+        {warning && <p className="text-orange-600 text-sm">{warning}</p>}
+        {Object.values(errors).length > 0 && (
+          <p className="text-red-600 text-sm">Please fix the errors above.</p>
+        )}
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex justify-between pt-2">
+          {step > 0 && (
+            <button type="button" onClick={prev} className="px-4 py-2 bg-gray-200 rounded">
+              Back
+            </button>
+          )}
+          {step < steps.length - 1 ? (
+            <button type="button" onClick={next} className="ml-auto px-4 py-2 bg-indigo-600 text-white rounded">
+              Next
+            </button>
+          ) : (
+            <button type="button" onClick={saveDraft} className="ml-auto px-4 py-2 bg-green-600 text-white rounded">
+              Save Draft
+            </button>
           )}
         </div>
-      )}
-
-      {step === 1 && (
-        <div>
-          <label className="block text-sm font-medium">Event location</label>
-          <input
-            type="text"
-            value={details.location || ''}
-            onChange={(e) => setDetails({ ...details, location: e.target.value })}
-            className="border p-2 rounded w-full"
-            placeholder="Address"
-          />
-        </div>
-      )}
-
-      {step === 2 && (
-        <div>
-          <label className="block text-sm font-medium">Number of guests</label>
-          <input
-            type="number"
-            min={1}
-            value={details.guests}
-            onChange={(e) => setDetails({ ...details, guests: parseInt(e.target.value, 10) })}
-            className="border p-2 rounded w-full"
-          />
-        </div>
-      )}
-
-      {step === 3 && (
-        <div>
-          <label className="block text-sm font-medium">Venue type</label>
-          <select
-            value={details.venueType}
-            onChange={(e) => setDetails({ ...details, venueType: e.target.value as any })}
-            className="border p-2 rounded w-full"
-          >
-            <option value="indoor">Indoor</option>
-            <option value="outdoor">Outdoor</option>
-            <option value="hybrid">Hybrid</option>
-          </select>
-        </div>
-      )}
-
-      {step === 4 && (
-        <div>
-          <label className="block text-sm font-medium">Extra notes</label>
-          <textarea
-            value={details.notes || ''}
-            onChange={(e) => setDetails({ ...details, notes: e.target.value })}
-            className="border p-2 rounded w-full"
-            rows={3}
-          />
-        </div>
-      )}
-
-      {error && <p className="text-red-600 text-sm">{error}</p>}
-
-      <div className="flex justify-between pt-2">
-        {step > 0 && (
-          <button onClick={prev} className="px-4 py-2 bg-gray-200 rounded">
-            Back
-          </button>
-        )}
-        {step < steps.length - 1 ? (
-          <button onClick={next} className="ml-auto px-4 py-2 bg-indigo-600 text-white rounded">
-            Next
-          </button>
-        ) : (
-          <button onClick={saveDraft} className="ml-auto px-4 py-2 bg-green-600 text-white rounded">
-            Save Draft
-          </button>
-        )}
+      </div>
+      <div className="hidden lg:block w-64">
+        <SummarySidebar />
       </div>
     </div>
   );

--- a/frontend/src/components/booking/SummarySidebar.tsx
+++ b/frontend/src/components/booking/SummarySidebar.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useBooking } from '@/contexts/BookingContext';
+import { format } from 'date-fns';
+
+export default function SummarySidebar() {
+  const { details } = useBooking();
+  return (
+    <div className="p-4 bg-white shadow rounded space-y-2">
+      <h2 className="text-lg font-medium">Summary</h2>
+      <ul className="text-sm space-y-1">
+        {details.date && (
+          <li>
+            <strong>Date:</strong> {format(details.date, 'PP')} {details.time}
+          </li>
+        )}
+        {details.location && (
+          <li>
+            <strong>Location:</strong> {details.location}
+          </li>
+        )}
+        {details.guests && (
+          <li>
+            <strong>Guests:</strong> {details.guests}
+          </li>
+        )}
+        {details.venueType && (
+          <li>
+            <strong>Venue:</strong> {details.venueType}
+          </li>
+        )}
+        {details.notes && (
+          <li>
+            <strong>Notes:</strong> {details.notes}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { Controller } from 'react-hook-form';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import { format } from 'date-fns';
+
+interface Props {
+  control: any;
+  unavailable: string[];
+  watch: any;
+}
+
+export default function DateTimeStep({ control, unavailable, watch }: Props) {
+  const tileDisabled = ({ date }: { date: Date }) => {
+    const day = format(date, 'yyyy-MM-dd');
+    return unavailable.includes(day) || date < new Date();
+  };
+  return (
+    <div className="space-y-4">
+      <Controller
+        name="date"
+        control={control}
+        render={({ field }) => (
+          <Calendar {...field} onChange={field.onChange} tileDisabled={tileDisabled} />
+        )}
+      />
+      {watch('date') && (
+        <Controller
+          name="time"
+          control={control}
+          render={({ field }) => (
+            <input type="time" className="border p-2 rounded w-full" {...field} />
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { Controller } from 'react-hook-form';
+
+interface Props {
+  control: any;
+}
+
+export default function GuestsStep({ control }: Props) {
+  return (
+    <div>
+      <label className="block text-sm font-medium">Number of guests</label>
+      <Controller
+        name="guests"
+        control={control}
+        render={({ field }) => (
+          <input
+            type="number"
+            min={1}
+            className="border p-2 rounded w-full"
+            {...field}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -1,0 +1,83 @@
+'use client';
+import { Controller } from 'react-hook-form';
+import { GoogleMap, Marker, useLoadScript, Autocomplete } from '@react-google-maps/api';
+import { useRef, useState, useEffect } from 'react';
+import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
+
+interface Props {
+  control: any;
+  artistLocation?: string | null;
+  setWarning: (w: string | null) => void;
+}
+
+const containerStyle = { width: '100%', height: '250px' };
+
+export default function LocationStep({ control, artistLocation, setWarning }: Props) {
+  const { isLoaded } = useLoadScript({
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
+    libraries: ['places'],
+  });
+  const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
+  const [marker, setMarker] = useState<LatLng | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      if (artistLocation) {
+        const artistPos = await geocodeAddress(artistLocation);
+        if (artistPos && marker) {
+          const dist = calculateDistanceKm(artistPos, marker);
+          if (dist > 100) setWarning('This location is over 100km from the artist.');
+          else setWarning(null);
+        }
+      }
+    })();
+  }, [artistLocation, marker, setWarning]);
+
+  if (!isLoaded) return <p>Loading map...</p>;
+  return (
+    <div className="space-y-2">
+      <Autocomplete
+        onLoad={(a) => (autocompleteRef.current = a)}
+        onPlaceChanged={async () => {
+          const place = autocompleteRef.current?.getPlace();
+          if (place && place.geometry?.location) {
+            const loc = {
+              lat: place.geometry.location.lat(),
+              lng: place.geometry.location.lng(),
+            };
+            setMarker(loc);
+          }
+        }}
+      >
+        <Controller
+          name="location"
+          control={control}
+          render={({ field }) => (
+            <input
+              {...field}
+              className="border p-2 rounded w-full"
+              placeholder="Search address"
+            />
+          )}
+        />
+      </Autocomplete>
+      {marker && (
+        <GoogleMap center={marker} zoom={14} mapContainerStyle={containerStyle}>
+          <Marker position={marker} />
+        </GoogleMap>
+      )}
+      <button
+        type="button"
+        className="mt-2 text-sm text-indigo-600 underline"
+        onClick={() => {
+          navigator.geolocation.getCurrentPosition((pos) => {
+            const loc = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+            setMarker(loc);
+          });
+        }}
+      >
+        Use my location
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { Controller } from 'react-hook-form';
+
+interface Props {
+  control: any;
+}
+
+export default function NotesStep({ control }: Props) {
+  return (
+    <div>
+      <label className="block text-sm font-medium">Extra notes</label>
+      <Controller
+        name="notes"
+        control={control}
+        render={({ field }) => (
+          <textarea rows={3} className="border p-2 rounded w-full" {...field} />
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { Controller } from 'react-hook-form';
+
+interface Props {
+  control: any;
+}
+
+export default function VenueStep({ control }: Props) {
+  return (
+    <div>
+      <label className="block text-sm font-medium">Venue type</label>
+      <Controller
+        name="venueType"
+        control={control}
+        render={({ field }) => (
+          <select className="border p-2 rounded w-full" {...field}>
+            <option value="indoor">Indoor</option>
+            <option value="outdoor">Outdoor</option>
+            <option value="hybrid">Hybrid</option>
+          </select>
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -14,6 +14,8 @@ interface BookingContextValue {
   setStep: (s: number) => void;
   details: EventDetails;
   setDetails: (d: EventDetails) => void;
+  requestId?: number;
+  setRequestId: (id: number | undefined) => void;
 }
 
 const BookingContext = createContext<BookingContextValue | undefined>(undefined);
@@ -21,8 +23,9 @@ const BookingContext = createContext<BookingContextValue | undefined>(undefined)
 export const BookingProvider = ({ children }: { children: ReactNode }) => {
   const [step, setStep] = useState(0);
   const [details, setDetails] = useState<EventDetails>({ guests: 1, venueType: 'indoor' });
+  const [requestId, setRequestId] = useState<number | undefined>(undefined);
   return (
-    <BookingContext.Provider value={{ step, setStep, details, setDetails }}>
+    <BookingContext.Provider value={{ step, setStep, details, setDetails, requestId, setRequestId }}>
       {children}
     </BookingContext.Provider>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -185,6 +185,12 @@ export const getBookingRequestsForArtist = () =>
 export const getBookingRequestById = (id: number) =>
   api.get<BookingRequest>(`${API_V1}/booking-requests/${id}`);
 
+// Update an existing booking request as the client
+export const updateBookingRequest = (
+  id: number,
+  data: Partial<BookingRequestCreate> & { status?: string }
+) => api.put<BookingRequest>(`${API_V1}/booking-requests/${id}/client`, data);
+
 // Create a new quote (artist → client) for an existing booking request:
 //    POST /api/v1/quotes/
 // Body must match QuoteCreate interface.

--- a/frontend/src/lib/geo.ts
+++ b/frontend/src/lib/geo.ts
@@ -1,0 +1,32 @@
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export const geocodeAddress = async (address: string): Promise<LatLng | null> => {
+  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  if (!key) return null;
+  const res = await fetch(
+    `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${key}`
+  );
+  const data = await res.json();
+  if (data.status === 'OK') {
+    const { lat, lng } = data.results[0].geometry.location;
+    return { lat, lng };
+  }
+  return null;
+};
+
+export const calculateDistanceKm = (a: LatLng, b: LatLng): number => {
+  const toRad = (v: number) => (v * Math.PI) / 180;
+  const R = 6371; // km
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const x =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+  const c = 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+  return R * c;
+};


### PR DESCRIPTION
## Summary
- break booking wizard into smaller steps with validation
- add location map, availability checks and progress bar
- save draft bookings via API and track request id in context
- document changes in AGENTS.md
- add Google Maps helpers and new dependencies

## Testing
- `npx next lint` *(fails: prompts for config)*
- `PYTHONPATH=backend pytest`

------
https://chatgpt.com/codex/tasks/task_e_684046bca194832e9dc88cfb974038bb