### PR TITLE
Fix mobile artist fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ The frontend is in `frontend/`. After installing dependencies with `npm install`
 npm run dev
 ```
 
+When testing on another device, run the dev server so it listens on all
+network interfaces:
+
+```bash
+npm run dev -- -H 0.0.0.0
+```
+
 The frontend expects the backend to be running on `http://localhost:8000`.
 If the backend or WebSocket server runs elsewhere, set `NEXT_PUBLIC_API_URL` and
 `NEXT_PUBLIC_WS_URL` in `.env.local` accordingly. When accessing the app from

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,7 +70,9 @@ const normalizeArtistProfile = (
 // ─── ARTISTS ───────────────────────────────────────────────────────────────────
 
 export const getArtists = async () => {
-  const res = await api.get<ArtistProfile[]>(`${API_V1}/artist-profiles`);
+  // FastAPI defines the listing route with a trailing slash. Avoid a redirect
+  // on mobile devices by requesting the exact path.
+  const res = await api.get<ArtistProfile[]>(`${API_V1}/artist-profiles/`);
   return { ...res, data: res.data.map(normalizeArtistProfile) };
 };
 


### PR DESCRIPTION
## Summary
- avoid redirect when fetching artists by requesting `/artist-profiles/`
- document how to expose the dev server on your network

## Testing
- `pytest -q`
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842ec04d904832eb1704439a2ba356c