### PR TITLE
Refactor notification modal buttons

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -77,32 +77,30 @@ export default function FullScreenNotificationModal({
                   Messages
                 </div>
                 {threads.map((t) => (
-                  <div
+                  <button
                     key={`mobile-thread-${t.booking_request_id}`}
-                    className="flex w-full items-start px-4 py-3 text-base gap-3"
+                    type="button"
+                    onClick={() => markThread(t.booking_request_id)}
+                    className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
                   >
                     {/* Avatar circle */}
-                    <div className="h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                    <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
                       {t.name.split(' ').map((w) => w[0]).join('')}
                     </div>
 
                     {/* Rest of row */}
-                    <button
-                      type="button"
-                      onClick={() => markThread(t.booking_request_id)}
-                      className="flex-1 text-left text-gray-500"
-                    >
+                    <div className="flex-1 text-left text-gray-500">
                       <span className="flex items-start gap-2">
                         <span className="flex-1">{t.name}</span>
                       </span>
-                      <span className="block w-full text-sm text-gray-400 truncate break-words">
+                      <span className="block w-full text-sm text-gray-400 whitespace-pre-wrap break-words">
                         {t.last_message}
                       </span>
                       <span className="block text-sm text-gray-400">
                         {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
                       </span>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 ))}
               </div>
             )}
@@ -112,26 +110,25 @@ export default function FullScreenNotificationModal({
                   {type === 'booking_update' ? 'Bookings' : 'Other'}
                 </div>
                 {items.map((n) => (
-                  <div
-                    key={`mobile-notif-${n.id}`}
-                    className="flex w-full items-start px-4 py-3 text-base gap-3"
-                  >
-                    {/* Avatar circle for each notification */}
-                    <div className="h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                      🔔
-                    </div>
-
+                  <div key={`mobile-notif-${n.id}`} className="flex items-start">
                     <button
                       type="button"
                       onClick={() => markRead(n.id)}
-                      className="flex-1 text-left text-gray-500"
+                      className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
                     >
-                      <span className="flex items-start gap-2">
-                        <span className="flex-1">{n.message}</span>
-                      </span>
-                      <span className="block text-sm text-gray-400">
-                        {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-                      </span>
+                      {/* Avatar circle for each notification */}
+                      <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                        🔔
+                      </div>
+
+                      <div className="flex-1 text-left text-gray-500">
+                        <span className="flex items-start gap-2">
+                          <span className="flex-1">{n.message}</span>
+                        </span>
+                        <span className="block text-sm text-gray-400">
+                          {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
+                        </span>
+                      </div>
                     </button>
                     {!n.is_read ? (
                       <button


### PR DESCRIPTION
## Summary
- wrap notification rows in a single button element
- keep avatars a fixed circle with `flex-shrink-0`
- allow message text to wrap with `whitespace-pre-wrap`
- apply focus styles to row buttons

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6842b9b86eec832e8744940f9455ad82