### PR TITLE
Add message thread navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 
 ### Inbox Page
 
-Open `/inbox` from the Messages icon in the mobile bottom navigation to see all your conversations. Each row shows the latest message snippet and a badge with the number of unread messages. Selecting a thread marks it read and jumps directly to the chat. The inbox now separates **Booking Requests** and **Chats** into tabs for quicker access.
+Open `/inbox` from the Messages icon in the mobile bottom navigation to see all your conversations. Each row shows the latest message snippet and a badge with the number of unread messages. Selecting a thread marks it read and opens the conversation at `/messages/thread/{id}`. The inbox now separates **Booking Requests** and **Chats** into tabs for quicker access.
 
 The registration page now includes a password strength meter and shows a toast notification once an account is created successfully.
 Both auth pages use new shared form components and include optional Google and GitHub sign-in buttons.

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -87,7 +87,7 @@ export default function InboxPage() {
 
   const handleClick = async (id: number) => {
     await markThread(id);
-    router.push(`/bookings/${id}`);
+    router.push(`/messages/thread/${id}`);
   };
 
   const renderBookings = () => (
@@ -97,7 +97,7 @@ export default function InboxPage() {
           <button
             type="button"
             onClick={() => handleClick(b.id)}
-            className="w-full text-left cursor-pointer active:bg-gray-100"
+            className="w-full text-left cursor-pointer active:bg-gray-100 rounded"
           >
             <div className="bg-white shadow rounded-lg p-4 space-y-2">
               <div className="flex justify-between items-center">

--- a/frontend/src/app/messages/thread/[threadId]/page.tsx
+++ b/frontend/src/app/messages/thread/[threadId]/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import MessageThread from '@/components/booking/MessageThread';
+import { getBookingRequestById } from '@/lib/api';
+import { BookingRequest } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function ThreadPage() {
+  const params = useParams();
+  const id = Number(params.threadId);
+  const { user } = useAuth();
+  const [request, setRequest] = useState<BookingRequest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchRequest = async () => {
+      try {
+        const res = await getBookingRequestById(id);
+        setRequest(res.data);
+      } catch (err) {
+        console.error('Failed to load booking request', err);
+        setError('Failed to load conversation');
+      }
+    };
+    fetchRequest();
+  }, [id]);
+
+  if (!user) {
+    return (
+      <MainLayout>
+        <div className="p-8">Please log in to view this conversation.</div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error}</div>
+      </MainLayout>
+    );
+  }
+
+  if (!request) {
+    return (
+      <MainLayout>
+        <div className="flex justify-center items-center min-h-[60vh]">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  const isParticipant =
+    user.id === request.client_id || user.id === request.artist_id;
+  if (!isParticipant) {
+    return (
+      <MainLayout>
+        <div className="p-8">You are not authorized to view this conversation.</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-3xl mx-auto p-4">
+        <MessageThread
+          bookingRequestId={request.id}
+          clientName={request.client?.first_name}
+          artistName={request.artist?.first_name}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -58,6 +58,11 @@ export default function FullScreenNotificationModal({
     if (link) router.push(link);
   };
 
+  const handleThreadClick = async (id: number) => {
+    await markThread(id);
+    router.push(`/messages/thread/${id}`);
+  };
+
   return (
     <Transition.Root show={open} as={Fragment}>
       <Dialog as="div" className="fixed inset-0 z-50" onClose={onClose}>
@@ -103,9 +108,9 @@ export default function FullScreenNotificationModal({
                         key={`thread-${t.booking_request_id}`}
                         role="button"
                         tabIndex={0}
-                        onClick={() => navigateToBooking(t.link, t.booking_request_id, markThread)}
-                        onKeyPress={() => navigateToBooking(t.link, t.booking_request_id, markThread)}
-                        className="relative bg-white shadow rounded-lg p-4 flex flex-col space-y-2 transition hover:bg-gray-50"
+                        onClick={() => handleThreadClick(t.booking_request_id)}
+                        onKeyPress={() => handleThreadClick(t.booking_request_id)}
+                        className="relative bg-white shadow rounded-lg p-4 flex flex-col space-y-2 transition hover:bg-gray-50 cursor-pointer active:bg-gray-100 rounded"
                       >
                         {status && (
                           <span className="absolute top-2 right-2 rounded-full bg-yellow-100 text-yellow-700 text-xs px-2 py-0.5">

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -58,11 +58,7 @@ export default function NotificationBell() {
     }
     await markThread(id);
     setOpen(false);
-    if (thread.link) {
-      router.push(thread.link);
-    } else {
-      console.warn('Thread notification missing link', thread);
-    }
+    router.push(`/messages/thread/${id}`);
   };
 
   const markAllRead = async () => {

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Fragment } from 'react';
+import { useRouter } from 'next/navigation';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { formatDistanceToNow } from 'date-fns';
@@ -33,6 +34,7 @@ export default function NotificationDrawer({
   loadMore,
   hasMore,
 }: NotificationDrawerProps) {
+  const router = useRouter();
   const hasThreads = threads.length > 0;
   const grouped = notifications.reduce<Record<string, Notification[]>>((acc, n) => {
     const key = n.type || 'other';
@@ -40,6 +42,11 @@ export default function NotificationDrawer({
     acc[key].push(n);
     return acc;
   }, {});
+
+  const handleThreadClick = async (id: number) => {
+    await markThread(id);
+    router.push(`/messages/thread/${id}`);
+  };
 
   return (
     <Transition.Root show={open} as={Fragment}>
@@ -100,9 +107,9 @@ export default function NotificationDrawer({
                           <button
                             key={`thread-${t.booking_request_id}`}
                             type="button"
-                            onClick={() => markThread(t.booking_request_id)}
+                            onClick={() => handleThreadClick(t.booking_request_id)}
                             className={classNames(
-                              'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50',
+                              'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 cursor-pointer active:bg-gray-100 rounded',
                               t.unread_count > 0 ? 'font-medium' : 'text-gray-500',
                             )}
                           >


### PR DESCRIPTION
## Summary
- allow navigating to threads in inbox, notifications and modals
- open thread pages under `/messages/thread/[threadId]`
- link all message notifications to new route
- document updated inbox behavior

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_684347253500832eb14deffeffb4f348