### PR TITLE
Improve BookingWizard mobile progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Notification rows now have larger padding and text sizes so they're easier to tap on mobile screens.
 - Each notification row is a single button with a fixed avatar circle, making the entire row clickable and accessible.
 - Message threads and grouped notifications now keep their headers visible while scrolling on mobile.
+- The booking wizard now shows a compact progress bar on small screens so steps remain readable.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -224,6 +224,9 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
       <div className="hidden lg:block w-64">
         <SummarySidebar />
       </div>
+      <div className="lg:hidden mt-4">
+        <SummarySidebar />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import useIsMobile from '@/hooks/useIsMobile';
 
 interface StepperProps {
   steps: string[];
@@ -7,6 +8,34 @@ interface StepperProps {
 }
 
 export default function Stepper({ steps, currentStep }: StepperProps) {
+  const isMobile = useIsMobile();
+  const progress = (currentStep / (steps.length - 1)) * 100;
+
+  if (isMobile) {
+    return (
+      <div className="space-y-1">
+        <div className="flex justify-between text-sm">
+          <span>{steps[currentStep]}</span>
+          <span>
+            {currentStep + 1}/{steps.length}
+          </span>
+        </div>
+        <div
+          className="w-full bg-gray-200 rounded h-2"
+          role="progressbar"
+          aria-valuenow={currentStep}
+          aria-valuemin={0}
+          aria-valuemax={steps.length - 1}
+        >
+          <div
+            className="bg-indigo-600 h-2 rounded"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-2">
       <div className="flex items-center" aria-label="Progress">
@@ -33,7 +62,7 @@ export default function Stepper({ steps, currentStep }: StepperProps) {
       >
         <div
           className="bg-indigo-600 h-2 rounded"
-          style={{ width: `${(currentStep / (steps.length - 1)) * 100}%` }}
+          style={{ width: `${progress}%` }}
         />
       </div>
     </div>

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -1,0 +1,36 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import Stepper from '../Stepper';
+
+describe('Stepper responsive layout', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('renders mobile progress when width < 640px', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+    act(() => {
+      root.render(<Stepper steps={["One", "Two"]} currentStep={0} />);
+    });
+    expect(container.textContent).toContain('1/2');
+  });
+
+  it('renders desktop layout when width >= 640px', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
+    act(() => {
+      root.render(<Stepper steps={["One", "Two"]} currentStep={1} />);
+    });
+    expect(container.textContent).toContain('Two');
+  });
+});


### PR DESCRIPTION
## Summary
- show SummarySidebar on small screens
- adjust Stepper component to render compact progress on mobile
- test Stepper responsive layout
- document new progress bar behaviour in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f24b166c832e9bef1bf05b242145