### PR TITLE
Improve notification UX with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The latest update refines the chat bubbles even further: each message now shows 
 - When artists are logged in, their own messages now appear in blue bubbles just like the client view, while the other person's messages show in gray.
 The backend now persists notifications when a new booking request or message is created. Clients and artists can fetch unread notifications from `/api/v1/notifications` and mark them read with `/api/v1/notifications/{id}/read`.
 The frontend now shows a notification bell in the top navigation. Clicking it reveals recent alerts and automatically marks them as read.
+Each notification links directly to the related booking request so you can jump straight into the conversation.
 The chat thread now displays a friendly placeholder when no messages are present and formats quote prices with the appropriate currency symbol. Any errors fetching or sending messages appear below the input field so problems can be spotted quickly.
 
 ### Service Types

--- a/backend/app/api/api_message.py
+++ b/backend/app/api/api_message.py
@@ -56,7 +56,7 @@ def create_message(request_id: int, message_in: schemas.MessageCreate, db: Sessi
     other_user_id = booking_request.artist_id if sender_type == models.SenderType.CLIENT else booking_request.client_id
     other_user = db.query(models.User).filter(models.User.id == other_user_id).first()
     if other_user:
-        notify_user_new_message(db, other_user, message_in.content)
+        notify_user_new_message(db, other_user, request_id, message_in.content)
     return msg
 
 

--- a/backend/app/crud/crud_notification.py
+++ b/backend/app/crud/crud_notification.py
@@ -9,8 +9,11 @@ def create_notification(
     user_id: int,
     type: models.NotificationType,
     message: str,
+    link: str,
 ) -> models.Notification:
-    db_obj = models.Notification(user_id=user_id, type=type, message=message)
+    db_obj = models.Notification(
+        user_id=user_id, type=type, message=message, link=link
+    )
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -16,6 +16,7 @@ class Notification(BaseModel):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     type = Column(Enum(NotificationType), nullable=False)
     message = Column(String, nullable=False)
+    link = Column(String, nullable=False)
     is_read = Column(Boolean, default=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
 

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -7,6 +7,7 @@ class NotificationCreate(BaseModel):
     user_id: int
     type: NotificationType
     message: str
+    link: str
 
 
 class NotificationResponse(BaseModel):
@@ -14,6 +15,7 @@ class NotificationResponse(BaseModel):
     user_id: int
     type: NotificationType
     message: str
+    link: str
     is_read: bool
     timestamp: datetime
 

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -2,10 +2,16 @@ from sqlalchemy.orm import Session
 from ..models import User, NotificationType
 from ..crud import crud_notification
 
-def notify_user_new_message(db: Session, user: User, content: str) -> None:
+def notify_user_new_message(
+    db: Session, user: User, booking_request_id: int, content: str
+) -> None:
     """Create a notification for a new message."""
     crud_notification.create_notification(
-        db, user_id=user.id, type=NotificationType.NEW_MESSAGE, message=content
+        db,
+        user_id=user.id,
+        type=NotificationType.NEW_MESSAGE,
+        message=content,
+        link=f"/booking-requests/{booking_request_id}",
     )
     # Placeholder for real email or in-app push
     print(f"Notify {user.email}: new message - {content}")
@@ -18,5 +24,6 @@ def notify_user_new_booking_request(db: Session, user: User, request_id: int) ->
         user_id=user.id,
         type=NotificationType.NEW_BOOKING_REQUEST,
         message=f"New booking request #{request_id}",
+        link=f"/booking-requests/{request_id}",
     )
     print(f"Notify {user.email}: new booking request #{request_id}")

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -42,6 +42,7 @@ def test_message_creates_notification():
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
     assert notifs[0].type.value == 'new_message'
+    assert notifs[0].link == f"/booking-requests/{br.id}"
 
 
 def test_booking_request_creates_notification():
@@ -59,3 +60,4 @@ def test_booking_request_creates_notification():
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
     assert notifs[0].type.value == 'new_booking_request'
+    assert notifs[0].link.startswith('/booking-requests/')

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Fragment } from 'react';
+import { useRouter } from 'next/navigation';
 import { Menu, Transition } from '@headlessui/react';
 import { BellIcon } from '@heroicons/react/24/outline';
 import useNotifications from '@/hooks/useNotifications';
+import type { Notification } from '@/types';
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ');
@@ -11,6 +13,14 @@ function classNames(...classes: string[]) {
 
 export default function NotificationBell() {
   const { notifications, unreadCount, markRead } = useNotifications();
+  const router = useRouter();
+
+  const handleClick = async (n: Notification) => {
+    if (!n.is_read) {
+      await markRead(n.id);
+    }
+    router.push(n.link);
+  };
 
   return (
     <Menu as="div" className="relative ml-3">
@@ -39,16 +49,17 @@ export default function NotificationBell() {
           {notifications.map((n) => (
             <Menu.Item key={n.id}>
               {({ active }) => (
-                <div
-                  onClick={() => !n.is_read && markRead(n.id)}
+                <button
+                  type="button"
+                  onClick={() => handleClick(n)}
                   className={classNames(
                     active ? 'bg-gray-100' : '',
-                    'px-4 py-2 text-sm cursor-pointer',
+                    'block w-full text-left px-4 py-2 text-sm',
                     n.is_read ? 'text-gray-500' : 'font-medium'
                   )}
                 >
                   {n.message}
-                </div>
+                </button>
               )}
             </Menu.Item>
           ))}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -173,6 +173,7 @@ export interface Notification {
   user_id: number;
   type: 'new_message' | 'new_booking_request';
   message: string;
+  link: string;
   is_read: boolean;
   timestamp: string;
 }


### PR DESCRIPTION
## Summary
- add `link` column to Notification model & schema
- pass chat links when creating notifications
- update NotificationBell to navigate to link when clicked
- document linked notifications in README
- test updated notifications

## Testing
- `npm run lint`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d57056e8832e85e43920f98340b2