### PR TITLE
Improve notifications layout and add test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,17 @@ npm run lint
 ```
 
 ### Testing
-Be sure dependencies are installed via `./setup.sh` before running tests.
+Use the helper script to install dependencies and run all tests in one step:
+```bash
+./scripts/test-all.sh
+```
+The script runs `pytest`, frontend Jest tests and ESLint. You can still run them
+individually if needed:
 ```bash
 pytest
 cd frontend
 npm test
+npm run lint
 ```
 
 ### Build
@@ -118,6 +124,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - The notification bell now appears on mobile screens so alerts can be accessed anywhere.
 - On small screens, notifications open in a full-screen modal built with `@headlessui/react`'s `Dialog` for easier reading.
 - Notification rows now have larger padding and text sizes so they're easier to tap on mobile screens.
+- Message threads and grouped notifications now keep their headers visible while scrolling on mobile.
 - Duplicate notifications are now removed when loading additional pages.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -195,6 +195,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
 
   return (
     <div className="border rounded-md p-4 bg-white flex flex-col h-96 space-y-2">
+      <div className="sticky top-0 z-10 bg-white border-b pb-2 mb-2">
+        <span className="text-sm font-medium">
+          {clientName} ↔ {artistName}
+        </span>
+      </div>
       <div className="flex-1 overflow-y-auto space-y-3">
         {loading ? (
           <div className="flex justify-center py-4" aria-label="Loading messages">

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -69,7 +69,7 @@ export default function NotificationDrawer({
                 leaveTo="translate-x-full"
               >
                 <Dialog.Panel className="pointer-events-auto w-screen max-w-sm bg-white shadow-xl flex flex-col">
-                  <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+                  <div className="sticky top-0 z-20 flex items-center justify-between bg-white px-4 py-3 border-b border-gray-200">
                     <Dialog.Title className="text-lg font-medium text-gray-900">Notifications</Dialog.Title>
                     <div className="flex items-center gap-2">
                       <button
@@ -95,7 +95,7 @@ export default function NotificationDrawer({
                     )}
                     {hasThreads && (
                       <div className="py-1" key="threads">
-                        <p className="px-4 pt-2 text-xs font-semibold text-gray-500">Messages</p>
+                        <p className="sticky top-0 z-10 bg-white px-4 pt-2 pb-1 border-b text-xs font-semibold text-gray-500">Messages</p>
                         {threads.map((t) => (
                           <div key={`thread-${t.booking_request_id}`} className="flex w-full items-start px-4 py-3 text-base gap-3">
                             <button
@@ -117,7 +117,7 @@ export default function NotificationDrawer({
                     )}
                     {Object.entries(grouped).map(([type, items]) => (
                       <div key={type} className="py-1">
-                        <p className="px-4 pt-2 text-xs font-semibold text-gray-500">
+                        <p className="sticky top-0 z-10 bg-white px-4 pt-2 pb-1 border-b text-xs font-semibold text-gray-500">
                           {type === 'booking_update' ? 'Bookings' : 'Other'}
                         </p>
                         {items.map((n) => (

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+DIR=$(dirname "$0")/..
+cd "$DIR"
+./setup.sh >/dev/null
+pytest -q
+cd frontend
+npm test
+npm run lint >/dev/null


### PR DESCRIPTION
## Summary
- add sticky header at the top of each message thread
- keep notification group headers visible while scrolling
- expose a `scripts/test-all.sh` helper for running backend and frontend tests
- document new test helper in README

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842b1b14170832e9f28b610d72046c3