### PR TITLE
Fix mobile unread badge placement

### DIFF
--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -49,7 +49,7 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
           const active = pathname === item.href;
           const showBadge = item.name === 'Messages' && unreadMessages > 0;
           return (
-            <li key={item.name} className="relative">
+            <li key={item.name} className="relative flex-1">
               <Link
                 href={item.href}
                 className={classNames(
@@ -57,15 +57,17 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
                   active ? 'text-indigo-600' : 'text-gray-500 hover:text-gray-700'
                 )}
               >
-                <item.icon className="h-6 w-6" aria-hidden="true" />
+                <div className="relative">
+                  <item.icon className="h-6 w-6" aria-hidden="true" />
+                  {showBadge && (
+                    <span
+                      className="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
+                    >
+                      {badgeCount}
+                    </span>
+                  )}
+                </div>
                 <span>{item.name}</span>
-                {showBadge && (
-                  <span
-                    className="absolute top-0 right-0 inline-flex translate-x-1/2 -translate-y-1/2 items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
-                  >
-                    {badgeCount}
-                  </span>
-                )}
               </Link>
             </li>
           );


### PR DESCRIPTION
## Summary
- correctly anchor unread message badge inside mobile nav

## Testing
- `npm run lint --prefix frontend` *(fails: next not found)*
- `npm test --prefix frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68431da057e0832eb2b4a356c07f98ba