### PR TITLE
Fix missing display_order column

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ When running against an existing SQLite database created before this field
 existed, the backend will automatically add the `service_type` column at
 startup so older installations continue to work without manual migrations.
 
+Likewise, services now use a `display_order` integer to control sorting in the
+dashboard. If your database was created prior to this addition the column will
+be added automatically when the backend starts.
+
 ### Service Management
 
 From the artist dashboard you can now edit, delete, and rearrange your offered

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -47,9 +47,21 @@ def ensure_attachment_url_column(engine: Engine) -> None:
     column_names = [col["name"] for col in inspector.get_columns("messages")]
     if "attachment_url" not in column_names:
         with engine.connect() as conn:
+            conn.execute(text("ALTER TABLE messages ADD COLUMN attachment_url VARCHAR"))
+            conn.commit()
+
+
+def ensure_display_order_column(engine: Engine) -> None:
+    """Add the display_order column to services if it's missing."""
+    inspector = inspect(engine)
+    if "services" not in inspector.get_table_names():
+        return
+    column_names = [col["name"] for col in inspector.get_columns("services")]
+    if "display_order" not in column_names:
+        with engine.connect() as conn:
             conn.execute(
                 text(
-                    "ALTER TABLE messages ADD COLUMN attachment_url VARCHAR"
+                    "ALTER TABLE services ADD COLUMN display_order INTEGER NOT NULL DEFAULT 0"
                 )
             )
             conn.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from .db_utils import (
     ensure_message_type_column,
     ensure_attachment_url_column,
     ensure_service_type_column,
+    ensure_display_order_column,
 )
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
@@ -39,6 +40,7 @@ from .core.config import settings
 ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
 ensure_service_type_column(engine)
+ensure_display_order_column(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")


### PR DESCRIPTION
## Summary
- add `ensure_display_order_column` helper
- call the new helper on startup
- document automatic creation of the new column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418b4187cc832ea31021ae40dec18e