### PR TITLE
Clarify frontend linting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ export PYTHONPATH=.
 pytest
 ```
 
-Run linting without prompts:
+Run linting from the `frontend` directory. Install dependencies with `npm install` first if needed:
 
 ```bash
-npx eslint .
+cd frontend
+npm install   # if node_modules are missing
+npx eslint src
 ```


### PR DESCRIPTION
## Summary
- direct developers to run linting from `frontend`
- mention installing dependencies before running `eslint`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684166d36c14832e9f96c857df0bf3f3