### PR TITLE
Fix quote routing path

### DIFF
--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -12,7 +12,11 @@ router = APIRouter(
     tags=["Quotes"],
 )
 
-@router.post("/booking-requests/{request_id}/quotes/", response_model=schemas.QuoteResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/booking-requests/{request_id}/quotes",
+    response_model=schemas.QuoteResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 def create_quote_for_request(
     request_id: int,
     quote_in: schemas.QuoteCreate,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -197,7 +197,7 @@ export const updateBookingRequest = (
 export const createQuoteForRequest = (
   requestId: number,
   data: QuoteCreate
-) => api.post<Quote>(`${API_V1}/booking-requests/${requestId}/quotes/`, data);
+) => api.post<Quote>(`${API_V1}/booking-requests/${requestId}/quotes`, data);
 
 // Optionally, fetch all quotes for a given booking request:
 export const getQuotesForBookingRequest = (bookingRequestId: number) =>


### PR DESCRIPTION
## Summary
- correct trailing slash in the quote creation endpoint
- update frontend API helper to match

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404d34609c832eaf8dd9c715537353