### PR TITLE
Fix overlay blocking mobile notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.
-- Fixed an overlay blocking notification clicks on narrow screens.
+- The dark overlay is hidden on small screens so notification links remain clickable.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -50,7 +50,8 @@ export default function FullScreenNotificationModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-gray-600 bg-opacity-75" />
+          {/* Hide overlay on small screens so it doesn't block clicks */}
+          <div className="fixed inset-0 bg-gray-600 bg-opacity-75 hidden sm:block" />
         </Transition.Child>
 
         <Dialog.Panel className="flex h-full w-full flex-col bg-white">


### PR DESCRIPTION
## Summary
- hide notification modal overlay on small screens
- document overlay fix in README

## Testing
- `./scripts/test-all.sh`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842c455f124832e8d6bb4fcf364664d