### PR TITLE
Fix missing link column for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Likewise, services now use a `display_order` integer to control sorting in the
 dashboard. If your database was created prior to this addition the column will
 be added automatically when the backend starts.
 
+Notifications also store a `link` field used by the UI. Older SQLite databases
+are patched on startup to add this column if it's missing.
+
 ### Service Management
 
 From the artist dashboard you can now edit, delete, and rearrange your offered

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -65,3 +65,19 @@ def ensure_display_order_column(engine: Engine) -> None:
                 )
             )
             conn.commit()
+
+
+def ensure_notification_link_column(engine: Engine) -> None:
+    """Add the link column to notifications if it's missing."""
+    inspector = inspect(engine)
+    if "notifications" not in inspector.get_table_names():
+        return
+    column_names = [col["name"] for col in inspector.get_columns("notifications")]
+    if "link" not in column_names:
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE notifications ADD COLUMN link VARCHAR NOT NULL DEFAULT ''"
+                )
+            )
+            conn.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from .db_utils import (
     ensure_attachment_url_column,
     ensure_service_type_column,
     ensure_display_order_column,
+    ensure_notification_link_column,
 )
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
@@ -47,6 +48,7 @@ ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
 ensure_service_type_column(engine)
 ensure_display_order_column(engine)
+ensure_notification_link_column(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -1,0 +1,33 @@
+import sqlite3
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
+
+from app.db_utils import ensure_notification_link_column
+
+
+def setup_engine() -> Engine:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE notifications (
+                    id INTEGER PRIMARY KEY,
+                    user_id INTEGER,
+                    type VARCHAR,
+                    message VARCHAR,
+                    is_read BOOLEAN,
+                    timestamp DATETIME
+                )
+                """
+            )
+        )
+    return engine
+
+
+def test_add_link_column():
+    engine = setup_engine()
+    ensure_notification_link_column(engine)
+    inspector = inspect(engine)
+    column_names = [col["name"] for col in inspector.get_columns("notifications")]
+    assert "link" in column_names


### PR DESCRIPTION
## Summary
- add `ensure_notification_link_column` helper
- call helper on startup
- document automatic creation of notification link column
- test column creation logic

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dbac7164832eac1de12f3fa242c8