### PR TITLE
Add personalized video chat flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Services now include a required **service_type** field with the following option
 
 If a client chooses a service that is not a Live Performance or Virtual Appearance, the booking wizard is skipped and they are taken directly to the request chat with the service prefilled.
 
+For **Personalized Video** requests, the chat automatically asks the client a few built‑in questions one at a time (who the video is for, occasion, due date, and any instructions). After all answers are collected the artist is notified in the thread.
+
 When running against an existing SQLite database created before this field
 existed, the backend will automatically add the `service_type` column at
 startup so older installations continue to work without manual migrations.

--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MessageThread from '@/components/booking/MessageThread';
+import PersonalizedVideoFlow from '@/components/booking/PersonalizedVideoFlow';
 import { getBookingRequestById } from '@/lib/api';
 import { BookingRequest } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
@@ -93,7 +94,11 @@ export default function BookingRequestDetailPage() {
             {request.message}
           </p>
         )}
-        <MessageThread bookingRequestId={request.id} />
+        {request.service?.service_type === 'Personalized Video' ? (
+          <PersonalizedVideoFlow bookingRequestId={request.id} />
+        ) : (
+          <MessageThread bookingRequestId={request.id} />
+        )}
       </div>
     </MainLayout>
   );

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -13,9 +13,11 @@ import { useAuth } from '@/contexts/AuthContext';
 
 interface MessageThreadProps {
   bookingRequestId: number;
+  /** Optional callback invoked after a message is successfully sent */
+  onMessageSent?: () => void;
 }
 
-export default function MessageThread({ bookingRequestId }: MessageThreadProps) {
+export default function MessageThread({ bookingRequestId, onMessageSent }: MessageThreadProps) {
   const { user } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [quotes, setQuotes] = useState<Record<number, Quote>>({});
@@ -71,6 +73,7 @@ export default function MessageThread({ bookingRequestId }: MessageThreadProps) 
       setNewMessage('');
       setFile(null);
       fetchMessages();
+      if (onMessageSent) onMessageSent();
     } catch (err) {
       console.error('Failed to send message', err);
     }
@@ -89,6 +92,7 @@ export default function MessageThread({ bookingRequestId }: MessageThreadProps) 
       setQuotePrice('');
       fetchMessages();
       fetchQuotes();
+      if (onMessageSent) onMessageSent();
     } catch (err) {
       console.error('Failed to send quote', err);
     }

--- a/frontend/src/components/booking/PersonalizedVideoFlow.tsx
+++ b/frontend/src/components/booking/PersonalizedVideoFlow.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { useCallback, useEffect } from 'react';
+import MessageThread from './MessageThread';
+import { getMessagesForBookingRequest, postMessageToBookingRequest } from '@/lib/api';
+import { computeVideoProgress, videoQuestions } from '@/lib/videoFlow';
+import { useAuth } from '@/contexts/AuthContext';
+
+const READY_MESSAGE = 'All details collected! The artist has been notified.';
+
+interface Props {
+  bookingRequestId: number;
+}
+
+/**
+ * Wrapper for MessageThread that runs the personalized video Q&A sequence.
+ */
+export default function PersonalizedVideoFlow({ bookingRequestId }: Props) {
+  const { user } = useAuth();
+
+  const refreshFlow = useCallback(async () => {
+    try {
+      const res = await getMessagesForBookingRequest(bookingRequestId);
+      const msgs = res.data;
+      const progress = computeVideoProgress(msgs);
+
+      if (user?.user_type === 'client') {
+        if (progress < videoQuestions.length) {
+          const next = videoQuestions[progress];
+          const alreadyAsked = msgs.some(
+            (m) => m.message_type === 'system' && m.content === next,
+          );
+          if (!alreadyAsked) {
+            await postMessageToBookingRequest(bookingRequestId, {
+              content: next,
+              message_type: 'system',
+            });
+          }
+        } else {
+          const done = msgs.some(
+            (m) => m.message_type === 'system' && m.content === READY_MESSAGE,
+          );
+          if (!done) {
+            await postMessageToBookingRequest(bookingRequestId, {
+              content: READY_MESSAGE,
+              message_type: 'system',
+            });
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Video flow check failed', err);
+    }
+  }, [bookingRequestId, user]);
+
+  useEffect(() => {
+    (async () => {
+      await refreshFlow();
+    })();
+    const id = setInterval(refreshFlow, 4000);
+    return () => clearInterval(id);
+  }, [refreshFlow]);
+
+  return <MessageThread bookingRequestId={bookingRequestId} onMessageSent={refreshFlow} />;
+}

--- a/frontend/src/lib/__tests__/videoFlow.test.ts
+++ b/frontend/src/lib/__tests__/videoFlow.test.ts
@@ -1,0 +1,42 @@
+import { computeVideoProgress, videoQuestions } from '../videoFlow';
+import type { Message } from '@/types';
+
+const baseMessage = {
+  id: 1,
+  booking_request_id: 1,
+  sender_id: 1,
+  message_type: 'system' as const,
+  sender_type: 'client' as const,
+  content: '',
+  quote_id: null,
+  attachment_url: null,
+  timestamp: '2024-01-01T00:00:00Z',
+};
+
+function q(content: string): Message {
+  return { ...baseMessage, content, message_type: 'system' } as Message;
+}
+
+function a(): Message {
+  return { ...baseMessage, sender_type: 'client', message_type: 'text', content: 'ans' } as Message;
+}
+
+describe('computeVideoProgress', () => {
+  it('returns 0 when no messages', () => {
+    expect(computeVideoProgress([])).toBe(0);
+  });
+
+  it('detects a single answered question', () => {
+    const msgs = [q(videoQuestions[0]), a()];
+    expect(computeVideoProgress(msgs)).toBe(1);
+  });
+
+  it('detects all questions answered', () => {
+    const msgs: Message[] = [];
+    videoQuestions.forEach((qt) => {
+      msgs.push(q(qt));
+      msgs.push(a());
+    });
+    expect(computeVideoProgress(msgs)).toBe(videoQuestions.length);
+  });
+});

--- a/frontend/src/lib/videoFlow.ts
+++ b/frontend/src/lib/videoFlow.ts
@@ -1,0 +1,32 @@
+export const videoQuestions = [
+  'Who is the video for?',
+  'What is the occasion?',
+  'When should the video be ready?',
+  'Any specific instructions or message?',
+];
+
+import type { Message } from '@/types';
+
+/**
+ * Determine how many personalized video questions have been answered.
+ */
+export function computeVideoProgress(messages: Message[]): number {
+  let index = 0;
+  let cursor = 0;
+  for (const question of videoQuestions) {
+    const qIndex = messages.findIndex(
+      (m, i) =>
+        i >= cursor &&
+        m.message_type === 'system' &&
+        m.content === question,
+    );
+    if (qIndex === -1) break;
+    const answerIndex = messages.findIndex(
+      (m, i) => i > qIndex && m.sender_type === 'client',
+    );
+    if (answerIndex === -1) break;
+    index += 1;
+    cursor = answerIndex + 1;
+  }
+  return index;
+}


### PR DESCRIPTION
## Summary
- prompt clients sequentially in chat when booking Personalized Videos
- add PersonalizedVideoFlow component
- extend MessageThread with `onMessageSent` callback
- provide helper for question progress detection with tests
- document Personalized Video workflow in README

## Testing
- `npx eslint src`
- `npm test --silent`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418e2968b8832e99ed08b63e0e2978