### PR TITLE
Improve notification UX with drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Introduced shared `Card`, `Tag`, and `TextInput` components with built-in loading states and accessibility helpers.
 - Profile pages now generate Open Graph meta tags for easier sharing and show a fallback avatar image with an edit overlay for artists.
 - Notifications are grouped by type in a dropdown with options to mark each as read or preview the related item.
+- The notification dropdown has been replaced with a slide-out drawer that offers more room and a single click to mark all notifications read.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Menu, Transition } from '@headlessui/react';
 import { BellIcon, ChatBubbleOvalLeftEllipsisIcon, CalendarIcon } from '@heroicons/react/24/outline';
+import NotificationDrawer from './NotificationDrawer';
 import { formatDistanceToNow } from 'date-fns';
 import useNotifications from '@/hooks/useNotifications';
 import type { Notification, ThreadNotification } from '@/types';
@@ -27,16 +27,19 @@ export default function NotificationBell() {
     hasMore,
   } = useNotifications();
   const router = useRouter();
+  const [open, setOpen] = useState(false);
 
   const handleClick = async (n: Notification) => {
     if (!n.is_read) {
       await markRead(n.id);
     }
+    setOpen(false);
     router.push(n.link);
   };
 
   const handleThreadClick = async (t: ThreadNotification) => {
     await markThread(t.booking_request_id);
+    setOpen(false);
     router.push(t.link);
   };
 
@@ -56,8 +59,12 @@ export default function NotificationBell() {
   }, {});
 
   return (
-    <Menu as="div" className="relative ml-3" aria-live="polite">
-      <Menu.Button className="flex text-gray-400 hover:text-gray-600 focus:outline-none">
+    <div className="relative ml-3" aria-live="polite">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex text-gray-400 hover:text-gray-600 focus:outline-none"
+      >
         <span className="sr-only">View notifications</span>
         <BellIcon className="h-6 w-6" aria-hidden="true" />
         {unreadCount > 0 && (
@@ -65,135 +72,18 @@ export default function NotificationBell() {
             {unreadCount}
           </span>
         )}
-      </Menu.Button>
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-200"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <Menu.Items className="absolute right-0 z-10 mt-2 w-80 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
-          {(notifications.length > 0 || hasThreads) && (
-            <div className="px-4 py-2 border-b border-gray-200 flex justify-end">
-              <button
-                type="button"
-                onClick={markAllRead}
-                className="text-xs text-indigo-600 hover:underline focus:outline-none"
-                aria-label="Mark all notifications read"
-              >
-                Mark all read
-              </button>
-            </div>
-          )}
-          {notifications.length === 0 && !hasThreads && (
-            <div className="px-4 py-2 text-sm text-gray-500">No notifications</div>
-          )}
-          {hasThreads && (
-            <div className="py-1" key="threads">
-              <p className="px-4 pt-2 text-xs font-semibold text-gray-500">Messages</p>
-              {threads.map((t) => (
-                <Menu.Item key={t.booking_request_id}>
-                  {({ active }) => (
-                    <div
-                      className={classNames(
-                        active ? 'bg-gray-100' : '',
-                        'flex w-full items-start px-4 py-2 text-sm gap-2'
-                      )}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => handleThreadClick(t)}
-                        className={classNames(
-                          'flex-1 text-left',
-                          t.unread_count > 0 ? 'font-medium' : 'text-gray-500'
-                        )}
-                      >
-                        <span className="flex items-start gap-2">
-                          <ChatBubbleOvalLeftEllipsisIcon className="h-4 w-4 mt-0.5" />
-                          <span className="flex-1">
-                            {t.name}
-                            {t.unread_count > 0 && ` — ${t.unread_count} new messages`}
-                          </span>
-                        </span>
-                        <span className="block w-full text-xs text-gray-400 truncate break-words">
-                          {t.last_message}
-                        </span>
-                        <span className="block text-xs text-gray-400">
-                          {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
-                        </span>
-                      </button>
-                    </div>
-                  )}
-                </Menu.Item>
-              ))}
-            </div>
-          )}
-          {Object.entries(grouped).map(([type, items]) => (
-            <div key={type} className="py-1">
-              <p className="px-4 pt-2 text-xs font-semibold text-gray-500">
-                {type === 'booking_update' ? 'Bookings' : 'Other'}
-              </p>
-              {items.map((n) => (
-                <Menu.Item key={n.id}>
-                  {({ active }) => {
-                    const Icon = n.type === 'new_message' ? ChatBubbleOvalLeftEllipsisIcon : CalendarIcon;
-                    return (
-                      <div
-                        className={classNames(
-                          active ? 'bg-gray-100' : '',
-                          'flex w-full items-start px-4 py-2 text-sm gap-2'
-                        )}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleClick(n)}
-                          className={classNames('flex-1 text-left', n.is_read ? 'text-gray-500' : 'font-medium')}
-                        >
-                          <span className="flex items-start gap-2">
-                            <Icon className="h-4 w-4 mt-0.5" />
-                            <span className="flex-1">{n.message}</span>
-                          </span>
-                          <span className="block text-xs text-gray-400">
-                            {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-                          </span>
-                        </button>
-                        {!n.is_read ? (
-                          <button
-                            type="button"
-                            onClick={() => markRead(n.id)}
-                            className="text-xs text-indigo-600 hover:underline ml-2"
-                            aria-label="Mark read"
-                          >
-                            Mark read
-                          </button>
-                        ) : (
-                          <span className="ml-2 text-xs text-gray-400" aria-label="Read">
-                            Read
-                          </span>
-                        )}
-                      </div>
-                    );
-                  }}
-                </Menu.Item>
-              ))}
-            </div>
-          ))}
-          {hasMore && (
-            <div className="px-4 py-2 border-t border-gray-200 text-center">
-              <button
-                type="button"
-                onClick={loadMore}
-                className="text-xs text-indigo-600 hover:underline focus:outline-none"
-              >
-                Load more
-              </button>
-            </div>
-          )}
-        </Menu.Items>
-      </Transition>
-    </Menu>
+      </button>
+      <NotificationDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        notifications={notifications}
+        threads={threads}
+        markRead={handleClick}
+        markThread={handleThreadClick}
+        markAllRead={markAllRead}
+        loadMore={loadMore}
+        hasMore={hasMore}
+      />
+    </div>
   );
 }

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { formatDistanceToNow } from 'date-fns';
+import type { Notification, ThreadNotification } from '@/types';
+
+interface NotificationDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  notifications: Notification[];
+  threads: ThreadNotification[];
+  markRead: (id: number) => Promise<void>;
+  markThread: (id: number) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  hasMore: boolean;
+}
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function NotificationDrawer({
+  open,
+  onClose,
+  notifications,
+  threads,
+  markRead,
+  markThread,
+  markAllRead,
+  loadMore,
+  hasMore,
+}: NotificationDrawerProps) {
+  const hasThreads = threads.length > 0;
+  const grouped = notifications.reduce<Record<string, Notification[]>>((acc, n) => {
+    const key = n.type || 'other';
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(n);
+    return acc;
+  }, {});
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-600 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-0 overflow-hidden">
+            <div className="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-300"
+                enterFrom="translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-300"
+                leaveFrom="translate-x-0"
+                leaveTo="translate-x-full"
+              >
+                <Dialog.Panel className="pointer-events-auto w-screen max-w-sm bg-white shadow-xl flex flex-col">
+                  <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+                    <Dialog.Title className="text-lg font-medium text-gray-900">Notifications</Dialog.Title>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={markAllRead}
+                        className="text-xs text-indigo-600 hover:underline"
+                      >
+                        Mark all read
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none"
+                        onClick={onClose}
+                      >
+                        <span className="sr-only">Close panel</span>
+                        <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+                  <div className="flex-1 overflow-y-auto">
+                    {notifications.length === 0 && !hasThreads && (
+                      <div className="px-4 py-2 text-sm text-gray-500">No notifications</div>
+                    )}
+                    {hasThreads && (
+                      <div className="py-1" key="threads">
+                        <p className="px-4 pt-2 text-xs font-semibold text-gray-500">Messages</p>
+                        {threads.map((t) => (
+                          <div key={t.booking_request_id} className="flex w-full items-start px-4 py-2 text-sm gap-2">
+                            <button
+                              type="button"
+                              onClick={() => markThread(t.booking_request_id)}
+                              className={classNames('flex-1 text-left', t.unread_count > 0 ? 'font-medium' : 'text-gray-500')}
+                            >
+                              <span className="flex items-start gap-2">
+                                <span className="flex-1">{t.name}{t.unread_count > 0 && ` — ${t.unread_count} new messages`}</span>
+                              </span>
+                              <span className="block w-full text-xs text-gray-400 truncate break-words">{t.last_message}</span>
+                              <span className="block text-xs text-gray-400">
+                                {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
+                              </span>
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {Object.entries(grouped).map(([type, items]) => (
+                      <div key={type} className="py-1">
+                        <p className="px-4 pt-2 text-xs font-semibold text-gray-500">
+                          {type === 'booking_update' ? 'Bookings' : 'Other'}
+                        </p>
+                        {items.map((n) => (
+                          <div key={n.id} className="flex w-full items-start px-4 py-2 text-sm gap-2">
+                            <button
+                              type="button"
+                              onClick={() => markRead(n.id)}
+                              className={classNames('flex-1 text-left', n.is_read ? 'text-gray-500' : 'font-medium')}
+                            >
+                              <span className="flex items-start gap-2">
+                                <span className="flex-1">{n.message}</span>
+                              </span>
+                              <span className="block text-xs text-gray-400">
+                                {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
+                              </span>
+                            </button>
+                            {!n.is_read ? (
+                              <button
+                                type="button"
+                                onClick={() => markRead(n.id)}
+                                className="text-xs text-indigo-600 hover:underline ml-2"
+                                aria-label="Mark read"
+                              >
+                                Mark read
+                              </button>
+                            ) : (
+                              <span className="ml-2 text-xs text-gray-400" aria-label="Read">
+                                Read
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    ))}
+                    {hasMore && (
+                      <div className="px-4 py-2 border-t border-gray-200 text-center">
+                        <button
+                          type="button"
+                          onClick={loadMore}
+                          className="text-xs text-indigo-600 hover:underline focus:outline-none"
+                        >
+                          Load more
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- replace dropdown with NotificationDrawer component
- add mark all read button inside the drawer
- document the new drawer UI

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68422db04fa8832eb8ada73b77bd0dee