### PR TITLE
Fix mismatched date aria-label

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -21,7 +21,12 @@ export default function DateTimeStep({ control, unavailable, watch }: Props) {
         name="date"
         control={control}
         render={({ field }) => (
-          <Calendar {...field} onChange={field.onChange} tileDisabled={tileDisabled} />
+          <Calendar
+            {...field}
+            locale="en-US"
+            onChange={field.onChange}
+            tileDisabled={tileDisabled}
+          />
         )}
       />
       {watch('date') && (


### PR DESCRIPTION
## Summary
- enforce consistent date locale on Calendar component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416d89f904832e83a8f66033f4bc87