### PR TITLE
Fix booking notification header type check

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -108,7 +108,7 @@ export default function FullScreenNotificationModal({
             {Object.entries(grouped).map(([type, items]) => (
               <div key={type} className="mt-4">
                 <div className="sticky top-0 bg-white px-4 py-2 z-10 border-b font-sans text-xs text-gray-600">
-                  {type === 'booking_update' ? 'Bookings' : 'Other'}
+                  {type === 'new_booking_request' ? 'Bookings' : 'Other'}
                 </div>
                 {items.map((n) => (
                   <button

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -131,7 +131,7 @@ export default function NotificationDrawer({
                     {Object.entries(grouped).map(([type, items]) => (
                       <div key={type} className="py-1">
                         <p className="sticky top-0 z-10 bg-white px-4 pt-2 pb-1 border-b text-xs font-semibold text-gray-500">
-                          {type === 'booking_update' ? 'Bookings' : 'Other'}
+                          {type === 'new_booking_request' ? 'Bookings' : 'Other'}
                         </p>
                         {items.map((n) => (
                           <button

--- a/frontend/src/hooks/__tests__/useNotifications.test.ts
+++ b/frontend/src/hooks/__tests__/useNotifications.test.ts
@@ -5,7 +5,7 @@ describe('mergeNotifications', () => {
   const base: Notification = {
     id: 0,
     user_id: 1,
-    type: 'booking_update',
+    type: 'new_booking_request',
     message: '',
     link: '/foo',
     is_read: false,


### PR DESCRIPTION
## Summary
- fix sticky header text for booking notifications
- update test constants

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842c6c5ba88832ea2212b55c5b07fbd