### PR TITLE
Fix notification link crash

### DIFF
--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -32,7 +32,11 @@ export default function NotificationBell() {
       await markRead(n.id);
     }
     setOpen(false);
-    router.push(n.link);
+    if (n.link && typeof n.link === 'string') {
+      router.push(n.link);
+    } else {
+      console.warn('Notification missing link', n);
+    }
   };
 
   const handleThreadClick = async (id: number) => {
@@ -43,7 +47,11 @@ export default function NotificationBell() {
     }
     await markThread(id);
     setOpen(false);
-    router.push(thread.link);
+    if (thread.link) {
+      router.push(thread.link);
+    } else {
+      console.warn('Thread notification missing link', thread);
+    }
   };
 
   const markAllRead = async () => {


### PR DESCRIPTION
## Summary
- avoid crashing when a notification's link is missing

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842c8ecb0b4832eb16a238bc709b5aa