### PR TITLE
Add mobile buttons for booking wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Steps now automatically scroll to the top when moving between steps on mobile, keeping the next form field in view.
 - An inline Next button now appears after selecting a date on mobile so users can quickly continue to the next step.
 - The location step now shows a mobile-only Confirm Location button so stage two is easy to advance.
+- Guests, venue, notes and review steps now also include inline buttons on mobile so progress is consistent through step six.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -193,13 +193,19 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
           />
         );
       case 2:
-        return <GuestsStep control={control} />;
+        return <GuestsStep control={control} onNext={next} />;
       case 3:
-        return <VenueStep control={control} />;
+        return <VenueStep control={control} onNext={next} />;
       case 4:
-        return <NotesStep control={control} />;
+        return <NotesStep control={control} onNext={next} />;
       default:
-        return <ReviewStep />;
+        return (
+          <ReviewStep
+            onSaveDraft={saveDraft}
+            onSubmit={submitRequest}
+            submitting={submitting}
+          />
+        );
     }
   };
 

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -63,4 +63,23 @@ describe('BookingWizard mobile scrolling', () => {
     const confirm = container.querySelector('[data-testid="location-next-button"]');
     expect(confirm).not.toBeNull();
   });
+
+  it('shows inline buttons for all remaining steps', async () => {
+    const click = async (testId: string) => {
+      const btn = container.querySelector(`[data-testid="${testId}"]`) as HTMLButtonElement;
+      await act(async () => {
+        btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    };
+
+    await click('date-next-button');
+    await click('location-next-button');
+    expect(container.querySelector('[data-testid="guests-next-button"]')).not.toBeNull();
+    await click('guests-next-button');
+    expect(container.querySelector('[data-testid="venue-next-button"]')).not.toBeNull();
+    await click('venue-next-button');
+    expect(container.querySelector('[data-testid="notes-next-button"]')).not.toBeNull();
+    await click('notes-next-button');
+    expect(container.querySelector('[data-testid="review-submit-button"]')).not.toBeNull();
+  });
 });

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -1,13 +1,17 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
 interface Props {
   control: Control<FieldValues>;
+  onNext: () => void;
 }
 
-export default function GuestsStep({ control }: Props) {
+export default function GuestsStep({ control, onNext }: Props) {
+  const isMobile = useIsMobile();
   return (
-    <div>
+    <div className="space-y-2">
       <label className="block text-sm font-medium">Number of guests</label>
       <Controller
         name="guests"
@@ -21,6 +25,11 @@ export default function GuestsStep({ control }: Props) {
           />
         )}
       />
+      {isMobile && (
+        <Button data-testid="guests-next-button" onClick={onNext} fullWidth>
+          Next
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -1,13 +1,17 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
 interface Props {
   control: Control<FieldValues>;
+  onNext: () => void;
 }
 
-export default function NotesStep({ control }: Props) {
+export default function NotesStep({ control, onNext }: Props) {
+  const isMobile = useIsMobile();
   return (
-    <div>
+    <div className="space-y-2">
       <label className="block text-sm font-medium">Extra notes</label>
       <Controller
         name="notes"
@@ -16,6 +20,11 @@ export default function NotesStep({ control }: Props) {
           <textarea rows={3} className="border p-2 rounded w-full" {...field} />
         )}
       />
+      {isMobile && (
+        <Button data-testid="notes-next-button" onClick={onNext} fullWidth>
+          Next
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -1,9 +1,22 @@
 'use client';
 import { useBooking } from '@/contexts/BookingContext';
 import { format } from 'date-fns';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
-export default function ReviewStep() {
+interface Props {
+  onSaveDraft: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+
+export default function ReviewStep({
+  onSaveDraft,
+  onSubmit,
+  submitting,
+}: Props) {
   const { details } = useBooking();
+  const isMobile = useIsMobile();
   return (
     <div className="space-y-2">
       <h3 className="text-lg font-medium">Review Details</h3>
@@ -38,6 +51,27 @@ export default function ReviewStep() {
       <p className="text-gray-600 text-sm">
         Please confirm the information above before sending your request.
       </p>
+      {isMobile && (
+        <div className="flex space-x-2">
+          <Button
+            data-testid="review-save-button"
+            variant="secondary"
+            onClick={onSaveDraft}
+            fullWidth
+          >
+            Save Draft
+          </Button>
+          <Button
+            data-testid="review-submit-button"
+            onClick={onSubmit}
+            fullWidth
+            disabled={submitting}
+            className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
+          >
+            {submitting ? 'Submitting...' : 'Submit'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -1,13 +1,17 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '../../ui/Button';
 
 interface Props {
   control: Control<FieldValues>;
+  onNext: () => void;
 }
 
-export default function VenueStep({ control }: Props) {
+export default function VenueStep({ control, onNext }: Props) {
+  const isMobile = useIsMobile();
   return (
-    <div>
+    <div className="space-y-2">
       <label className="block text-sm font-medium">Venue type</label>
       <Controller
         name="venueType"
@@ -20,6 +24,11 @@ export default function VenueStep({ control }: Props) {
           </select>
         )}
       />
+      {isMobile && (
+        <Button data-testid="venue-next-button" onClick={onNext} fullWidth>
+          Next
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show inline buttons for all booking steps on mobile
- expose submit actions in mobile review step
- update README mobile notes
- test extra buttons

## Testing
- `npm test --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432c0ff2f0832ebf7ad7718d7e079e