### PR TITLE
Implement shared stepper and hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ This version introduces basic management of sound providers and an API for quick
 
 The booking wizard also features a new **Review** step. This shows a preview of the calculated quote and summarizes all entered details with an improved progress indicator and clearer submit buttons.
 
+### Shared stepper and form hook
+
+The wizard now uses a reusable `Stepper` component along with a `useBookingForm` hook to manage form state. These utilities live under `src/components/ui` and `src/hooks` and can be reused by other multi-step forms.
+
 Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,0 +1,41 @@
+'use client';
+import React from 'react';
+
+interface StepperProps {
+  steps: string[];
+  currentStep: number;
+}
+
+export default function Stepper({ steps, currentStep }: StepperProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center" aria-label="Progress">
+        {steps.map((label, i) => (
+          <div key={label} className="flex items-center flex-1">
+            <div
+              className={`h-6 w-6 rounded-full flex items-center justify-center text-xs font-medium ${i <= currentStep ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-600'}`}
+            >
+              {i + 1}
+            </div>
+            <span className="ml-2 text-sm">{label}</span>
+            {i < steps.length - 1 && (
+              <div className="flex-1 border-t border-gray-200 mx-2" />
+            )}
+          </div>
+        ))}
+      </div>
+      <div
+        className="w-full bg-gray-200 rounded h-2"
+        role="progressbar"
+        aria-valuenow={currentStep}
+        aria-valuemin={0}
+        aria-valuemax={steps.length - 1}
+      >
+        <div
+          className="bg-indigo-600 h-2 rounded"
+          style={{ width: `${(currentStep / (steps.length - 1)) * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useBookingForm.ts
+++ b/frontend/src/hooks/useBookingForm.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import type * as yup from 'yup';
+import { EventDetails } from '@/contexts/BookingContext';
+
+export default function useBookingForm(
+  schema: yup.ObjectSchema<EventDetails>,
+  defaultValues: EventDetails,
+  setDetails: (d: EventDetails) => void,
+) {
+  const {
+    control,
+    handleSubmit,
+    trigger,
+    watch,
+    formState: { errors },
+  } = useForm<EventDetails>({
+    defaultValues,
+    resolver: yupResolver(schema),
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    const sub = watch((v) => setDetails(v as EventDetails));
+    return () => sub.unsubscribe();
+  }, [watch, setDetails]);
+
+  return { control, handleSubmit, trigger, watch, errors };
+}


### PR DESCRIPTION
## Summary
- introduce a reusable `Stepper` component
- factor booking wizard form logic into a `useBookingForm` hook
- refactor `BookingWizard` to use the new hook and component
- document the new shared form utilities in README

## Testing
- `npm run lint --prefix frontend`
- `npm test --prefix frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e6842fc4832ea9369985798325ed