### PR TITLE
Remove initial chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This version introduces basic management of sound providers and an API for quick
 The booking wizard also features a new **Review** step. This shows a preview of the calculated quote and summarizes all entered details with an improved progress indicator and clearer submit buttons.
 
 Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
-After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox.
+After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 
 ### Service Types
 

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -48,15 +48,9 @@ def create_booking_request(
             message_type=models.MessageType.TEXT,
             attachment_url=None,
         )
-    crud.crud_message.create_message(
-        db=db,
-        booking_request_id=new_request.id,
-        sender_id=current_user.id,
-        sender_type=models.SenderType.CLIENT,
-        content="Booking request sent",
-        message_type=models.MessageType.SYSTEM,
-        attachment_url=None,
-    )
+    # The chat thread used to include a generic "Booking request sent" system
+    # message immediately after creation. This extra message cluttered the
+    # conversation view, so it has been removed.
     notify_user_new_booking_request(artist_user, new_request.id)
     return new_request
 

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -102,7 +102,6 @@ export default function ArtistProfilePage() {
       const res = await createBookingRequest({
         artist_id: artistId,
         service_id: service.id,
-        message: `Requesting ${service.title} (${service.service_type})`,
       });
       router.push(`/booking-requests/${res.data.id}`);
     } catch (err) {

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -40,7 +40,14 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const fetchMessages = async () => {
     try {
       const res = await getMessagesForBookingRequest(bookingRequestId);
-      setMessages(res.data);
+      const filtered = res.data.filter(
+        (m) =>
+          !(
+            (m.message_type === 'text' && m.content.startsWith('Requesting ')) ||
+            (m.message_type === 'system' && m.content === 'Booking request sent')
+          ),
+      );
+      setMessages(filtered);
     } catch (err) {
       console.error('Failed to fetch messages', err);
     }


### PR DESCRIPTION
## Summary
- stop sending a `message` when creating requests for non-performance services
- drop the auto-generated "Booking request sent" system message
- filter legacy auto messages when rendering chat threads
- document the cleaner conversation start

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68419395ac08832eb8f8eaadcde2b9a3