### PR TITLE
Improve mobile message UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Fixed a crash in the notification dropdown caused by calling hooks before they were initialized.
 - Fixed an infinite notifications fetch loop that caused excessive API requests.
 - Mobile navigation now slides in from the left with a smooth animation.
-- A persistent bottom navigation bar on small screens provides quick access to key pages.
+- A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
 
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import Link from 'next/link';
-import { HomeIcon, UsersIcon, ChatBubbleLeftRightIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import {
+  HomeIcon,
+  UsersIcon,
+  ChatBubbleLeftRightIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/outline';
 import type { User } from '@/types';
+import useNotifications from '@/hooks/useNotifications';
 
 interface MobileBottomNavProps {
   user: User | null;
@@ -28,6 +34,9 @@ function classNames(...classes: string[]) {
 }
 
 export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps) {
+  const { threads } = useNotifications();
+  const unreadMessages = threads.reduce((acc, t) => acc + t.unread_count, 0);
+
   return (
     <nav
       className="fixed bottom-0 inset-x-0 z-40 bg-white border-t shadow sm:hidden"
@@ -37,8 +46,9 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
         {items.map((item) => {
           if (item.auth && !user) return null;
           const active = pathname === item.href;
+          const showBadge = item.name === 'Messages' && unreadMessages > 0;
           return (
-            <li key={item.name}>
+            <li key={item.name} className="relative">
               <Link
                 href={item.href}
                 className={classNames(
@@ -48,6 +58,11 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
               >
                 <item.icon className="h-6 w-6" aria-hidden="true" />
                 <span>{item.name}</span>
+                {showBadge && (
+                  <span className="absolute -top-1 right-0 inline-flex items-center justify-center px-1 py-0.5 text-[10px] font-bold leading-none text-white bg-red-600 rounded-full">
+                    {unreadMessages}
+                  </span>
+                )}
               </Link>
             </li>
           );

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -2,6 +2,12 @@ import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import MobileBottomNav from '../MobileBottomNav';
+import type { User } from '@/types';
+
+jest.mock('../../../hooks/useNotifications', () => ({
+  __esModule: true,
+  default: () => ({ threads: [{ unread_count: 3 }] }),
+}));
 
 describe('MobileBottomNav', () => {
   let container: HTMLDivElement;
@@ -35,5 +41,15 @@ describe('MobileBottomNav', () => {
       );
     });
     expect(container.textContent).not.toContain('Dashboard');
+  });
+
+  it('shows unread message count badge', () => {
+    act(() => {
+      root.render(
+        React.createElement(MobileBottomNav, { user: {} as User, pathname: '/' })
+      );
+    });
+    const badge = container.querySelector('span[class*=bg-red-600]');
+    expect(badge?.textContent).toBe('3');
   });
 });


### PR DESCRIPTION
## Summary
- show message badge on mobile bottom nav using notification hook
- test badge logic in MobileBottomNav
- document unread badge in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843149b35e8832eab2e5f3ef020cfc0