### PR TITLE
Improve mobile inbox UX and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ The chat thread now displays a friendly placeholder when no messages are present
 - A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
 - A dedicated **Inbox** page lists all message threads and is accessible from the bottom navigation so opening conversations never results in a 404.
 
+### Inbox Page
+
+Open `/inbox` from the Messages icon in the mobile bottom navigation to see all your conversations. Each row shows the latest message snippet and a badge with the number of unread messages. Selecting a thread marks it read and jumps directly to the chat.
+
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
-    '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.module\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "babel-jest": "^29.7.0",
         "eslint": "^8.54.0",
         "eslint-config-next": "14.0.3",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8.4.31",
@@ -6577,6 +6578,13 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6731,6 +6739,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -60,7 +60,9 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
                 <item.icon className="h-6 w-6" aria-hidden="true" />
                 <span>{item.name}</span>
                 {showBadge && (
-                  <span className="absolute -top-2 -right-2 inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
+                  <span
+                    className="absolute top-0 right-0 inline-flex translate-x-1/2 -translate-y-1/2 items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
+                  >
                     {badgeCount}
                   </span>
                 )}


### PR DESCRIPTION
## Summary
- document inbox page in README
- refine message badge placement on mobile bottom navigation
- stub css and scss modules in Jest

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68431ae4ad70832e9798e8a9eb740926