### PR TITLE
Fix CORS headers on 500 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ includes both `http://localhost:3000` and `http://localhost:3002`.
 The value can be provided as a JSON array or a comma separated string.
 If your frontend runs on another origin, update the `CORS_ORIGINS` entry
 in `.env`.
+Unhandled exceptions are wrapped in a middleware that returns JSON
+`500` responses so the configured CORS headers are always included.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- include logging and response utilities in `main.py`
- add `catch_exceptions` middleware to always return JSON 500 responses
- document the new behavior in the CORS section of the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841da0f6390832e93a7b138cbae71fe