### PR TITLE
Fix duplicate password label on login page

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -59,16 +59,6 @@ export default function LoginPage() {
             />
 
             <div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="password" className="block text-sm font-medium leading-6 text-gray-900">
-                  Password
-                </label>
-                <div className="text-sm">
-                  <Link href="/forgot-password" className="font-semibold text-indigo-600 hover:text-indigo-500">
-                    Forgot password?
-                  </Link>
-                </div>
-              </div>
               <AuthInput
                 id="password"
                 type="password"
@@ -83,6 +73,11 @@ export default function LoginPage() {
                 })}
                 error={errors.password}
               />
+              <div className="mt-2 text-right text-sm">
+                <Link href="/forgot-password" className="font-semibold text-indigo-600 hover:text-indigo-500">
+                  Forgot password?
+                </Link>
+              </div>
             </div>
 
             {error && (


### PR DESCRIPTION
## Summary
- remove redundant password label in login form

## Testing
- `npm run lint`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841eba03e58832eb827e012ac46cace