### PR TITLE
Improve booking request details

### DIFF
--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -70,8 +70,29 @@ export default function BookingRequestDetailPage() {
     <MainLayout>
       <div className="max-w-3xl mx-auto p-4 space-y-4">
         <h1 className="text-xl font-semibold">Booking Request #{request.id}</h1>
+        <div className="space-y-1 text-sm text-gray-700">
+          {request.client && (
+            <p>
+              <span className="font-medium">Client:</span> {request.client.first_name}{' '}
+              {request.client.last_name} ({request.client.email})
+            </p>
+          )}
+          {request.service && (
+            <p>
+              <span className="font-medium">Service:</span> {request.service.title}
+            </p>
+          )}
+          {request.proposed_datetime_1 && (
+            <p>
+              <span className="font-medium">Proposed:</span>{' '}
+              {new Date(request.proposed_datetime_1).toLocaleString()}
+            </p>
+          )}
+        </div>
         {request.message && (
-          <p className="border p-2 bg-white rounded-md">{request.message}</p>
+          <p className="border p-2 bg-white rounded-md whitespace-pre-wrap">
+            {request.message}
+          </p>
         )}
         <MessageThread bookingRequestId={request.id} />
       </div>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -207,13 +207,28 @@ export default function DashboardPage() {
                 <table className="min-w-full divide-y divide-gray-300">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th scope="col" className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                      <th
+                        scope="col"
+                        className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                      >
                         {user.user_type === 'artist' ? 'Client' : 'Artist'}
                       </th>
-                      <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                      >
+                        Service
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                      >
                         Status
                       </th>
-                      <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                      >
                         Created
                       </th>
                     </tr>
@@ -222,9 +237,20 @@ export default function DashboardPage() {
                     {bookingRequests.map((req) => (
                       <tr key={req.id}>
                         <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
-                          <Link href={`/booking-requests/${req.id}`} className="text-indigo-600 hover:underline">
+                          <div className="font-medium text-gray-900">
+                            {user.user_type === 'artist'
+                              ? `${req.client?.first_name} ${req.client?.last_name}`
+                              : `${req.artist?.first_name} ${req.artist?.last_name}`}
+                          </div>
+                          <Link
+                            href={`/booking-requests/${req.id}`}
+                            className="text-indigo-600 hover:underline text-sm"
+                          >
                             View Chat
                           </Link>
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                          {req.service?.title || '—'}
                         </td>
                         <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">{req.status}</td>
                         <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,10 +85,10 @@ export interface BookingRequest {
   status: string; // e.g. "pending_quote", "quote_provided", etc.
   created_at: string;
   updated_at: string;
-  // If you want to expand relationships, you could add:
-  // client?: User;
-  // artist?: User;
-  // service?: Service;
+  // Optional expanded relations returned by the API
+  client?: User;
+  artist?: User;
+  service?: Service;
   // quotes?: Quote[];
 }
 


### PR DESCRIPTION
## Summary
- add optional relations to `BookingRequest` type
- show counterpart name and service on Dashboard booking requests table
- display client/service info on booking request detail page

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68414f26d198832e953f36c9e3fdb203