### PR TITLE
Add service type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ The booking wizard also features a new **Review** step. This shows a preview of 
 Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox.
 
+### Service Types
+
+Services now include a required **service_type** field with the following options:
+
+- **Live Performance**
+- **Virtual Appearance**
+- **Personalized Video**
+- **Custom Song**
+- **Other**
+
+If a client chooses a service that is not a Live Performance or Virtual Appearance, the booking wizard is skipped and they are taken directly to the request chat with the service prefilled.
+
 
 ### Artist Availability
 

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -1,7 +1,17 @@
 # backend/app/models/service.py
-from sqlalchemy import Column, Integer, String, Numeric, ForeignKey, Text
+from sqlalchemy import Column, Integer, String, Numeric, ForeignKey, Text, Enum as SQLAlchemyEnum
 from sqlalchemy.orm import relationship
 from .base import BaseModel
+import enum
+
+
+class ServiceType(str, enum.Enum):
+    """Allowed service categories."""
+    LIVE_PERFORMANCE = "Live Performance"
+    VIRTUAL_APPEARANCE = "Virtual Appearance"
+    PERSONALIZED_VIDEO = "Personalized Video"
+    CUSTOM_SONG = "Custom Song"
+    OTHER = "Other"
 
 class Service(BaseModel):
     __tablename__ = "services"
@@ -12,6 +22,11 @@ class Service(BaseModel):
     description = Column(Text, nullable=True)
     price       = Column(Numeric(10, 2), nullable=False)
     duration_minutes = Column(Integer, nullable=False)
+    service_type = Column(
+        SQLAlchemyEnum(ServiceType),
+        nullable=False,
+        default=ServiceType.LIVE_PERFORMANCE,
+    )
 
     # Link back to the ArtistProfileV2
     artist = relationship("ArtistProfileV2", back_populates="services")

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional
+from ..models.service import ServiceType
 from .artist import ArtistProfileNested
 from decimal import Decimal
 from datetime import datetime
@@ -10,12 +11,14 @@ class ServiceBase(BaseModel):
     description: Optional[str] = None
     duration_minutes: Optional[int] = None
     price: Optional[Decimal] = None
+    service_type: Optional[ServiceType] = None
 
 # Properties to receive on item creation
 class ServiceCreate(ServiceBase):
     title: str
     duration_minutes: int
     price: Decimal
+    service_type: ServiceType
     # artist_id will be set based on the authenticated artist, not in schema
 
 # Properties to receive on item update

--- a/backend/tests/test_service_schema.py
+++ b/backend/tests/test_service_schema.py
@@ -1,0 +1,19 @@
+import pytest
+from app.schemas.service import ServiceCreate, ServiceUpdate, ServiceType
+
+
+def test_service_create_requires_type():
+    with pytest.raises(Exception):
+        ServiceCreate(title="Test", duration_minutes=10, price=5.0)
+    s = ServiceCreate(
+        title="Test",
+        duration_minutes=10,
+        price=5.0,
+        service_type=ServiceType.OTHER,
+    )
+    assert s.service_type == ServiceType.OTHER
+
+
+def test_service_update_type_optional():
+    upd = ServiceUpdate()
+    assert upd.service_type is None

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   getArtists,
   getArtistServices,
   getArtistReviews,
+  createBookingRequest,
 } from '@/lib/api';
 
 import {
@@ -97,8 +98,25 @@ export default function ArtistProfilePage() {
       ? (reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length).toFixed(1)
       : null;
 
-  const handleScrollToBooking = () => {
-    router.push(`/booking?artist_id=${artistId}`);
+  const handleBookService = async (service: Service) => {
+    if (
+      service.service_type === 'Live Performance' ||
+      service.service_type === 'Virtual Appearance'
+    ) {
+      router.push(`/booking?artist_id=${artistId}&service_id=${service.id}`);
+      return;
+    }
+    try {
+      const res = await createBookingRequest({
+        artist_id: artistId,
+        service_id: service.id,
+        message: `Requesting ${service.title} (${service.service_type})`,
+      });
+      router.push(`/booking-requests/${res.data.id}`);
+    } catch (err) {
+      console.error('Failed to create request', err);
+      alert('Failed to create request');
+    }
   };
 
 
@@ -273,6 +291,7 @@ export default function ArtistProfilePage() {
                         {service.description && (
                           <p className="mt-2 text-gray-600 text-sm">{service.description}</p>
                         )}
+                        <p className="mt-1 text-sm text-gray-500">Type: {service.service_type}</p>
                         <div className="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between">
                           <p className="text-2xl font-bold text-gray-800">${Number(service.price).toFixed(2)}</p>
                           <p className="text-sm text-gray-500">
@@ -280,7 +299,7 @@ export default function ArtistProfilePage() {
                           </p>
                         </div>
                         <button
-                          onClick={handleScrollToBooking}
+                          onClick={() => handleBookService(service)}
                           className="mt-6 w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
                         >
                           Book {service.title}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -376,6 +376,7 @@ export default function DashboardPage() {
                       <div className="focus:outline-none">
                         <p className="text-sm font-medium text-gray-900">{service.title}</p>
                         <p className="truncate text-sm text-gray-500">{service.description}</p>
+                        <p className="text-xs text-gray-500">{service.service_type}</p>
                         <div className="mt-2 flex items-center justify-between">
                           <span className="text-sm font-medium text-gray-900">
                             ${service.price.toFixed(2)}

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -13,10 +13,20 @@ interface AddServiceModalProps {
   onServiceAdded: (newService: Service) => void;
 }
 
-type ServiceFormData = Pick<Service, 'title' | 'description' | 'price' | 'duration_minutes'>;
+type ServiceFormData = Pick<
+  Service,
+  'title' | 'description' | 'price' | 'duration_minutes' | 'service_type'
+>;
 
 export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: AddServiceModalProps) {
-  const { register, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<ServiceFormData>();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ServiceFormData>({
+    defaultValues: { service_type: 'Live Performance' },
+  });
   const [serverError, setServerError] = useState<string | null>(null);
 
   const onSubmit: SubmitHandler<ServiceFormData> = async (data) => {
@@ -73,6 +83,22 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                 className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
               />
               {errors.description && <p className="mt-1 text-xs text-red-600">{errors.description.message}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="service_type" className="block text-sm font-medium text-gray-700">Service Type</label>
+              <select
+                id="service_type"
+                {...register('service_type', { required: 'Service type is required' })}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              >
+                <option value="Live Performance">Live Performance</option>
+                <option value="Virtual Appearance">Virtual Appearance</option>
+                <option value="Personalized Video">Personalized Video</option>
+                <option value="Custom Song">Custom Song</option>
+                <option value="Other">Other</option>
+              </select>
+              {errors.service_type && <p className="mt-1 text-xs text-red-600">{errors.service_type.message}</p>}
             </div>
 
             <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -32,6 +32,7 @@ export interface Service {
   artist_id: number;
   title: string;
   description: string;
+  service_type: 'Live Performance' | 'Virtual Appearance' | 'Personalized Video' | 'Custom Song' | 'Other';
   duration_minutes: number;
   price: number;
   artist: ArtistProfile;


### PR DESCRIPTION
## Summary
- introduce `ServiceType` enum and `service_type` field in backend
- update service schemas and create unit tests
- show service type in dashboard and artist pages
- add service type dropdown when creating a service
- extend booking flow to handle service types
- document service types in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`
- `npm install --silent`
- `npx eslint src`

------
https://chatgpt.com/codex/tasks/task_e_684183616864832ea8ea91ee3eafe1fd