### PR TITLE
Improve chat timestamp layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After submitting a booking request, clients are redirected straight to the assoc
 
 The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears under each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client. Once all questions are answered the progress bar disappears automatically.
 - The Personalized Video progress bar now disappears once all questions are answered.
-The latest update refines the chat bubbles even further: each message now includes the send time directly inside the bubble. The timestamp uses an extra-small font that matches the bubble color (white on blue, black on gray) and sits slightly separated from the text, while the message input highlights when focused for better accessibility.
+The latest update refines the chat bubbles even further: each message now shows its send time just to the right of the bubble. The timestamp uses a tiny gray font with a bit of margin so the message text never bumps against it, while the input field still highlights when focused for better accessibility.
 
 ### Service Types
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -180,7 +180,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             minute: '2-digit',
             hour12: false,
           });
-          const timeClass = `ml-3 text-[10px] font-light ${isClientMessage ? 'text-white' : 'text-black'}`;
+          const timeClass = 'ml-2 text-[10px] font-light text-gray-500';
 
           return (
             <div
@@ -216,15 +216,15 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                       View attachment
                     </a>
                   )}
-                  <span className={timeClass}>{timeString}</span>
                 </div>
+                <span className={timeClass}>{timeString}</span>
                 {isSelf && (
                   <div className="h-6 w-6 bg-gray-300 rounded-full flex items-center justify-center text-xs font-medium">
                     {avatar}
                   </div>
                 )}
               </div>
-              {/* Artist and system messages previously displayed time below the bubble. Now shown inside bubble. */}
+              {/* Timestamps now appear to the right of each bubble instead of below. */}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- display message timestamps to the right of each chat bubble
- note new timestamp style in README

## Testing
- `npm run lint`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841ad2108ac832eb10773951b964a49