### PR TITLE
Add mobile scroll button

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 
 - The message input bar has been redesigned for mobile: the file upload button now uses a compact icon and the text field shares the outer border so there are no double lines. Attachments stay inside the chatbox without overlapping other elements.
 - The chat box now stretches to roughly 70% of the viewport height on mobile and the Send button uses standard spacing so it's easier to tap.
+- A floating "scroll to latest" button appears on mobile when you scroll up so you can quickly jump back to the newest message.
 
 ### Artist profile polish (2025-06)
 - Added ARIA roles and clearer empty states for better accessibility.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -60,6 +60,8 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [quotePrice, setQuotePrice] = useState('');
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [showScrollButton, setShowScrollButton] = useState(false);
 
   const fetchMessages = async () => {
     try {
@@ -151,6 +153,14 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isSystemTyping]);
 
+  // Show scroll-to-bottom button when not viewing the latest message
+  const handleScroll = () => {
+    if (!containerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    const atBottom = scrollHeight - scrollTop - clientHeight < 20;
+    setShowScrollButton(!atBottom);
+  };
+
   const handleSend = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!newMessage.trim() && !file) return;
@@ -202,7 +212,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           {clientName} ↔ {artistName}
         </span>
       </div>
-      <div className="flex-1 overflow-y-auto space-y-3">
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto space-y-3"
+      >
         {loading ? (
           <div className="flex justify-center py-4" aria-label="Loading messages">
             <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-indigo-600" />
@@ -305,6 +319,31 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
         )}
         <div ref={messagesEndRef} />
       </div>
+      {showScrollButton && (
+        <button
+          type="button"
+          aria-label="Scroll to latest message"
+          onClick={() =>
+            messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+          }
+          className="fixed bottom-20 right-4 z-50 md:hidden rounded-full bg-indigo-600 p-2 text-white shadow"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M19.5 8.25L12 15.75 4.5 8.25"
+            />
+          </svg>
+        </button>
+      )}
       {user && (
         <>
           {previewUrl && (

--- a/frontend/src/components/booking/__tests__/MessageThread.test.ts
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.ts
@@ -1,0 +1,53 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import MessageThread from '../MessageThread';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+
+// Minimal WebSocket stub
+class StubSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((e: any) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close() {}
+}
+// @ts-ignore
+global.WebSocket = StubSocket;
+
+describe('MessageThread scroll button', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getQuotesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' } });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('shows button when scrolled away from bottom', async () => {
+    await act(async () => {
+      root.render(React.createElement(MessageThread, { bookingRequestId: 1 }));
+    });
+    const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+    Object.defineProperty(scrollContainer, 'scrollHeight', { value: 200, configurable: true });
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 100, configurable: true });
+    scrollContainer.scrollTop = 0;
+    act(() => {
+      scrollContainer.dispatchEvent(new Event('scroll'));
+    });
+    const button = container.querySelector('button[aria-label="Scroll to latest message"]');
+    expect(button).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add scroll-to-bottom button in `MessageThread`
- document new mobile convenience in README
- test scroll button visibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: ENOTEMPTY during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68430a3b64a0832eb866db977f88cf9a