### PR TITLE
Fix notification hook initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.
+- Fixed a crash in the notification dropdown caused by calling hooks before they
+  were initialized.
 
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -20,12 +20,6 @@ export default function useNotifications() {
 
   const [threads, setThreads] = useState<ThreadNotification[]>([]);
 
-  useEffect(() => {
-    if (!user) return;
-    loadMore();
-    loadThreads();
-  }, [user, loadMore, loadThreads]);
-
   const loadMore = useCallback(async () => {
     if (!user) return;
     setLoading(true);
@@ -51,6 +45,12 @@ export default function useNotifications() {
       setError('Failed to load notifications.');
     }
   }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    loadMore();
+    loadThreads();
+  }, [user, loadMore, loadThreads]);
 
   const unreadCount =
     notifications.filter((n) => !n.is_read).length +


### PR DESCRIPTION
## Summary
- avoid referencing callbacks before they're defined in `useNotifications`
- document fix in README

## Testing
- `npm run lint` in `frontend`
- `npm test` in `frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68421c65f1a0832e9ea2cdc31f54aa3c