### PR TITLE
Add full-screen notification modal for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Notifications are grouped by type in a dropdown with options to mark each as read or preview the related item.
 - The notification dropdown has been replaced with a slide-out drawer that offers more room and a single click to mark all notifications read.
 - The notification bell now appears on mobile screens so alerts can be accessed anywhere.
+- On small screens, notifications open in a full-screen modal instead of the drawer for easier reading.
 - Duplicate notifications are now removed when loading additional pages.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { formatDistanceToNow } from 'date-fns';
+import type { Notification, ThreadNotification } from '@/types';
+
+interface FullScreenNotificationModalProps {
+  open: boolean;
+  onClose: () => void;
+  notifications: Notification[];
+  threads: ThreadNotification[];
+  markRead: (id: number) => Promise<void>;
+  markThread: (id: number) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  hasMore: boolean;
+}
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function FullScreenNotificationModal({
+  open,
+  onClose,
+  notifications,
+  threads,
+  markRead,
+  markThread,
+  markAllRead,
+  loadMore,
+  hasMore,
+}: FullScreenNotificationModalProps) {
+  const hasThreads = threads.length > 0;
+  const grouped = notifications.reduce<Record<string, Notification[]>>((acc, n) => {
+    const key = n.type || 'other';
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(n);
+    return acc;
+  }, {});
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-600 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="relative w-full transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all">
+                <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+                  <Dialog.Title className="text-lg font-medium text-gray-900">Notifications</Dialog.Title>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={markAllRead}
+                      className="text-xs text-indigo-600 hover:underline"
+                    >
+                      Mark all read
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none"
+                      onClick={onClose}
+                    >
+                      <span className="sr-only">Close panel</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+                <div className="max-h-[calc(100vh-4rem)] overflow-y-auto">
+                  {notifications.length === 0 && !hasThreads && (
+                    <div className="px-4 py-2 text-sm text-gray-500">No notifications</div>
+                  )}
+                  {hasThreads && (
+                    <div className="py-1" key="threads">
+                      <p className="px-4 pt-2 text-xs font-semibold text-gray-500">Messages</p>
+                      {threads.map((t) => (
+                        <div key={`thread-${t.booking_request_id}`} className="flex w-full items-start px-4 py-2 text-sm gap-2">
+                          <button
+                            type="button"
+                            onClick={() => markThread(t.booking_request_id)}
+                            className={classNames('flex-1 text-left', t.unread_count > 0 ? 'font-medium' : 'text-gray-500')}
+                          >
+                            <span className="flex items-start gap-2">
+                              <span className="flex-1">{t.name}{t.unread_count > 0 && ` — ${t.unread_count} new messages`}</span>
+                            </span>
+                            <span className="block w-full text-xs text-gray-400 truncate break-words">{t.last_message}</span>
+                            <span className="block text-xs text-gray-400">
+                              {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
+                            </span>
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {Object.entries(grouped).map(([type, items]) => (
+                    <div key={type} className="py-1">
+                      <p className="px-4 pt-2 text-xs font-semibold text-gray-500">
+                        {type === 'booking_update' ? 'Bookings' : 'Other'}
+                      </p>
+                      {items.map((n) => (
+                        <div key={`notif-${n.id}`} className="flex w-full items-start px-4 py-2 text-sm gap-2">
+                          <button
+                            type="button"
+                            onClick={() => markRead(n.id)}
+                            className={classNames('flex-1 text-left', n.is_read ? 'text-gray-500' : 'font-medium')}
+                          >
+                            <span className="flex items-start gap-2">
+                              <span className="flex-1">{n.message}</span>
+                            </span>
+                            <span className="block text-xs text-gray-400">
+                              {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
+                            </span>
+                          </button>
+                          {!n.is_read ? (
+                            <button
+                              type="button"
+                              onClick={() => markRead(n.id)}
+                              className="text-xs text-indigo-600 hover:underline ml-2"
+                              aria-label="Mark read"
+                            >
+                              Mark read
+                            </button>
+                          ) : (
+                            <span className="ml-2 text-xs text-gray-400" aria-label="Read">
+                              Read
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                  {hasMore && (
+                    <div className="px-4 py-2 border-t border-gray-200 text-center">
+                      <button
+                        type="button"
+                        onClick={loadMore}
+                        className="text-xs text-indigo-600 hover:underline focus:outline-none"
+                      >
+                        Load more
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { BellIcon } from '@heroicons/react/24/outline';
 import NotificationDrawer from './NotificationDrawer';
+import FullScreenNotificationModal from './FullScreenNotificationModal';
+import isMobileScreen from '@/lib/isMobile';
 import useNotifications from '@/hooks/useNotifications';
 import type { Notification } from '@/types';
 
@@ -65,17 +67,31 @@ export default function NotificationBell() {
           </span>
         )}
       </button>
-      <NotificationDrawer
-        open={open}
-        onClose={() => setOpen(false)}
-        notifications={notifications}
-        threads={threads}
-        markRead={handleClick}
-        markThread={handleThreadClick}
-        markAllRead={markAllRead}
-        loadMore={loadMore}
-        hasMore={hasMore}
-      />
+      {isMobileScreen() ? (
+        <FullScreenNotificationModal
+          open={open}
+          onClose={() => setOpen(false)}
+          notifications={notifications}
+          threads={threads}
+          markRead={handleClick}
+          markThread={handleThreadClick}
+          markAllRead={markAllRead}
+          loadMore={loadMore}
+          hasMore={hasMore}
+        />
+      ) : (
+        <NotificationDrawer
+          open={open}
+          onClose={() => setOpen(false)}
+          notifications={notifications}
+          threads={threads}
+          markRead={handleClick}
+          markThread={handleThreadClick}
+          markAllRead={markAllRead}
+          loadMore={loadMore}
+          hasMore={hasMore}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/__tests__/isMobile.test.ts
+++ b/frontend/src/lib/__tests__/isMobile.test.ts
@@ -1,0 +1,22 @@
+import isMobileScreen from '../isMobile';
+
+describe('isMobileScreen', () => {
+  const g = global as unknown as { window?: { innerWidth: number } };
+
+  it('returns true when window width is below 640', () => {
+    g.window = { innerWidth: 500 };
+    expect(isMobileScreen()).toBe(true);
+  });
+
+  it('returns false when window width is 640 or more', () => {
+    g.window = { innerWidth: 800 };
+    expect(isMobileScreen()).toBe(false);
+  });
+
+  it('returns false when window is undefined', () => {
+    const win = g.window;
+    delete g.window;
+    expect(isMobileScreen()).toBe(false);
+    g.window = win;
+  });
+});

--- a/frontend/src/lib/isMobile.ts
+++ b/frontend/src/lib/isMobile.ts
@@ -1,0 +1,4 @@
+export default function isMobileScreen(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth < 640;
+}


### PR DESCRIPTION
## Summary
- show notifications in a new `FullScreenNotificationModal` when viewport width < 640px
- use helper `isMobileScreen()` to detect screen size
- conditionally render drawer vs. modal in `NotificationBell`
- document mobile modal behavior in README
- test `isMobileScreen`

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842a1561b48832eb4827584fea2b4be