### PR TITLE
Improve mobile UX with bottom nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Fixed a crash in the notification dropdown caused by calling hooks before they were initialized.
 - Fixed an infinite notifications fetch loop that caused excessive API requests.
 - Mobile navigation now slides in from the left with a smooth animation.
+- A persistent bottom navigation bar on small screens provides quick access to key pages.
 
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-
+import React from 'react';
 import {
   useEffect,
   useState,

--- a/frontend/src/components/booking/__tests__/MessageThread.test.ts
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.ts
@@ -29,6 +29,9 @@ describe('MessageThread scroll button', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
+    // jsdom lacks scrollIntoView which is used by the component
+    // @ts-ignore
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   afterEach(() => {

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import NotificationBell from './NotificationBell';
 import MobileMenuDrawer from './MobileMenuDrawer';
+import MobileBottomNav from './MobileBottomNav';
 
 const navigation = [
   { name: 'Home', href: '/' },
@@ -166,11 +167,12 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         pathname={pathname}
       />
 
-      <main className="py-10">
+      <main className="py-10 pb-20">
         <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
           {children}
         </div>
       </main>
+      <MobileBottomNav user={user} pathname={pathname} />
     </div>
   );
-} 
+}

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { HomeIcon, UsersIcon, ChatBubbleLeftRightIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import type { User } from '@/types';
+
+interface MobileBottomNavProps {
+  user: User | null;
+  pathname: string;
+}
+
+interface Item {
+  name: string;
+  href: string;
+  icon: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
+  auth?: boolean;
+}
+
+const items: Item[] = [
+  { name: 'Home', href: '/', icon: HomeIcon },
+  { name: 'Artists', href: '/artists', icon: UsersIcon },
+  { name: 'Messages', href: '/inbox', icon: ChatBubbleLeftRightIcon, auth: true },
+  { name: 'Dashboard', href: '/dashboard', icon: UserCircleIcon, auth: true },
+];
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}
+
+export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps) {
+  return (
+    <nav
+      className="fixed bottom-0 inset-x-0 z-40 bg-white border-t shadow sm:hidden"
+      aria-label="Mobile navigation"
+    >
+      <ul className="flex justify-around">
+        {items.map((item) => {
+          if (item.auth && !user) return null;
+          const active = pathname === item.href;
+          return (
+            <li key={item.name}>
+              <Link
+                href={item.href}
+                className={classNames(
+                  'flex flex-col items-center px-3 py-2 text-xs',
+                  active ? 'text-indigo-600' : 'text-gray-500 hover:text-gray-700'
+                )}
+              >
+                <item.icon className="h-6 w-6" aria-hidden="true" />
+                <span>{item.name}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -1,0 +1,39 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import MobileBottomNav from '../MobileBottomNav';
+
+describe('MobileBottomNav', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('renders navigation links', () => {
+    act(() => {
+      root.render(
+        React.createElement(MobileBottomNav, { user: null, pathname: '/' })
+      );
+    });
+    expect(container.textContent).toContain('Home');
+    expect(container.textContent).toContain('Artists');
+  });
+
+  it('hides auth-only links when not logged in', () => {
+    act(() => {
+      root.render(
+        React.createElement(MobileBottomNav, { user: null, pathname: '/' })
+      );
+    });
+    expect(container.textContent).not.toContain('Dashboard');
+  });
+});


### PR DESCRIPTION
## Summary
- add MobileBottomNav component and Jest test
- integrate bottom nav into MainLayout
- stub scrollIntoView in MessageThread test
- document new mobile navigation feature

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68430f44ff74832e8fa583da0b47b348