### PR TITLE
Add custom subtitle to artist profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Explore Other Artists offers grid/list toggles and shows specialties.
 - Notification dropdown now displays icons and timestamps.
 - Buttons and modals include subtle scale animations.
+- Artist profiles now support an optional subtitle/tagline displayed beneath the main name.
 - Introduced shared `Card`, `Tag`, and `TextInput` components with built-in loading states and accessibility helpers.
 - Profile pages now generate Open Graph meta tags for easier sharing and show a fallback avatar image with an edit overlay for artists.
 - Notifications are grouped by type in a dropdown with options to mark each as read or preview the related item.

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -81,3 +81,15 @@ def ensure_notification_link_column(engine: Engine) -> None:
                 )
             )
             conn.commit()
+
+
+def ensure_custom_subtitle_column(engine: Engine) -> None:
+    """Add the custom_subtitle column to artist_profiles if it's missing."""
+    inspector = inspect(engine)
+    if "artist_profiles" not in inspector.get_table_names():
+        return
+    column_names = [col["name"] for col in inspector.get_columns("artist_profiles")]
+    if "custom_subtitle" not in column_names:
+        with engine.connect() as conn:
+            conn.execute(text("ALTER TABLE artist_profiles ADD COLUMN custom_subtitle VARCHAR"))
+            conn.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .db_utils import (
     ensure_service_type_column,
     ensure_display_order_column,
     ensure_notification_link_column,
+    ensure_custom_subtitle_column,
 )
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
@@ -50,6 +51,7 @@ ensure_attachment_url_column(engine)
 ensure_service_type_column(engine)
 ensure_display_order_column(engine)
 ensure_notification_link_column(engine)
+ensure_custom_subtitle_column(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")

--- a/backend/app/models/artist_profile_v2.py
+++ b/backend/app/models/artist_profile_v2.py
@@ -16,6 +16,7 @@ class ArtistProfileV2(BaseModel):
         index=True,
     )
     business_name      = Column(String, index=True, nullable=True)
+    custom_subtitle    = Column(String, nullable=True)
     description        = Column(Text, nullable=True)
     location           = Column(String, nullable=True)
     hourly_rate        = Column(Numeric(10, 2), nullable=True)

--- a/backend/app/schemas/artist.py
+++ b/backend/app/schemas/artist.py
@@ -13,6 +13,7 @@ from .user import UserResponse  # <-- make sure this points at your nested User 
 #
 class ArtistProfileBase(BaseModel):
     business_name: Optional[str] = None
+    custom_subtitle: Optional[str] = None
     description: Optional[str] = None
     location: Optional[str] = None
     hourly_rate: Optional[Decimal] = None

--- a/backend/tests/test_artist_profile_subtitle.py
+++ b/backend/tests/test_artist_profile_subtitle.py
@@ -1,0 +1,30 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.models.user import User, UserType
+from app.models.base import BaseModel
+from app.schemas.artist import ArtistProfileResponse
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_custom_subtitle_field_roundtrip():
+    db = setup_db()
+    user = User(email='a@test.com', password='x', first_name='A', last_name='B', user_type=UserType.ARTIST)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    profile = ArtistProfileV2(user_id=user.id, business_name='The Band', custom_subtitle='Indie Rock Band')
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+
+    schema = ArtistProfileResponse.model_validate(profile)
+    assert schema.custom_subtitle == 'Indie Rock Band'

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -237,13 +237,13 @@ export default function ArtistProfilePage() {
                 <h1 className="text-3xl md:text-4xl font-bold text-gray-900 truncate md:break-words">
                   {artist.business_name || `${artist.user.first_name} ${artist.user.last_name}`}
                 </h1>
-                {artist.business_name && (
+                {(artist.custom_subtitle || (!artist.custom_subtitle && artist.location)) && (
                   <p className="text-md text-gray-600">
-                    {artist.user.first_name} {artist.user.last_name}
+                    {artist.custom_subtitle || artist.location}
                   </p>
                 )}
                 <div className="mt-2 flex flex-wrap items-center justify-center md:justify-start gap-x-3 gap-y-1 text-sm text-gray-500">
-                  {artist.location && (
+                  {artist.location && !artist.custom_subtitle && (
                     <span className="flex items-center">
                       <MapPinIcon className="h-4 w-4 mr-1" /> {artist.location}
                     </span>
@@ -263,7 +263,7 @@ export default function ArtistProfilePage() {
           <div className="space-y-8">
               {/* “About” Section */}
               <section>
-                <h2 className="text-xl font-semibold text-gray-800 mb-3">About {artist.user.first_name}</h2>
+                <h2 className="text-xl font-semibold text-gray-800 mb-3">About</h2>
                 {artist.description ? (
                   <p className="text-gray-600 whitespace-pre-line">{artist.description}</p>
                 ) : (

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -108,6 +108,7 @@ export default function EditArtistProfilePage() {
 
   // Business‐form fields
   const [businessNameInput, setBusinessNameInput] = useState('');
+  const [customSubtitleInput, setCustomSubtitleInput] = useState('');
   const [descriptionInput, setDescriptionInput] = useState('');
   const [locationInput, setLocationInput] = useState('');
   const [hourlyRateInput, setHourlyRateInput] = useState<string | number>('');
@@ -158,6 +159,7 @@ export default function EditArtistProfilePage() {
 
         // Initialize form inputs
         setBusinessNameInput(fetchedProfile.business_name || '');
+        setCustomSubtitleInput(fetchedProfile.custom_subtitle || '');
         setDescriptionInput(fetchedProfile.description || '');
         setLocationInput(fetchedProfile.location || '');
         setHourlyRateInput(fetchedProfile.hourly_rate?.toString() || '');
@@ -203,6 +205,7 @@ export default function EditArtistProfilePage() {
       setLoading(true);
       const dataToUpdate: Partial<ArtistProfile> = {
         business_name: businessNameInput.trim(),
+        custom_subtitle: customSubtitleInput.trim() || undefined,
         description: descriptionInput.trim(),
         location: locationInput.trim(),
         hourly_rate: hourlyRateInput
@@ -547,6 +550,19 @@ export default function EditArtistProfilePage() {
                     className={inputClasses}
                     placeholder="e.g., Your Awesome Studio"
                     required
+                  />
+                </div>
+                <div>
+                  <label htmlFor="customSubtitle" className={labelClasses}>
+                    Subtitle / Tagline
+                  </label>
+                  <input
+                    type="text"
+                    id="customSubtitle"
+                    value={customSubtitleInput}
+                    onChange={(e) => setCustomSubtitleInput(e.target.value)}
+                    className={inputClasses}
+                    placeholder="e.g., Indie Rock Band"
                   />
                 </div>
                 <div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,7 @@ export interface ArtistProfile {
   id: number;
   user_id: number;
   business_name: string;
+  custom_subtitle?: string | null;
   description?: string | null;
   location?: string | null;
   hourly_rate?: number | string | null;


### PR DESCRIPTION
## Summary
- allow artists to store a `custom_subtitle`
- support database patching for the new column
- expose the field via schemas and API
- update artist profile edit form and display
- document the new feature
- add test for subtitle roundtrip

## Testing
- `npx eslint src`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68421e27fa70832e97420151e1f1381b