### PR TITLE
Fix service type enum parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
 Install dependencies using `pip install -r requirements.txt` first if needed.
 
+### Service type enum
+
+`services.service_type` stores the enum's string values such as "Live Performance".
+If you see lookup errors when reading services, check that the `Service` model
+uses `SQLAlchemyEnum(ServiceType, values_callable=lambda e: [v.value for v in e])`.
+
 ### CORS configuration
 
 The backend reads allowed origins from the `.env` file. By default it

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -23,7 +23,11 @@ class Service(BaseModel):
     price       = Column(Numeric(10, 2), nullable=False)
     duration_minutes = Column(Integer, nullable=False)
     service_type = Column(
-        SQLAlchemyEnum(ServiceType),
+        SQLAlchemyEnum(
+            ServiceType,
+            values_callable=lambda enum: [e.value for e in enum],
+            native_enum=False,
+        ),
         nullable=False,
         default=ServiceType.LIVE_PERFORMANCE,
     )


### PR DESCRIPTION
## Summary
- fix enum mapping for `Service.service_type`
- document enum handling in README
- install dependencies and run unit tests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841878fdfcc832e85a6064d1bcff1b7