### PR TITLE
Add mobile confirm button for location step

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - A sticky action bar keeps Back/Next buttons visible on small screens so users can easily navigate each step.
 - Steps now automatically scroll to the top when moving between steps on mobile, keeping the next form field in view.
 - An inline Next button now appears after selecting a date on mobile so users can quickly continue to the next step.
+- The location step now shows a mobile-only Confirm Location button so stage two is easy to advance.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -189,6 +189,7 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
             control={control}
             artistLocation={artistLocation || undefined}
             setWarning={setWarning}
+            onNext={next}
           />
         );
       case 2:

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -54,4 +54,13 @@ describe('BookingWizard mobile scrolling', () => {
     const inline = container.querySelector('[data-testid="date-next-button"]');
     expect(inline).not.toBeNull();
   });
+
+  it('shows confirm location button after advancing', async () => {
+    const inline = container.querySelector('[data-testid="date-next-button"]') as HTMLButtonElement;
+    await act(async () => {
+      inline.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const confirm = container.querySelector('[data-testid="location-next-button"]');
+    expect(confirm).not.toBeNull();
+  });
 });

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -3,22 +3,31 @@ import { Controller, Control, FieldValues } from 'react-hook-form';
 import { GoogleMap, Marker, useLoadScript, Autocomplete } from '@react-google-maps/api';
 import { useRef, useState, useEffect } from 'react';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
 interface Props {
   control: Control<FieldValues>;
   artistLocation?: string | null;
   setWarning: (w: string | null) => void;
+  onNext: () => void;
 }
 
 const containerStyle = { width: '100%', height: '250px' };
 
-export default function LocationStep({ control, artistLocation, setWarning }: Props) {
+export default function LocationStep({
+  control,
+  artistLocation,
+  setWarning,
+  onNext,
+}: Props) {
   const { isLoaded } = useLoadScript({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
     libraries: ['places'],
   });
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
   const [marker, setMarker] = useState<LatLng | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     (async () => {
@@ -78,6 +87,11 @@ export default function LocationStep({ control, artistLocation, setWarning }: Pr
       >
         Use my location
       </button>
+      {isMobile && (
+        <Button data-testid="location-next-button" onClick={onNext} fullWidth>
+          Confirm Location
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show Confirm Location button during location step on mobile
- wire new callback through BookingWizard
- test that LocationStep button renders on mobile
- document the new behavior in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --prefix frontend` *(fails: ENOTEMPTY rename node_modules)*
- `npm run lint --prefix frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684326b63354832ea9dfb27e078bb581