### PR TITLE
Add mobile Next button for date step

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - The booking wizard now shows a compact progress bar on small screens so steps remain readable.
 - A sticky action bar keeps Back/Next buttons visible on small screens so users can easily navigate each step.
 - Steps now automatically scroll to the top when moving between steps on mobile, keeping the next form field in view.
+- An inline Next button now appears after selecting a date on mobile so users can quickly continue to the next step.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -175,7 +175,14 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
   const renderStep = () => {
     switch (step) {
       case 0:
-        return <DateTimeStep control={control} unavailable={unavailable} watch={watch} />;
+        return (
+          <DateTimeStep
+            control={control}
+            unavailable={unavailable}
+            watch={watch}
+            onNext={next}
+          />
+        );
       case 1:
         return (
           <LocationStep

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -20,6 +20,7 @@ describe('BookingWizard mobile scrolling', () => {
   let root: ReturnType<typeof createRoot>;
 
   beforeEach(async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
     (api.getArtistAvailability as jest.Mock).mockResolvedValue({ data: { unavailable_dates: [] } });
     (api.getArtist as jest.Mock).mockResolvedValue({ data: { location: 'NYC' } });
 
@@ -27,7 +28,7 @@ describe('BookingWizard mobile scrolling', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     // jsdom does not implement scrollTo, so provide a stub
-    // @ts-ignore
+    // @ts-expect-error - jsdom does not implement scrollTo
     window.scrollTo = jest.fn();
 
     await act(async () => {
@@ -47,5 +48,10 @@ describe('BookingWizard mobile scrolling', () => {
       nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(window.scrollTo).toHaveBeenCalled();
+  });
+
+  it('renders inline next button on mobile', () => {
+    const inline = container.querySelector('[data-testid="date-next-button"]');
+    expect(inline).not.toBeNull();
   });
 });

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -4,14 +4,18 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
 interface Props {
   control: Control<FieldValues>;
   unavailable: string[];
   watch: UseFormWatch<FieldValues>;
+  onNext: () => void;
 }
 
-export default function DateTimeStep({ control, unavailable, watch }: Props) {
+export default function DateTimeStep({ control, unavailable, watch, onNext }: Props) {
+  const isMobile = useIsMobile();
   const tileDisabled = ({ date }: { date: Date }) => {
     const day = format(date, 'yyyy-MM-dd');
     return unavailable.includes(day) || date < new Date();
@@ -41,6 +45,13 @@ export default function DateTimeStep({ control, unavailable, watch }: Props) {
             <input type="time" className="border p-2 rounded w-full" {...field} />
           )}
         />
+      )}
+      {isMobile && (
+        <div>
+          <Button data-testid="date-next-button" onClick={onNext} fullWidth>
+            Next
+          </Button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show inline Next button when selecting a date on small screens
- wire booking wizard to call onNext from DateTimeStep
- test the new mobile button
- document the mobile date button

## Testing
- `npm test --prefix frontend`
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684323bd5020832e938e193c3e5c7649