### PR TITLE
Make dashboard stats clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Fixed an infinite notifications fetch loop that caused excessive API requests.
 - Mobile navigation now slides in from the left with a smooth animation.
 - A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
+- Dashboard stat cards are now tappable and link directly to their respective pages.
 - A dedicated **Inbox** page lists all message threads and is accessible from the bottom navigation so opening conversations never results in a 404.
 - Unread messages within a thread now highlight the sender's name in **bold** and tint the background purple so new chat activity is easier to spot.
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -214,25 +214,34 @@ export default function DashboardPage() {
           {/* Stats */}
           <div className="mt-8">
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+              <Link
+                href="/bookings"
+                className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition"
+              >
                 <dt className="truncate text-sm font-medium text-gray-500">
                   Total Bookings
                 </dt>
                 <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
                   {bookings.length}
                 </dd>
-              </div>
+              </Link>
               {user.user_type === "artist" && (
                 <>
-                  <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+                  <Link
+                    href="/services"
+                    className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition"
+                  >
                     <dt className="truncate text-sm font-medium text-gray-500">
                       Total Services
                     </dt>
                     <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
                       {services.length}
                     </dd>
-                  </div>
-                  <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+                  </Link>
+                  <Link
+                    href="/earnings"
+                    className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition"
+                  >
                     <dt className="truncate text-sm font-medium text-gray-500">
                       Total Earnings
                     </dt>
@@ -243,7 +252,7 @@ export default function DashboardPage() {
                         .reduce((acc, booking) => acc + booking.total_price, 0)
                         .toFixed(2)}
                     </dd>
-                  </div>
+                  </Link>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- make dashboard stat cards clickable with Next.js links
- document that dashboard stats link to their pages

## Testing
- `./scripts/test-all.sh` *(fails: npm ERR! network aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68434beb012c832e9d26a0dbfafa5afb