### PR TITLE
Improve mobile booking UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Each notification row is a single button with a fixed avatar circle, making the entire row clickable and accessible.
 - Message threads and grouped notifications now keep their headers visible while scrolling on mobile.
 - The booking wizard now shows a compact progress bar on small screens so steps remain readable.
+- A sticky action bar keeps Back/Next buttons visible on small screens so users can easily navigate each step.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -2,6 +2,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/src/**/*.test.ts'],
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'babel-jest',
+      { presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'] },
+    ],
+  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -5,6 +5,8 @@ import * as yup from 'yup';
 import { format } from 'date-fns';
 import Button from '../ui/Button';
 import Stepper from '../ui/Stepper';
+import useIsMobile from '@/hooks/useIsMobile';
+import MobileActionBar from './MobileActionBar';
 import {
   getArtistAvailability,
   createBookingRequest,
@@ -52,6 +54,7 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
   const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const isMobile = useIsMobile();
 
   const {
     control,
@@ -186,7 +189,7 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
 
   return (
     <div className="lg:flex lg:space-x-4">
-      <div className="flex-1 space-y-4">
+      <div className="flex-1 space-y-4 pb-16 lg:pb-0">
         <Stepper steps={steps} currentStep={step} />
         {renderStep()}
         {warning && <p className="text-orange-600 text-sm">{warning}</p>}
@@ -194,32 +197,34 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
           <p className="text-red-600 text-sm">Please fix the errors above.</p>
         )}
         {error && <p className="text-red-600 text-sm">{error}</p>}
-        <div className="flex justify-between pt-2">
-          {step > 0 && (
-            <Button variant="secondary" type="button" onClick={prev}>
-              Back
-            </Button>
-          )}
-          {step < steps.length - 1 ? (
-            <Button type="button" onClick={next} className="ml-auto">
-              Next
-            </Button>
-          ) : (
-            <div className="flex space-x-2 ml-auto">
-              <Button variant="secondary" type="button" onClick={saveDraft}>
-                Save Draft
+        {!isMobile && (
+          <div className="flex justify-between pt-2">
+            {step > 0 && (
+              <Button variant="secondary" type="button" onClick={prev}>
+                Back
               </Button>
-              <Button
-                type="button"
-                onClick={submitRequest}
-                disabled={submitting}
-                className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
-              >
-                {submitting ? 'Submitting...' : 'Submit Request'}
+            )}
+            {step < steps.length - 1 ? (
+              <Button type="button" onClick={next} className="ml-auto">
+                Next
               </Button>
-            </div>
-          )}
-        </div>
+            ) : (
+              <div className="flex space-x-2 ml-auto">
+                <Button variant="secondary" type="button" onClick={saveDraft}>
+                  Save Draft
+                </Button>
+                <Button
+                  type="button"
+                  onClick={submitRequest}
+                  disabled={submitting}
+                  className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
+                >
+                  {submitting ? 'Submitting...' : 'Submit Request'}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
       <div className="hidden lg:block w-64">
         <SummarySidebar />
@@ -227,6 +232,17 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
       <div className="lg:hidden mt-4">
         <SummarySidebar />
       </div>
+      {isMobile && (
+        <MobileActionBar
+          showBack={step > 0}
+          onBack={prev}
+          showNext={step < steps.length - 1}
+          onNext={next}
+          onSaveDraft={saveDraft}
+          onSubmit={submitRequest}
+          submitting={submitting}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/booking/MobileActionBar.tsx
+++ b/frontend/src/components/booking/MobileActionBar.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Button from '../ui/Button';
+
+interface Props {
+  showBack: boolean;
+  onBack: () => void;
+  showNext: boolean;
+  onNext: () => void;
+  onSaveDraft: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+
+export default function MobileActionBar({
+  showBack,
+  onBack,
+  showNext,
+  onNext,
+  onSaveDraft,
+  onSubmit,
+  submitting,
+}: Props) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2">
+      {showBack ? (
+        <Button variant="secondary" onClick={onBack} fullWidth>
+          Back
+        </Button>
+      ) : (
+        <div className="flex-1" />
+      )}
+      {showNext ? (
+        <Button onClick={onNext} fullWidth>
+          Next
+        </Button>
+      ) : (
+        <div className="flex flex-1 space-x-2">
+          <Button variant="secondary" onClick={onSaveDraft} fullWidth>
+            Save Draft
+          </Button>
+          <Button
+            onClick={onSubmit}
+            disabled={submitting}
+            className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
+            fullWidth
+          >
+            {submitting ? 'Submitting...' : 'Submit'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -1,0 +1,55 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import MobileActionBar from '../MobileActionBar';
+
+describe('MobileActionBar', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('shows Next button when showNext is true', () => {
+    act(() => {
+      root.render(
+        React.createElement(MobileActionBar, {
+          showBack: true,
+          onBack: () => {},
+          showNext: true,
+          onNext: () => {},
+          onSaveDraft: () => {},
+          onSubmit: () => {},
+          submitting: false,
+        }),
+      );
+    });
+    expect(container.textContent).toContain('Next');
+  });
+
+  it('shows submit actions when showNext is false', () => {
+    act(() => {
+      root.render(
+        React.createElement(MobileActionBar, {
+          showBack: false,
+          onBack: () => {},
+          showNext: false,
+          onNext: () => {},
+          onSaveDraft: () => {},
+          onSubmit: () => {},
+          submitting: false,
+        }),
+      );
+    });
+    expect(container.textContent).toContain('Save Draft');
+    expect(container.textContent).toContain('Submit');
+  });
+});

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 'use client';
-import type { ButtonHTMLAttributes } from 'react';
+import React, { type ButtonHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import { buttonVariants, type ButtonVariant } from '@/styles/buttonVariants';
 


### PR DESCRIPTION
## Summary
- show sticky action bar on mobile booking wizard
- refactor booking wizard layout for bottom bar
- add MobileActionBar component with tests
- ensure jest handles TSX via babel-jest
- document sticky action bar in README

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684302be3b00832e8f5ead3de1f6b013