### PR TITLE
Fix cascading delete for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ are patched on startup to add this column if it's missing.
 From the artist dashboard you can now edit, delete, and rearrange your offered
 services. Use the up/down arrows next to a service to change its display order.
 
+Deleting a service now cascades removal to any related booking requests and
+their messages. Existing conversations will be cleaned up automatically.
+
 ### Artist Availability
 
 You can now query an artist's unavailable dates via:

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, Text, DateTime, Enum, ForeignKey, String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from datetime import datetime
 import enum
 
@@ -28,6 +28,9 @@ class Message(BaseModel):
     attachment_url = Column(String, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
 
-    booking_request = relationship("BookingRequest", backref="messages")
+    booking_request = relationship(
+        "BookingRequest",
+        backref=backref("messages", cascade="all, delete-orphan"),
+    )
     sender = relationship("User")
     quote = relationship("Quote")

--- a/backend/tests/test_service_delete.py
+++ b/backend/tests/test_service_delete.py
@@ -1,0 +1,77 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import (
+    User,
+    UserType,
+    Service,
+    BookingRequest,
+    BookingRequestStatus,
+    Message,
+    MessageType,
+    SenderType,
+)
+from app.models.service import ServiceType
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.models.base import BaseModel
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_delete_service_cascades_messages():
+    db = setup_db()
+    # Create artist and client
+    artist_user = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    client_user = User(email='c@test.com', password='x', first_name='C', last_name='Client', user_type=UserType.CLIENT)
+    db.add_all([artist_user, client_user])
+    db.commit()
+    db.refresh(artist_user)
+    db.refresh(client_user)
+
+    # Artist profile and service
+    profile = ArtistProfileV2(user_id=artist_user.id)
+    service = Service(
+        artist_id=artist_user.id,
+        title='Gig',
+        price=100,
+        duration_minutes=60,
+        service_type=ServiceType.OTHER,
+    )
+    profile.services.append(service)
+    db.add(profile)
+    db.commit()
+    db.refresh(service)
+
+    # Booking request with message
+    br = BookingRequest(
+        client_id=client_user.id,
+        artist_id=artist_user.id,
+        service_id=service.id,
+        status=BookingRequestStatus.PENDING_QUOTE,
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    msg = Message(
+        booking_request_id=br.id,
+        sender_id=client_user.id,
+        sender_type=SenderType.CLIENT,
+        content='hi',
+        message_type=MessageType.TEXT,
+    )
+    db.add(msg)
+    db.commit()
+
+    assert db.query(Message).count() == 1
+    db.delete(service)
+    db.commit()
+
+    assert db.query(BookingRequest).count() == 0
+    assert db.query(Message).count() == 0


### PR DESCRIPTION
## Summary
- cascade delete messages when their booking request is removed
- document cascade behavior in README
- add regression test for service deletion cleaning up messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fd43f194832eb0c6c6067cbe15cb