### PR TITLE
Implement WebSocket chat updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm run dev
 ```
 
 The frontend expects the backend to be running on `http://localhost:8000`.
+If the backend or WebSocket server runs elsewhere, set `NEXT_PUBLIC_API_URL` and
+`NEXT_PUBLIC_WS_URL` in `.env.local` accordingly.
 ## Development
 
 ### Setup
@@ -83,6 +85,7 @@ Artist profile pages now link to this wizard via a "Start Booking" button which 
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 
 The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears inside each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client. Once all questions are answered the progress bar disappears automatically.
+- Chat updates are now delivered over a WebSocket connection for real-time conversations without polling.
 - The Personalized Video progress bar now disappears once all questions are answered.
 The latest update refines the chat bubbles even further: each message now shows its send time inside the bubble. The timestamp sits beneath the text in a tiny gray font and the input field still highlights when focused for better accessibility.
 - When artists are logged in, their own messages now appear in blue bubbles just like the client view, while the other person's messages show in gray.

--- a/backend/app/api/api_message.py
+++ b/backend/app/api/api_message.py
@@ -1,35 +1,75 @@
-from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    status,
+    UploadFile,
+    File,
+    BackgroundTasks,
+)
 from sqlalchemy.orm import Session
 from typing import List
 
 from .. import crud, models, schemas
 from .dependencies import get_db, get_current_user
 from ..utils.notifications import notify_user_new_message
+from .api_ws import manager
 import os, uuid, shutil
 
 router = APIRouter(tags=["messages"])
 
-ATTACHMENTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static", "attachments"))
+ATTACHMENTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "static", "attachments")
+)
 os.makedirs(ATTACHMENTS_DIR, exist_ok=True)
 
 
-@router.get("/booking-requests/{request_id}/messages", response_model=List[schemas.MessageResponse])
-def read_messages(request_id: int, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
-    booking_request = crud.crud_booking_request.get_booking_request(db, request_id=request_id)
+@router.get(
+    "/booking-requests/{request_id}/messages",
+    response_model=List[schemas.MessageResponse],
+)
+def read_messages(
+    request_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    booking_request = crud.crud_booking_request.get_booking_request(
+        db, request_id=request_id
+    )
     if not booking_request:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found"
+        )
     if current_user.id not in [booking_request.client_id, booking_request.artist_id]:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access messages")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access messages",
+        )
     return crud.crud_message.get_messages_for_request(db, request_id)
 
 
-@router.post("/booking-requests/{request_id}/messages", response_model=schemas.MessageResponse)
-def create_message(request_id: int, message_in: schemas.MessageCreate, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
-    booking_request = crud.crud_booking_request.get_booking_request(db, request_id=request_id)
+@router.post(
+    "/booking-requests/{request_id}/messages", response_model=schemas.MessageResponse
+)
+def create_message(
+    request_id: int,
+    message_in: schemas.MessageCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
+    booking_request = crud.crud_booking_request.get_booking_request(
+        db, request_id=request_id
+    )
     if not booking_request:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found"
+        )
     if current_user.id not in [booking_request.client_id, booking_request.artist_id]:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to send message")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to send message",
+        )
     sender_type = (
         models.SenderType.CLIENT
         if current_user.id == booking_request.client_id
@@ -53,20 +93,43 @@ def create_message(request_id: int, message_in: schemas.MessageCreate, db: Sessi
         quote_id=message_in.quote_id,
         attachment_url=message_in.attachment_url,
     )
-    other_user_id = booking_request.artist_id if sender_type == models.SenderType.CLIENT else booking_request.client_id
+    other_user_id = (
+        booking_request.artist_id
+        if sender_type == models.SenderType.CLIENT
+        else booking_request.client_id
+    )
     other_user = db.query(models.User).filter(models.User.id == other_user_id).first()
     if other_user:
         notify_user_new_message(db, other_user, request_id, message_in.content)
+    background_tasks.add_task(
+        manager.broadcast,
+        request_id,
+        schemas.MessageResponse.model_validate(msg).model_dump(),
+    )
     return msg
 
 
-@router.post("/booking-requests/{request_id}/attachments", status_code=status.HTTP_201_CREATED)
-async def upload_attachment(request_id: int, file: UploadFile = File(...), db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
-    booking_request = crud.crud_booking_request.get_booking_request(db, request_id=request_id)
+@router.post(
+    "/booking-requests/{request_id}/attachments", status_code=status.HTTP_201_CREATED
+)
+async def upload_attachment(
+    request_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    booking_request = crud.crud_booking_request.get_booking_request(
+        db, request_id=request_id
+    )
     if not booking_request:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found"
+        )
     if current_user.id not in [booking_request.client_id, booking_request.artist_id]:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to upload attachment")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to upload attachment",
+        )
 
     _, ext = os.path.splitext(file.filename)
     unique_filename = f"{uuid.uuid4()}{ext}"

--- a/backend/app/api/api_ws.py
+++ b/backend/app/api/api_ws.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, Query
+from sqlalchemy.orm import Session
+from typing import Dict, List, Any
+from jose import JWTError, jwt
+
+from .dependencies import get_db
+from ..models.user import User
+from ..crud import crud_booking_request
+from .auth import SECRET_KEY, ALGORITHM
+
+router = APIRouter()
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.active_connections: Dict[int, List[WebSocket]] = {}
+
+    async def connect(self, request_id: int, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.setdefault(request_id, []).append(websocket)
+
+    def disconnect(self, request_id: int, websocket: WebSocket) -> None:
+        conns = self.active_connections.get(request_id)
+        if conns and websocket in conns:
+            conns.remove(websocket)
+            if not conns:
+                del self.active_connections[request_id]
+
+    async def broadcast(self, request_id: int, message: Any) -> None:
+        for ws in self.active_connections.get(request_id, []):
+            await ws.send_json(message)
+
+
+manager = ConnectionManager()
+
+
+@router.websocket("/ws/booking-requests/{request_id}")
+async def booking_request_ws(
+    websocket: WebSocket,
+    request_id: int,
+    token: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    user: User | None = None
+    if token:
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            email = payload.get("sub")
+            if email:
+                user = db.query(User).filter(User.email == email).first()
+        except JWTError:
+            user = None
+    booking_request = crud_booking_request.get_booking_request(
+        db, request_id=request_id
+    )
+    if not booking_request or (
+        user and user.id not in [booking_request.client_id, booking_request.artist_id]
+    ):
+        await websocket.close()
+        return
+
+    await manager.connect(request_id, websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(request_id, websocket)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from .api import (
     api_booking_request,
     api_quote,
     api_sound_provider,
+    api_ws,
     api_message,
     api_notification,
 )
@@ -100,6 +101,7 @@ async def catch_exceptions(request: Request, call_next):
             content={"detail": "Internal Server Error"},
         )
 
+
 api_prefix = settings.API_V1_STR  # usually something like "/api/v1"
 
 
@@ -146,6 +148,12 @@ app.include_router(
     api_message.router,
     prefix=f"{api_prefix}",
     tags=["messages"],
+)
+
+app.include_router(
+    api_ws.router,
+    prefix=f"{api_prefix}",
+    tags=["ws"],
 )
 
 # ─── NOTIFICATION ROUTES (under /api/v1) ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- add WebSocket endpoint and connection manager
- broadcast new messages via WebSocket
- replace polling in `MessageThread` with WebSocket logic
- document the new WebSocket setup in README

## Testing
- `npm run lint`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841e2023b60832e8b6698cce2f241fc