### PR TITLE
Add swipe-to-mark notification read

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.
 - The dark overlay is hidden on small screens so notification links remain clickable.
+- Notification rows now support swipe left to mark them read thanks to `react-swipeable-list`.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-hook-form": "^7.48.2",
         "react-hot-toast": "^2.4.1",
         "react-image-crop": "^11.0.10",
+        "react-swipeable-list": "^1.10.0",
         "yup": "^1.3.2"
       },
       "devDependencies": {
@@ -9421,6 +9422,12 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-swipeable-list": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-swipeable-list/-/react-swipeable-list-1.10.0.tgz",
+      "integrity": "sha512-Ap85a3c5sgvglZBlaansfT6VfwuMad5U4puxFW4sJbUU6alE7epzW39CHvs5AohUZi7wjlP1KFunpXoD+iUyGQ==",
+      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@hookform/resolvers": "^3.3.2",
     "@react-google-maps/api": "^2.19.1",
     "axios": "^1.6.2",
+    "clsx": "^2.1.0",
     "date-fns": "^2.30.0",
     "next": "^14.2.29",
     "react": "^18.2.0",
@@ -24,11 +25,15 @@
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
     "react-image-crop": "^11.0.10",
-    "clsx": "^2.1.0",
+    "react-swipeable-list": "^1.10.0",
     "yup": "^1.3.2"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.23.9",
+    "@babel/preset-react": "^7.23.3",
+    "@babel/preset-typescript": "^7.23.3",
     "@eslint/eslintrc": "^3.3.1",
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.38",
     "@types/react-calendar": "^4.1.0",
@@ -36,18 +41,14 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "autoprefixer": "^10.4.16",
+    "babel-jest": "^29.7.0",
     "eslint": "^8.54.0",
     "eslint-config-next": "14.0.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
-    "typescript": "^5.3.2",
-    "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.0",
-    "babel-jest": "^29.7.0",
-    "@babel/preset-env": "^7.23.9",
-    "@babel/preset-react": "^7.23.3",
-    "@babel/preset-typescript": "^7.23.3",
-    "jest-environment-jsdom": "^29.7.0"
+    "typescript": "^5.3.2"
   }
 }

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -2,6 +2,8 @@
 
 import { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
+import { SwipeableList, SwipeableListItem } from 'react-swipeable-list';
+import 'react-swipeable-list/dist/styles.css';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { formatDistanceToNow } from 'date-fns';
 import type { Notification, ThreadNotification } from '@/types';
@@ -77,32 +79,45 @@ export default function FullScreenNotificationModal({
                 <div className="sticky top-0 bg-white px-4 py-2 z-10 border-b font-sans text-xs text-gray-600">
                   Messages
                 </div>
-                {threads.map((t) => (
-                  <button
-                    key={`mobile-thread-${t.booking_request_id}`}
-                    type="button"
-                    onClick={() => markThread(t.booking_request_id)}
-                    className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50"
-                  >
-                    {/* Avatar circle */}
-                    <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                      {t.name.split(' ').map((w) => w[0]).join('')}
-                    </div>
+                <SwipeableList>
+                  {threads.map((t) => (
+                    <SwipeableListItem
+                      key={`mobile-thread-${t.booking_request_id}`}
+                      swipeLeft={{
+                        content: (
+                          <div className="bg-indigo-600 text-white px-4 flex items-center justify-end h-full">
+                            Mark Read
+                          </div>
+                        ),
+                        action: () => markThread(t.booking_request_id),
+                      }}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => markThread(t.booking_request_id)}
+                        className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50"
+                      >
+                        {/* Avatar circle */}
+                        <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                          {t.name.split(' ').map((w) => w[0]).join('')}
+                        </div>
 
-                    {/* Rest of row */}
-                    <div className="flex-1 text-left">
-                      <span className="block font-medium text-gray-900">
-                        {t.name}
-                      </span>
-                      <span className="block mt-0.5 text-sm text-gray-700 whitespace-pre-wrap break-words">
-                        {t.last_message}
-                      </span>
-                      <span className="block mt-1 text-sm text-gray-400">
-                        {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
-                      </span>
-                    </div>
-                  </button>
-                ))}
+                        {/* Rest of row */}
+                        <div className="flex-1 text-left">
+                          <span className="block font-medium text-gray-900">
+                            {t.name}
+                          </span>
+                          <span className="block mt-0.5 text-sm text-gray-700 whitespace-pre-wrap break-words">
+                            {t.last_message}
+                          </span>
+                          <span className="block mt-1 text-sm text-gray-400">
+                            {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
+                          </span>
+                        </div>
+                      </button>
+                    </SwipeableListItem>
+                  ))}
+                </SwipeableList>
               </div>
             )}
             {Object.entries(grouped).map(([type, items]) => (
@@ -110,27 +125,40 @@ export default function FullScreenNotificationModal({
                 <div className="sticky top-0 bg-white px-4 py-2 z-10 border-b font-sans text-xs text-gray-600">
                   {type === 'new_booking_request' ? 'Bookings' : 'Other'}
                 </div>
-                {items.map((n) => (
-                  <button
-                    key={`mobile-notif-${n.id}`}
-                    type="button"
-                    onClick={() => markRead(n.id)}
-                    className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50"
-                  >
-                    <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                      🔔
-                    </div>
+                <SwipeableList>
+                  {items.map((n) => (
+                    <SwipeableListItem
+                      key={`mobile-notif-${n.id}`}
+                      swipeLeft={{
+                        content: (
+                          <div className="bg-indigo-600 text-white px-4 flex items-center justify-end h-full">
+                            Mark Read
+                          </div>
+                        ),
+                        action: () => markRead(n.id),
+                      }}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => markRead(n.id)}
+                        className="group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50"
+                      >
+                        <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                          🔔
+                        </div>
 
-                    <div className="flex-1 text-left">
-                      <span className="block font-medium text-gray-900 whitespace-pre-wrap break-words">
-                        {n.message}
-                      </span>
-                      <span className="block mt-1 text-sm text-gray-400">
-                        {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-                      </span>
-                    </div>
-                  </button>
-                ))}
+                        <div className="flex-1 text-left">
+                          <span className="block font-medium text-gray-900 whitespace-pre-wrap break-words">
+                            {n.message}
+                          </span>
+                          <span className="block mt-1 text-sm text-gray-400">
+                            {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
+                          </span>
+                        </div>
+                      </button>
+                    </SwipeableListItem>
+                  ))}
+                </SwipeableList>
               </div>
             ))}
             {hasMore && (


### PR DESCRIPTION
## Summary
- enable swipe gestures in mobile notifications
- document new `react-swipeable-list` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy, fakeredis, pydantic)*
- `npm ci` *(fails: ENOTEMPTY rename errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842cd598740832eb8ae5dfa607e0bd0