### PR TITLE
Apply chat scroll container

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -216,7 +216,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto space-y-3"
+        className="flex-1 overflow-y-auto space-y-3 px-4 py-2 h-[calc(100vh-60px)]"
       >
         {loading ? (
           <div className="flex justify-center py-4" aria-label="Loading messages">


### PR DESCRIPTION
## Summary
- make the messages list scrollable with padding
- keep it under the mobile bottom nav

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843472caeec832e9247cdbca9f3ab9f