### PR TITLE
Fix mobile nav placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The chat thread now displays a friendly placeholder when no messages are present
 - Fixed a crash in the notification dropdown caused by calling hooks before they were initialized.
 - Fixed an infinite notifications fetch loop that caused excessive API requests.
 - Mobile navigation now slides in from the left with a smooth animation.
-- A persistent bottom navigation bar on small screens provides quick access to key pages. Unread message counts now appear over the Messages icon so conversations are never missed.
+ - A persistent bottom navigation bar on small screens now sticks to the bottom of the screen with extra padding so content isn't hidden. Unread message counts appear over the Messages icon so conversations are never missed.
 - Dashboard stat cards are now tappable and link directly to their respective pages.
 - A dedicated **Inbox** page lists all message threads and is accessible from the bottom navigation so opening conversations never results in a 404.
 - Unread messages within a thread now highlight the sender's name in **bold** and tint the background purple so new chat activity is easier to spot.

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -167,7 +167,8 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         pathname={pathname}
       />
 
-      <main className="py-10 pb-20">
+      {/* bottom padding prevents content from being hidden behind the fixed bottom nav */}
+      <main className="py-10 pb-24">
         <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
           {children}
         </div>

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -40,7 +40,7 @@ export default function MobileBottomNav({ user, pathname }: MobileBottomNavProps
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 z-40 bg-white border-t shadow sm:hidden"
+      className="fixed bottom-0 w-full bg-white border-t shadow z-50 sm:hidden"
       aria-label="Mobile navigation"
     >
       <ul className="flex justify-around">


### PR DESCRIPTION
## Summary
- keep mobile nav fixed to bottom
- add extra bottom padding in layout
- document sticky nav behavior in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843db589bdc832eac21d0fae88e4f1c