### PR TITLE
Remove profile calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The booking wizard also features a new **Review** step. This shows a preview of 
 
 The wizard now uses a reusable `Stepper` component along with a `useBookingForm` hook to manage form state. These utilities live under `src/components/ui` and `src/hooks` and can be reused by other multi-step forms.
 
-Artist profile pages now link to this wizard via a "Start Booking" button which navigates to `/booking?artist_id={id}`.
+Each service on an artist profile now includes a "Book Now" button. This opens the booking wizard (or request chat) for that specific service via `/booking?artist_id={id}&service_id={serviceId}` when applicable.
 After submitting a booking request, clients are redirected straight to the associated chat thread so they can continue the conversation. The chat interface uses polished message bubbles and aligns your own messages on the right, similar to Airbnb's inbox. The automatic "Requesting ..." and "Booking request sent" entries that previously appeared at the top of each conversation have been removed so the thread begins with meaningful details.
 
 The chat now auto-scrolls after each message, shows image previews before sending, and keeps the input bar fixed above the keyboard on mobile. A subtle timestamp appears inside each bubble, avatars display initials, and the Personalized Video flow shows a progress bar like "1/3 questions answered" with a typing indicator when waiting for the client. Once all questions are answered the progress bar disappears automatically.

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -305,7 +305,7 @@ export default function ArtistProfilePage() {
                           onClick={() => handleBookService(service)}
                           className="mt-6 w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
                         >
-                          Book {service.title}
+                          Book Now
                         </button>
                       </div>
                     ))}
@@ -355,10 +355,10 @@ export default function ArtistProfilePage() {
               </section>
             </div>
 
-            {/* ── Right-third: Contact & Booking Form ───────────────────────────────────── */}
+            {/* ── Right-third: Contact Info ───────────────────────────────────── */}
             <aside id="booking-contact-sidebar" className="lg:col-span-1 mt-12 lg:mt-0">
               <div className="sticky top-24 space-y-6 p-6 bg-white rounded-2xl shadow-md border border-gray-200">
-                <h3 className="text-xl font-semibold text-gray-800 border-b pb-3">Contact & Booking</h3>
+                <h3 className="text-xl font-semibold text-gray-800 border-b pb-3">Contact</h3>
                 {averageRating ? (
                   <div className="flex items-center text-sm text-gray-700">
                     <StarIcon className="h-5 w-5 text-yellow-400 mr-1" />
@@ -377,36 +377,12 @@ export default function ArtistProfilePage() {
                   </p>
                 )}
 
-                <div className="mt-6">
-                  <h4 className="text-md font-medium text-gray-700 mb-3 flex items-center">
-                    <CalendarDaysIcon className="h-5 w-5 mr-2 text-gray-500" /> Availability
-                  </h4>
-                  <div className="flex flex-wrap gap-2 mb-2">
-                    {nextAvailableDates.map((d) => (
-                      <span
-                        key={d.toISOString()}
-                        className="bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-sm"
-                      >
-                        {format(d, 'MMM d')}
-                      </span>
-                    ))}
-                    {nextAvailableDates.length === 0 && (
-                      <span className="text-sm text-gray-500">No upcoming availability</span>
-                    )}
-                  </div>
-                  <p className="mt-1 text-xs text-gray-500">
-                    See full calendar and select your date during booking.
+                {nextAvailableDates.length > 0 && (
+                  <p className="text-sm text-gray-500 flex items-center mt-4">
+                    <CalendarDaysIcon className="h-5 w-5 mr-2 text-gray-500" />
+                    Next available: {format(nextAvailableDates[0], 'MMM d')}
                   </p>
-                </div>
-
-                <div className="text-center">
-                  <Link
-                    href={`/booking?artist_id=${artist.user_id}`}
-                    className="block w-full bg-rose-500 text-white py-3 px-4 rounded-lg hover:bg-rose-600 font-semibold text-lg transition-colors"
-                  >
-                    Start Booking
-                  </Link>
-                </div>
+                )}
               </div>
             </aside>
           </div>


### PR DESCRIPTION
## Summary
- simplify artist profile sidebar
- replace service buttons with a "Book Now" label
- document changed booking entry point

## Testing
- `npm run lint`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f079324c832e93473b5533af6b2f