### PR TITLE
Implement password strength meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The frontend now shows a notification bell in the top navigation. Clicking it re
 Each notification links directly to the related booking request so you can jump straight into the conversation.
 The chat thread now displays a friendly placeholder when no messages are present and formats quote prices with the appropriate currency symbol. Any errors fetching or sending messages appear below the input field so problems can be spotted quickly.
 
+The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
+
 ### Service Types
 
 Services now include a required **service_type** field with the following options:

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import { Inter } from 'next/font/google'
-import { AuthProvider } from '@/contexts/AuthContext'
-import './globals.css'
+import { Inter } from 'next/font/google';
+import { Toaster } from 'react-hot-toast';
+import { AuthProvider } from '@/contexts/AuthContext';
+import './globals.css';
 
 const inter = Inter({ 
   subsets: ['latin'],
@@ -23,8 +24,9 @@ export default function RootLayout({
       <body className="font-sans antialiased">
         <AuthProvider>
           {children}
+          <Toaster position="top-right" />
         </AuthProvider>
       </body>
     </html>
-  )
-} 
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
-// TODO: Add password strength meter and better success feedback
+
+import toast from 'react-hot-toast';
 
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -23,14 +24,23 @@ export default function RegisterPage() {
   const [error, setError] = useState('');
   const { register, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<RegisterForm>();
 
-  const password = watch('password');
+  const password = watch('password', '');
+
+  const getPasswordStrength = (pass: string) => {
+    let score = 0;
+    if (pass.length >= 8) score += 1;
+    if (/[A-Z]/.test(pass)) score += 1;
+    if (/[0-9]/.test(pass)) score += 1;
+    if (/[^A-Za-z0-9]/.test(pass)) score += 1;
+    return score;
+  };
 
   const onSubmit = async (data: RegisterForm) => {
     try {
       const { confirmPassword, ...userData } = data;
       void confirmPassword;
       await registerUser(userData);
-      alert('Registration successful! Please log in.');
+      toast.success('Registration successful! Please log in.');
       router.push('/login');
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -179,6 +189,21 @@ export default function RegisterPage() {
                 />
                 {errors.password && (
                   <p className="mt-2 text-sm text-red-600">{errors.password.message}</p>
+                )}
+                {password && (
+                  <>
+                    <div className="mt-2 h-2 w-full rounded bg-gray-200">
+                      <div
+                        className={`h-full rounded ${
+                          ['bg-red-500', 'bg-yellow-500', 'bg-blue-500', 'bg-green-600'][Math.max(getPasswordStrength(password) - 1, 0)]
+                        }`}
+                        style={{ width: `${(getPasswordStrength(password) / 4) * 100}%` }}
+                      />
+                    </div>
+                    <p className="mt-1 text-sm text-gray-700">
+                      {['Weak', 'Fair', 'Good', 'Strong'][Math.max(getPasswordStrength(password) - 1, 0)]}
+                    </p>
+                  </>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add Toaster container for notifications
- show toast after successful registration
- display password strength meter on Register page
- document registration UX improvements

## Testing
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e43d00ec832ea2e54dcd93c217c4