### PR TITLE
Improve mobile notifications UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The chat thread now displays a friendly placeholder when no messages are present
   full-screen modal displays reliably on small screens.
 - The dark overlay is hidden on small screens so notification links remain clickable.
 - Notification rows now support swipe left to mark them read thanks to `react-swipeable-list`.
+- The mobile notification modal now shows cards with a "Mark All as Read" button for quicker cleanup.
 - Artist profile sections now load independently for faster page rendering and show loading states per section.
 - Cover and profile images use Next.js `<Image>` for responsive sizing and better performance.
 - Service cards refresh their data when expanded so pricing stays accurate.

--- a/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
+++ b/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
@@ -1,0 +1,46 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import FullScreenNotificationModal from '../FullScreenNotificationModal';
+
+const baseProps = {
+  open: true,
+  onClose: () => {},
+  notifications: [],
+  threads: [],
+  markRead: jest.fn(),
+  markThread: jest.fn(),
+  markAllRead: jest.fn(),
+  loadMore: jest.fn(),
+  hasMore: false,
+};
+
+describe('FullScreenNotificationModal', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('shows empty state message', () => {
+    act(() => {
+      root.render(React.createElement(FullScreenNotificationModal, baseProps));
+    });
+    expect(container.textContent).toContain("You're all caught up!");
+  });
+
+  it('renders mark all button', () => {
+    act(() => {
+      root.render(React.createElement(FullScreenNotificationModal, baseProps));
+    });
+    expect(container.textContent).toContain('Mark All as Read');
+  });
+});


### PR DESCRIPTION
## Summary
- redesign mobile notification modal to use card layout
- allow navigating to booking when tapping notification cards
- show a friendly empty state message
- add test for `FullScreenNotificationModal`
- document mobile card UI in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684339888754832eb23ecee3cb3f4be8