### PR TITLE
Fix artist profile header layout

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -233,8 +233,8 @@ export default function ArtistProfilePage() {
                   </button>
                 )}
               </div>
-              <div className="pt-3 md:pt-10 text-center md:text-left md:flex-1 md:min-w-0">
-                <h1 className="text-3xl md:text-4xl font-bold text-gray-900 break-words">
+              <div className="pt-3 md:pt-10 text-center md:text-left flex-1 min-w-0">
+                <h1 className="text-3xl md:text-4xl font-bold text-gray-900 truncate md:break-words">
                   {artist.business_name || `${artist.user.first_name} ${artist.user.last_name}`}
                 </h1>
                 {artist.business_name && (


### PR DESCRIPTION
## Summary
- ensure artist header info container allows truncation and wrapping without overlap
- keep image size fixed using `flex-shrink-0`

## Testing
- `npm run lint`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684213e0a028832e8d6d02303d23ae7f