### PR TITLE
Improve notification load more logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Guests, venue, notes and review steps now also include inline buttons on mobile so progress is consistent through step six.
 - Each step now displays a clear heading and automatically focuses the first field for faster entry.
 - Duplicate notifications are now removed when loading additional pages.
+- The Load More button now disappears once all notifications have been fetched.
 - Mobile detection for the notification bell now uses a responsive hook so the
   full-screen modal displays reliably on small screens.
 - The dark overlay is hidden on small screens so notification links remain clickable.

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -31,15 +31,19 @@ export default function useNotifications() {
   const limit = 20;
 
   const [threads, setThreads] = useState<ThreadNotification[]>([]);
+  const [hasMore, setHasMore] = useState(true);
 
   const loadMore = useCallback(async () => {
-    if (!user) return;
+    if (!user || !hasMore) return;
     setLoading(true);
     try {
       const res = await getNotifications(pageRef.current * limit, limit);
       const filtered = res.data.filter((n) => n.type !== 'new_message');
       setNotifications((prev) => mergeNotifications(prev, filtered));
       pageRef.current += 1;
+      if (res.data.length < limit) {
+        setHasMore(false);
+      }
     } catch (err) {
       console.error('Failed to fetch notifications:', err);
       setError('Failed to load notifications.');
@@ -122,6 +126,6 @@ export default function useNotifications() {
     markThread,
     markAll,
     loadMore,
-    hasMore: notifications.length % limit === 0,
+    hasMore,
   };
 }


### PR DESCRIPTION
## Summary
- hide Load More once all notifications are loaded
- track `hasMore` in `useNotifications` hook
- document behaviour change in README

## Testing
- `pytest -q`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843349e3074832e8560a218d58a49a4