### PR TITLE
Improve booking wizard UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - An inline Next button now appears after selecting a date on mobile so users can quickly continue to the next step.
 - The location step now shows a mobile-only Confirm Location button so stage two is easy to advance.
 - Guests, venue, notes and review steps now also include inline buttons on mobile so progress is consistent through step six.
+- Each step now displays a clear heading and automatically focuses the first field for faster entry.
 - Duplicate notifications are now removed when loading additional pages.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -213,6 +213,9 @@ export default function BookingWizard({ artistId }: { artistId: number }) {
     <div className="lg:flex lg:space-x-4">
       <div className="flex-1 space-y-4 pb-16 lg:pb-0">
         <Stepper steps={steps} currentStep={step} />
+        <h2 className="text-xl font-semibold" data-testid="step-heading">
+          {steps[step]}
+        </h2>
         {renderStep()}
         {warning && <p className="text-orange-600 text-sm">{warning}</p>}
         {Object.values(errors).length > 0 && (

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -55,6 +55,17 @@ describe('BookingWizard mobile scrolling', () => {
     expect(inline).not.toBeNull();
   });
 
+  it('shows step heading and updates on next', async () => {
+    const heading = () =>
+      container.querySelector('[data-testid="step-heading"]')?.textContent;
+    expect(heading()).toContain('Date & Time');
+    const next = container.querySelector('[data-testid="date-next-button"]') as HTMLButtonElement;
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(heading()).toContain('Location');
+  });
+
   it('shows confirm location button after advancing', async () => {
     const inline = container.querySelector('[data-testid="date-next-button"]') as HTMLButtonElement;
     await act(async () => {

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -22,6 +22,7 @@ export default function GuestsStep({ control, onNext }: Props) {
             min={1}
             className="border p-2 rounded w-full"
             {...field}
+            autoFocus
           />
         )}
       />

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -66,6 +66,7 @@ export default function LocationStep({
               {...field}
               className="border p-2 rounded w-full"
               placeholder="Search address"
+              autoFocus
             />
           )}
         />

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -17,7 +17,12 @@ export default function NotesStep({ control, onNext }: Props) {
         name="notes"
         control={control}
         render={({ field }) => (
-          <textarea rows={3} className="border p-2 rounded w-full" {...field} />
+          <textarea
+            rows={3}
+            className="border p-2 rounded w-full"
+            {...field}
+            autoFocus
+          />
         )}
       />
       {isMobile && (

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -17,7 +17,7 @@ export default function VenueStep({ control, onNext }: Props) {
         name="venueType"
         control={control}
         render={({ field }) => (
-          <select className="border p-2 rounded w-full" {...field}>
+          <select className="border p-2 rounded w-full" {...field} autoFocus>
             <option value="indoor">Indoor</option>
             <option value="outdoor">Outdoor</option>
             <option value="hybrid">Hybrid</option>


### PR DESCRIPTION
## Summary
- show step heading on booking wizard
- autofocus first input on each step
- test heading updates
- document new wizard enhancements

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68432ddfd194832e9448b37f0366c5b8