### PR TITLE
Centralize button variants

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,11 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## UI Theme
+
+Reusable style constants are defined in `src/styles`. Button variants come from
+`buttonVariants.ts` so colors stay consistent across the app.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:
@@ -34,3 +39,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,15 +1,12 @@
 'use client';
 import type { ButtonHTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { buttonVariants, type ButtonVariant } from '@/styles/buttonVariants';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?: ButtonVariant;
 }
 
-/**
- * TODO: Consider moving button variants to a central theme file
- * so colors and hover states remain consistent across the app.
- */
 export default function Button({
   variant = 'primary',
   className,
@@ -17,12 +14,7 @@ export default function Button({
 }: ButtonProps) {
   const base =
     'rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50';
-  const variantClass =
-    variant === 'primary'
-      ? 'bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500'
-      : variant === 'secondary'
-      ? 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-400'
-      : 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500';
+  const variantClass = buttonVariants[variant];
 
   return (
     <button type={props.type ?? 'button'} {...props} className={clsx(base, variantClass, className)} />

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -1,0 +1,16 @@
+import { buttonVariants } from '../buttonVariants';
+
+describe('buttonVariants', () => {
+  it('provides classes for primary buttons', () => {
+    expect(buttonVariants.primary).toMatch('bg-indigo-600');
+  });
+
+  it('provides classes for secondary buttons', () => {
+    expect(buttonVariants.secondary).toMatch('bg-gray-200');
+  });
+
+  it('provides classes for danger buttons', () => {
+    expect(buttonVariants.danger).toMatch('bg-red-600');
+  });
+});
+

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,0 +1,8 @@
+export const buttonVariants = {
+  primary: 'bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500',
+  secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-400',
+  danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+} as const;
+
+export type ButtonVariant = keyof typeof buttonVariants;
+


### PR DESCRIPTION
## Summary
- create `buttonVariants` theme constants
- refactor `<Button>` component to use theme constants
- document UI theme setup
- test button variants

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e0f9cbb8832e8998ddfa525f136f