### PR TITLE
Improve pytest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,9 @@ endpoint falls back to querying the database normally.
 
 ## Local Test Instructions
 
-Set the `PYTHONPATH` when running backend tests:
+Run backend tests from the project root:
 
 ```bash
-export PYTHONPATH=.
 pytest
 ```
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = backend
+testpaths = backend/tests
+


### PR DESCRIPTION
## Summary
- document how to run backend tests without needing PYTHONPATH
- provide pytest.ini so tests discover the backend app package

## Testing
- `pytest -q`
- `npx eslint src --config eslint.config.mjs`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684191f0d4b0832e9f1fc2c4f7b7a69f