### PR TITLE
Implement notification system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file documents the key automation, agent modules, and service components in
 | **Quote Generator**              | Gathers performance, provider, travel, and accommodation costs for client | backend/app/api/api_quote.py, frontend/components/QuoteSummary.tsx                 | Runs after all booking info is entered         |
 | **Quote Preview Agent**          | Shows estimated total during final booking step | frontend/components/booking/steps/ReviewStep.tsx | On review step before submitting request |
 | **Payment Agent**                | Manages payment workflows, booking status update, confirmation            | backend/app/api/api_payment.py (planned), frontend/components/PaymentForm.tsx      | On payment page/booking confirmation           |
-| **Notification Agent**           | Sends emails, chat alerts, and booking status updates                     | backend/app/notifications/ (if implemented), frontend/hooks/useNotifications.ts     | Triggered on status changes, messages, actions |
+| **Notification Agent**           | Sends emails, chat alerts, and booking status updates                     | backend/app/api/api_notification.py, backend/app/utils/notifications.py, frontend/hooks/useNotifications.ts | Triggered on status changes, messages, actions |
 | **Chat Agent**                   | Manages client-artist/support chat, delivers new message notifications    | backend/app/api/api_chat.py, frontend/components/Chat.tsx                          | Always-on for active bookings                  |
 | **Availability Agent**           | Handles real-time artist/service availability checks                      | backend/app/api/v1/api_artist.py, frontend/components/booking/BookingWizard.tsx                | On date/service selection, booking start       |
 | **Form State Agent**             | Maintains progress, handles multi-step UX, restores unfinished bookings   | frontend/components/booking/BookingWizard.tsx, frontend/contexts/BookingContext.tsx         | Throughout user session                        |
@@ -64,7 +64,7 @@ This file documents the key automation, agent modules, and service components in
 
 * **Purpose:** Sends transactional emails, booking updates, reminders, and chat alerts.
 * **Frontend:** `useNotifications.ts` for popups/toasts, badge updates.
-* **Backend:** Notification module or function (email/SMS integration planned or present in `notifications/`).
+* **Backend:** `api_notification.py` exposes CRUD endpoints while `utils/notifications.py` persists alerts in the `notifications` table.
 
 ### 8. Chat Agent
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The chat now auto-scrolls after each message, shows image previews before sendin
 - The Personalized Video progress bar now disappears once all questions are answered.
 The latest update refines the chat bubbles even further: each message now shows its send time inside the bubble. The timestamp sits beneath the text in a tiny gray font and the input field still highlights when focused for better accessibility.
 - When artists are logged in, their own messages now appear in blue bubbles just like the client view, while the other person's messages show in gray.
+The backend now persists notifications when a new booking request or message is created. Clients and artists can fetch unread notifications from `/api/v1/notifications` and mark them read with `/api/v1/notifications/{id}/read`.
 The chat thread now displays a friendly placeholder when no messages are present and formats quote prices with the appropriate currency symbol. Any errors fetching or sending messages appear below the input field so problems can be spotted quickly.
 
 ### Service Types

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -51,7 +51,7 @@ def create_booking_request(
     # The chat thread used to include a generic "Booking request sent" system
     # message immediately after creation. This extra message cluttered the
     # conversation view, so it has been removed.
-    notify_user_new_booking_request(artist_user, new_request.id)
+    notify_user_new_booking_request(db, artist_user, new_request.id)
     return new_request
 
 @router.get("/me/client", response_model=List[schemas.BookingRequestResponse])

--- a/backend/app/api/api_message.py
+++ b/backend/app/api/api_message.py
@@ -56,7 +56,7 @@ def create_message(request_id: int, message_in: schemas.MessageCreate, db: Sessi
     other_user_id = booking_request.artist_id if sender_type == models.SenderType.CLIENT else booking_request.client_id
     other_user = db.query(models.User).filter(models.User.id == other_user_id).first()
     if other_user:
-        notify_user_new_message(other_user, message_in.content)
+        notify_user_new_message(db, other_user, message_in.content)
     return msg
 
 

--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+
+from .. import models, schemas, crud
+from .dependencies import get_db, get_current_user
+
+router = APIRouter(tags=["notifications"])
+
+
+@router.get("/notifications", response_model=List[schemas.NotificationResponse])
+def read_my_notifications(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Retrieve notifications for the current user."""
+    return crud.crud_notification.get_notifications_for_user(db, current_user.id)
+
+
+@router.put(
+    "/notifications/{notification_id}/read",
+    response_model=schemas.NotificationResponse,
+)
+def mark_notification_read(
+    notification_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    """Mark a notification as read."""
+    db_notif = crud.crud_notification.get_notification(db, notification_id)
+    if not db_notif or db_notif.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+    return crud.crud_notification.mark_as_read(db, db_notif)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -6,6 +6,7 @@ from .crud_review import review
 from .crud_booking_request import create_booking_request, get_booking_request, get_booking_requests_by_client, get_booking_requests_by_artist, update_booking_request
 from .crud_quote import create_quote, get_quote, get_quotes_by_booking_request, get_quotes_by_artist, update_quote
 from . import crud_message
+from . import crud_notification
 
 # For a cleaner import, you could define __all__ or group them
 # For now, direct import is fine for usage like `crud.user.get` 

--- a/backend/app/crud/crud_notification.py
+++ b/backend/app/crud/crud_notification.py
@@ -1,0 +1,37 @@
+from sqlalchemy.orm import Session
+from typing import List
+
+from .. import models
+
+
+def create_notification(
+    db: Session,
+    user_id: int,
+    type: models.NotificationType,
+    message: str,
+) -> models.Notification:
+    db_obj = models.Notification(user_id=user_id, type=type, message=message)
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_notifications_for_user(db: Session, user_id: int) -> List[models.Notification]:
+    return (
+        db.query(models.Notification)
+        .filter(models.Notification.user_id == user_id)
+        .order_by(models.Notification.timestamp.desc())
+        .all()
+    )
+
+
+def get_notification(db: Session, notification_id: int) -> models.Notification | None:
+    return db.query(models.Notification).filter(models.Notification.id == notification_id).first()
+
+
+def mark_as_read(db: Session, db_notification: models.Notification) -> models.Notification:
+    db_notification.is_read = True
+    db.commit()
+    db.refresh(db_notification)
+    return db_notification

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from .models.service import Service
 from .models.booking import Booking
 from .models.review import Review
 from .models.request_quote import BookingRequest, Quote
+from .models.notification import Notification
 
 # Routers under app/api/
 from .api import auth
@@ -29,6 +30,7 @@ from .api import (
     api_quote,
     api_sound_provider,
     api_message,
+    api_notification,
 )
 
 # The “artist‐profiles” router lives under app/api/v1/
@@ -125,6 +127,13 @@ app.include_router(
     api_message.router,
     prefix=f"{api_prefix}",
     tags=["messages"],
+)
+
+# ─── NOTIFICATION ROUTES (under /api/v1) ───────────────────────────────────────
+app.include_router(
+    api_notification.router,
+    prefix=f"{api_prefix}",
+    tags=["notifications"],
 )
 
 # ─── SOUND PROVIDER ROUTES (under /api/v1/sound-providers) ───────────────

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from .request_quote import BookingRequest, Quote, BookingRequestStatus, QuoteSta
 from .sound_provider import SoundProvider
 from .artist_sound_preference import ArtistSoundPreference
 from .message import Message, SenderType, MessageType
+from .notification import Notification, NotificationType
 
 __all__ = [
     "User",
@@ -25,4 +26,6 @@ __all__ = [
     "QuoteStatus",
     "SenderType",
     "MessageType",
+    "Notification",
+    "NotificationType",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime
+import enum
+
+from .base import BaseModel
+
+class NotificationType(str, enum.Enum):
+    NEW_MESSAGE = "new_message"
+    NEW_BOOKING_REQUEST = "new_booking_request"
+
+class Notification(BaseModel):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    type = Column(Enum(NotificationType), nullable=False)
+    message = Column(String, nullable=False)
+    is_read = Column(Boolean, default=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", backref="notifications")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -26,6 +26,7 @@ from .request_quote import (
     QuoteCalculationParams,
 )
 from .message import MessageCreate, MessageResponse
+from .notification import NotificationCreate, NotificationResponse
 
 __all__ = [
     "UserBase",
@@ -62,6 +63,8 @@ __all__ = [
     "QuoteCalculationParams",
     "MessageCreate",
     "MessageResponse",
+    "NotificationCreate",
+    "NotificationResponse",
     "SoundProviderBase",
     "SoundProviderCreate",
     "SoundProviderUpdate",

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from datetime import datetime
+from ..models.notification import NotificationType
+
+
+class NotificationCreate(BaseModel):
+    user_id: int
+    type: NotificationType
+    message: str
+
+
+class NotificationResponse(BaseModel):
+    id: int
+    user_id: int
+    type: NotificationType
+    message: str
+    is_read: bool
+    timestamp: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -1,10 +1,22 @@
-from ..models import User
+from sqlalchemy.orm import Session
+from ..models import User, NotificationType
+from ..crud import crud_notification
 
-def notify_user_new_message(user: User, content: str) -> None:
-    # Placeholder for real email or in-app notification
+def notify_user_new_message(db: Session, user: User, content: str) -> None:
+    """Create a notification for a new message."""
+    crud_notification.create_notification(
+        db, user_id=user.id, type=NotificationType.NEW_MESSAGE, message=content
+    )
+    # Placeholder for real email or in-app push
     print(f"Notify {user.email}: new message - {content}")
 
 
-def notify_user_new_booking_request(user: User, request_id: int) -> None:
-    """Placeholder notification for a new booking request."""
+def notify_user_new_booking_request(db: Session, user: User, request_id: int) -> None:
+    """Create a notification for a new booking request."""
+    crud_notification.create_notification(
+        db,
+        user_id=user.id,
+        type=NotificationType.NEW_BOOKING_REQUEST,
+        message=f"New booking request #{request_id}",
+    )
     print(f"Notify {user.email}: new booking request #{request_id}")

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import (
+    User,
+    UserType,
+    BookingRequest,
+    BookingRequestStatus,
+    MessageType,
+)
+from app.models.base import BaseModel
+from app.api import api_message, api_booking_request
+from app.schemas import MessageCreate, BookingRequestCreate
+from app.crud import crud_notification
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_message_creates_notification():
+    db = setup_db()
+    client = User(email='c@test.com', password='x', first_name='C', last_name='User', user_type=UserType.CLIENT)
+    artist = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id, status=BookingRequestStatus.PENDING_QUOTE)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    msg_in = MessageCreate(content='hello', message_type=MessageType.TEXT)
+    api_message.create_message(br.id, msg_in, db, current_user=client)
+
+    notifs = crud_notification.get_notifications_for_user(db, artist.id)
+    assert len(notifs) == 1
+    assert notifs[0].type.value == 'new_message'
+
+
+def test_booking_request_creates_notification():
+    db = setup_db()
+    client = User(email='c@test.com', password='x', first_name='C', last_name='User', user_type=UserType.CLIENT)
+    artist = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    req_in = BookingRequestCreate(artist_id=artist.id, message='hi', status=BookingRequestStatus.PENDING_QUOTE)
+    api_booking_request.create_booking_request(req_in, db, current_user=client)
+
+    notifs = crud_notification.get_notifications_for_user(db, artist.id)
+    assert len(notifs) == 1
+    assert notifs[0].type.value == 'new_booking_request'


### PR DESCRIPTION
## Summary
- add Notification DB model and CRUD helpers
- record notifications when messages or booking requests are created
- expose `/api/v1/notifications` API
- document notification endpoints
- test new notification logic

## Testing
- `npm run lint`
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d106f054832e97f0d2eaec67563e