### PR TITLE
Add status badges to booking cards

### DIFF
--- a/frontend/src/components/booking/__tests__/MessageThread.test.ts
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.ts
@@ -11,11 +11,11 @@ jest.mock('@/contexts/AuthContext');
 // Minimal WebSocket stub
 class StubSocket {
   onopen: (() => void) | null = null;
-  onmessage: ((e: any) => void) | null = null;
+  onmessage: ((e: unknown) => void) | null = null;
   onerror: (() => void) | null = null;
   close() {}
 }
-// @ts-ignore
+// @ts-expect-error jsdom does not implement WebSocket
 global.WebSocket = StubSocket;
 
 describe('MessageThread scroll button', () => {
@@ -30,7 +30,7 @@ describe('MessageThread scroll button', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     // jsdom lacks scrollIntoView which is used by the component
-    // @ts-ignore
+    // @ts-expect-error jsdom lacks scrollIntoView
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 


### PR DESCRIPTION
## Summary
- show booking status badge in FullScreenNotificationModal cards
- expose status parsing helper
- fix MessageThread test lint warnings

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434348d0c4832e85c3b7ab52331dba