### PR TITLE
Fix notification modal on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Each notification row is a single button with a fixed avatar circle, making the entire row clickable and accessible.
 - Message threads and grouped notifications now keep their headers visible while scrolling on mobile.
 - Duplicate notifications are now removed when loading additional pages.
+- Mobile detection for the notification bell now uses a responsive hook so the
+  full-screen modal displays reliably on small screens.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { BellIcon } from '@heroicons/react/24/outline';
 import NotificationDrawer from './NotificationDrawer';
 import FullScreenNotificationModal from './FullScreenNotificationModal';
-import isMobileScreen from '@/lib/isMobile';
+import useIsMobile from '@/hooks/useIsMobile';
 import useNotifications from '@/hooks/useNotifications';
 import type { Notification } from '@/types';
 
@@ -25,6 +25,7 @@ export default function NotificationBell() {
   } = useNotifications();
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const handleClick = async (n: Notification) => {
     if (!n.is_read) {
@@ -67,7 +68,7 @@ export default function NotificationBell() {
           </span>
         )}
       </button>
-      {isMobileScreen() ? (
+      {isMobile ? (
         <FullScreenNotificationModal
           open={open}
           onClose={() => setOpen(false)}

--- a/frontend/src/hooks/__tests__/useIsMobile.test.ts
+++ b/frontend/src/hooks/__tests__/useIsMobile.test.ts
@@ -1,0 +1,42 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import useIsMobile from '../useIsMobile';
+import React from 'react';
+
+describe('useIsMobile', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let result = false;
+
+  function Test() {
+    result = useIsMobile();
+    return null;
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('returns true when window width is below 640', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+    act(() => {
+      root.render(React.createElement(Test));
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when window width is 640 or more', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
+    act(() => {
+      root.render(React.createElement(Test));
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import isMobileScreen from '@/lib/isMobile';
+
+export default function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(isMobileScreen());
+
+  useEffect(() => {
+    const check = () => setIsMobile(isMobileScreen());
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary
- add `useIsMobile` hook to detect screen size with resize listener
- switch to the new hook in `NotificationBell`
- document improved mobile detection in the README
- test hook logic with DOM-based unit test

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842bf4ab2e4832ea98fd1e38a25010a