### PR TITLE
Improve chat UX with scrolling and typing indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ This file documents the key automation, agent modules, and service components in
 * **Purpose:** Delivers real-time or async chat, manages unread notifications, logs chat history.
 * **Frontend:** `Chat.tsx` for UI, message sending, badge.
 * **Backend:** `api_chat.py` for storing/sending messages and push notifications.
+* **Features:** Auto-scrolls on new messages, mobile-friendly input bar, avatars, image previews, and a progress bar with typing indicator for Q&A flows.
 
 ### 9. Availability Agent
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The booking wizard also features a new **Review** step. This shows a preview of 
 Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 
+The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears under each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client.
+
 ### Service Types
 
 Services now include a required **service_type** field with the following options:

--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -95,9 +95,17 @@ export default function BookingRequestDetailPage() {
           </p>
         )}
         {request.service?.service_type === 'Personalized Video' ? (
-          <PersonalizedVideoFlow bookingRequestId={request.id} />
+          <PersonalizedVideoFlow
+            bookingRequestId={request.id}
+            clientName={request.client?.first_name}
+            artistName={request.artist?.first_name}
+          />
         ) : (
-          <MessageThread bookingRequestId={request.id} />
+          <MessageThread
+            bookingRequestId={request.id}
+            clientName={request.client?.first_name}
+            artistName={request.artist?.first_name}
+          />
         )}
       </div>
     </MainLayout>


### PR DESCRIPTION
## Summary
- auto scroll chat to latest message and show image previews
- keep input bar visible on mobile
- display avatars, subtle timestamps, and typing indicator
- show Q&A progress bar in personalized video flow
- update docs for chat agent and README

## Testing
- `npm test`
- `npm run lint` *(fails: next lint requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841961fc2c4832e8fa919219d40bd98