### PR TITLE
Highlight unread messages in inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Mobile navigation now slides in from the left with a smooth animation.
 - A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
 - A dedicated **Inbox** page lists all message threads and is accessible from the bottom navigation so opening conversations never results in a 404.
+- Unread messages within a thread now highlight the sender's name in **bold** and tint the background purple so new chat activity is easier to spot.
 
 ### Inbox Page
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -266,9 +266,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           return (
             <div
               key={msg.id}
-              className={`flex flex-col ${isSelf ? 'items-end' : 'items-start'} gap-1`}
+              className={`flex flex-col ${isSelf ? 'items-end' : 'items-start'} gap-1 ${msg.unread ? 'bg-purple-50' : ''}`}
             >
-              <span className="text-sm font-medium">{senderDisplayName}</span>
+              <span className={`text-sm ${msg.unread ? 'font-semibold' : 'font-medium'}`}>{senderDisplayName}</span>
               <div className={`flex items-end gap-2 ${isSelf ? 'justify-end' : 'justify-start'}`}>
                 {!isSelf && (
                   <div className="h-6 w-6 bg-gray-300 rounded-full flex items-center justify-center text-xs font-medium">

--- a/frontend/src/components/booking/__tests__/MessageThread.test.ts
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.ts
@@ -53,4 +53,28 @@ describe('MessageThread scroll button', () => {
     const button = container.querySelector('button[aria-label="Scroll to latest message"]');
     expect(button).not.toBeNull();
   });
+
+  it('highlights unread messages', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Hello',
+          message_type: 'text',
+          timestamp: new Date().toISOString(),
+          unread: true,
+        },
+      ],
+    });
+    await act(async () => {
+      root.render(React.createElement(MessageThread, { bookingRequestId: 1 }));
+    });
+    const row = container.querySelector('.bg-purple-50');
+    const name = container.querySelector('span.font-semibold');
+    expect(row).not.toBeNull();
+    expect(name?.textContent).toBe('Artist');
+  });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -133,6 +133,8 @@ export interface Message {
   message_type: "text" | "quote" | "system";
   quote_id?: number | null;
   attachment_url?: string | null;
+  /** Whether the message has been read by the current user */
+  unread?: boolean;
   timestamp: string;
 }
 


### PR DESCRIPTION
## Summary
- make sender bold and row tinted when message.unread is true
- adjust Message type for optional `unread`
- update MessageThread tests for unread styling
- document unread styling in README

## Testing
- `./scripts/test-all.sh`
- `cd frontend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68434733a6dc832e9c0c25891da3746d