### PR TITLE
Fix service_type column auto creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Services now include a required **service_type** field with the following option
 
 If a client chooses a service that is not a Live Performance or Virtual Appearance, the booking wizard is skipped and they are taken directly to the request chat with the service prefilled.
 
+When running against an existing SQLite database created before this field
+existed, the backend will automatically add the `service_type` column at
+startup so older installations continue to work without manual migrations.
+
 
 ### Artist Availability
 

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -2,6 +2,27 @@ from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 
 
+def ensure_service_type_column(engine: Engine) -> None:
+    """Ensure the service_type column exists on the services table.
+
+    Older SQLite databases created before the ServiceType enum was added will
+    be missing this column. This helper adds it with a sensible default so
+    queries referencing ``Service.service_type`` don't fail.
+    """
+    inspector = inspect(engine)
+    if "services" not in inspector.get_table_names():
+        return
+    column_names = [col["name"] for col in inspector.get_columns("services")]
+    if "service_type" not in column_names:
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE services ADD COLUMN service_type VARCHAR NOT NULL DEFAULT 'Live Performance'"
+                )
+            )
+            conn.commit()
+
+
 def ensure_message_type_column(engine: Engine) -> None:
     """Add the message_type column if it's missing (for SQLite databases)."""
     inspector = inspect(engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from .database import engine, Base
-from .db_utils import ensure_message_type_column, ensure_attachment_url_column
+from .db_utils import (
+    ensure_message_type_column,
+    ensure_attachment_url_column,
+    ensure_service_type_column,
+)
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
 from .models.service import Service
@@ -34,6 +38,7 @@ from .core.config import settings
 # ─── Ensure database schema is up-to-date ──────────────────────────────────
 ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
+ensure_service_type_column(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")


### PR DESCRIPTION
## Summary
- ensure `service_type` column exists for older SQLite databases
- call `ensure_service_type_column` during startup
- document automatic column creation in README

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest`

------
https://chatgpt.com/codex/tasks/task_e_684186242b60832ea494f1c002274ed6