### PR TITLE
Enhance chat UX and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The chat now auto-scrolls after each message, shows image previews before sendin
 - The Personalized Video progress bar now disappears once all questions are answered.
 The latest update refines the chat bubbles even further: each message now shows its send time inside the bubble. The timestamp sits beneath the text in a tiny gray font and the input field still highlights when focused for better accessibility.
 - When artists are logged in, their own messages now appear in blue bubbles just like the client view, while the other person's messages show in gray.
+The chat thread now displays a friendly placeholder when no messages are present and formats quote prices with the appropriate currency symbol. Any errors fetching or sending messages appear below the input field so problems can be spotted quickly.
 
 ### Service Types
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -50,6 +50,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [showQuoteForm, setShowQuoteForm] = useState(false);
   const [quoteDetails, setQuoteDetails] = useState('');
   const [quotePrice, setQuotePrice] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   const fetchMessages = async () => {
@@ -63,8 +64,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           ),
       );
       setMessages(filtered);
+      setErrorMsg(null);
     } catch (err) {
       console.error('Failed to fetch messages', err);
+      setErrorMsg('Failed to load messages');
     }
   };
 
@@ -78,6 +81,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       setQuotes(map);
     } catch (err) {
       console.error('Failed to fetch quotes', err);
+      setErrorMsg('Failed to load quotes');
     }
   };
 
@@ -132,6 +136,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       if (onMessageSent) onMessageSent();
     } catch (err) {
       console.error('Failed to send message', err);
+      setErrorMsg('Failed to send message');
     }
   };
 
@@ -151,12 +156,16 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       if (onMessageSent) onMessageSent();
     } catch (err) {
       console.error('Failed to send quote', err);
+      setErrorMsg('Failed to send quote');
     }
   };
 
   return (
     <div className="border rounded-md p-4 bg-white flex flex-col h-96 space-y-2">
       <div className="flex-1 overflow-y-auto space-y-3">
+        {messages.length === 0 && !isSystemTyping && (
+          <p className="text-sm text-gray-500">No messages yet. Start the conversation below.</p>
+        )}
         {messages.map((msg) => {
           const isSystem = msg.message_type === 'system';
           // Bubble alignment still depends on the logged in user
@@ -202,7 +211,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                       <div className="text-gray-800">
                         <p className="font-medium">{quotes[msg.quote_id].quote_details}</p>
                         <p className="text-sm mt-1">
-                          ${Number(quotes[msg.quote_id].price).toFixed(2)} {quotes[msg.quote_id].currency}
+                          {new Intl.NumberFormat('en-US', {
+                            style: 'currency',
+                            currency: quotes[msg.quote_id].currency,
+                          }).format(Number(quotes[msg.quote_id].price))}
                         </p>
                       </div>
                     ) : (
@@ -319,6 +331,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             </div>
           )}
         </>
+      )}
+      {errorMsg && (
+        <p className="text-sm text-red-600" role="alert">
+          {errorMsg}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/lib/__tests__/videoFlow.test.ts
+++ b/frontend/src/lib/__tests__/videoFlow.test.ts
@@ -39,4 +39,14 @@ describe('computeVideoProgress', () => {
     });
     expect(computeVideoProgress(msgs)).toBe(videoQuestions.length);
   });
+
+  it('stops counting when a question lacks an answer', () => {
+    const msgs = [q(videoQuestions[0]), a(), q(videoQuestions[1])];
+    expect(computeVideoProgress(msgs)).toBe(1);
+  });
+
+  it('ignores unrelated system messages', () => {
+    const msgs = [q(videoQuestions[0]), a(), q('Unrelated'), a()];
+    expect(computeVideoProgress(msgs)).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- show helpful placeholder and error messages in chat thread
- format quote prices with currency
- test video flow edge cases
- document chat improvements

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*
- `npm --prefix frontend test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf2b2880832eb68db22f8c5d8e6c