### PR TITLE
Fix messages navigation on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Fixed an infinite notifications fetch loop that caused excessive API requests.
 - Mobile navigation now slides in from the left with a smooth animation.
 - A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
+- A dedicated **Inbox** page lists all message threads and is accessible from the bottom navigation so opening conversations never results in a 404.
 
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.

--- a/frontend/__mocks__/styleMock.js
+++ b/frontend/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
   },
 };

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import useNotifications from '@/hooks/useNotifications';
+
+export default function InboxPage() {
+  const { threads, loading, error, markThread } = useNotifications();
+  const router = useRouter();
+
+  const handleClick = async (id: number, link: string) => {
+    await markThread(id);
+    router.push(link);
+  };
+
+  return (
+    <MainLayout>
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+        <h1 className="text-xl font-semibold">Inbox</h1>
+        {loading && <p>Loading...</p>}
+        {error && <p className="text-red-600">{error}</p>}
+        {!loading && !error && threads.length === 0 && (
+          <p className="text-sm text-gray-500">No messages yet.</p>
+        )}
+        <ul className="divide-y divide-gray-200">
+          {threads.map((t) => (
+            <li key={t.booking_request_id} className="py-3">
+              <button
+                type="button"
+                onClick={() => handleClick(t.booking_request_id, t.link)}
+                className="flex items-start gap-3 w-full text-left focus:outline-none hover:bg-gray-50 p-2 rounded-md"
+              >
+                <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                  {t.name
+                    .split(' ')
+                    .map((w) => w[0])
+                    .join('')}
+                </div>
+                <div className="flex-1">
+                  <span className="block font-medium text-gray-900">
+                    {t.name}
+                    {t.unread_count > 0 && (
+                      <span className="ml-1 text-xs font-semibold text-red-600">
+                        {t.unread_count}
+                      </span>
+                    )}
+                  </span>
+                  <span className="block mt-0.5 text-sm text-gray-700 whitespace-pre-wrap break-words">
+                    {t.last_message}
+                  </span>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -36,6 +36,7 @@ function classNames(...classes: string[]) {
 export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps) {
   const { threads } = useNotifications();
   const unreadMessages = threads.reduce((acc, t) => acc + t.unread_count, 0);
+  const badgeCount = unreadMessages > 99 ? '99+' : unreadMessages;
 
   return (
     <nav
@@ -59,8 +60,8 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
                 <item.icon className="h-6 w-6" aria-hidden="true" />
                 <span>{item.name}</span>
                 {showBadge && (
-                  <span className="absolute -top-1 right-0 inline-flex items-center justify-center px-1 py-0.5 text-[10px] font-bold leading-none text-white bg-red-600 rounded-full">
-                    {unreadMessages}
+                  <span className="absolute -top-2 -right-2 inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
+                    {badgeCount}
                   </span>
                 )}
               </Link>


### PR DESCRIPTION
## Summary
- add `Inbox` page to prevent 404s when tapping messages
- display unread message counts clearly on mobile bottom nav
- document the new inbox page in the README
- support css stubs in jest

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843173d6460832eadf12ffcae76d06e