### PR TITLE
Hide progress bar when video questions complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The booking wizard also features a new **Review** step. This shows a preview of 
 Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 
-The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears under each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client.
+The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears under each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client. Once all questions are answered the progress bar disappears automatically.
 
 ### Service Types
 

--- a/frontend/src/components/booking/PersonalizedVideoFlow.tsx
+++ b/frontend/src/components/booking/PersonalizedVideoFlow.tsx
@@ -83,15 +83,19 @@ export default function PersonalizedVideoFlow({ bookingRequestId, clientName, ar
 
   return (
     <div className="space-y-2">
-      <div className="text-sm text-gray-600">
-        {progress}/{videoQuestions.length} questions answered
-      </div>
-      <div className="w-full bg-gray-200 rounded h-2" aria-hidden="true">
-        <div
-          className="bg-indigo-600 h-2 rounded"
-          style={{ width: `${(progress / videoQuestions.length) * 100}%` }}
-        />
-      </div>
+      {progress < videoQuestions.length && (
+        <>
+          <div className="text-sm text-gray-600">
+            {progress}/{videoQuestions.length} questions answered
+          </div>
+          <div className="w-full bg-gray-200 rounded h-2" aria-hidden="true">
+            <div
+              className="bg-indigo-600 h-2 rounded"
+              style={{ width: `${(progress / videoQuestions.length) * 100}%` }}
+            />
+          </div>
+        </>
+      )}
       <MessageThread
         ref={threadRef}
         bookingRequestId={bookingRequestId}


### PR DESCRIPTION
## Summary
- hide the Personalized Video progress bar after all questions are answered
- document progress bar behavior

## Testing
- `npx next lint .` *(fails: prompts to configure ESLint)*
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a2044d54832e800f90c69d60746c