### PR TITLE
Add sticky input demo component

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm run build
 * Fixed input bar & auto-scroll on mobile.
 * Floating “scroll to latest” button on small screens.
 * Personalized Video flow: multi-step prompts, typing indicators, progress bar.
+* Sticky input demo at `/demo/sticky-input` shows local message appending.
 
 ### Notifications
 

--- a/frontend/src/app/demo/sticky-input/page.tsx
+++ b/frontend/src/app/demo/sticky-input/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import StickyInputDemo from '@/components/chat/StickyInputDemo';
+import MainLayout from '@/components/layout/MainLayout';
+
+export default function StickyInputPage() {
+  return (
+    <MainLayout>
+      <StickyInputDemo />
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/chat/StickyInputDemo.tsx
+++ b/frontend/src/components/chat/StickyInputDemo.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export default function StickyInputDemo() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [text, setText] = useState('');
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    setMessages((prev) => [...prev, text.trim()]);
+    setText('');
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <div className="flex-1 overflow-y-auto space-y-2 p-4">
+        {messages.map((m, idx) => (
+          <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={idx}
+            className="rounded-md bg-gray-100 p-2 text-sm"
+          >
+            {m}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 left-0 right-0 flex items-center gap-2 border-t bg-white p-2"
+      >
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="flex-grow rounded-full border px-3 py-2 text-sm"
+          placeholder="Type a message"
+        />
+        <button
+          type="submit"
+          className="bg-purple-600 text-white rounded px-4 py-2 text-sm"
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
+++ b/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
@@ -1,0 +1,48 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import StickyInputDemo from '../StickyInputDemo';
+
+
+describe('StickyInputDemo', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // @ts-expect-error jsdom lacks scrollIntoView
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('appends new message and clears input', () => {
+    act(() => {
+      root.render(<StickyInputDemo />);
+    });
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    const button = container.querySelector('button') as HTMLButtonElement;
+
+    act(() => {
+      input.value = 'Hello';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const messages = container.querySelectorAll('.bg-gray-100');
+    expect(messages.length).toBe(1);
+    expect(messages[0].textContent).toBe('Hello');
+    expect(input.value).toBe('');
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -35,8 +35,8 @@ function classNames(...classes: (string | false | undefined)[]) {
 
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   const router = useRouter();
-  // Next.js App Router doesn’t expose pathname, so cast router to any
-  const pathname = (router as any).pathname as string | undefined;
+  // Next.js App Router doesn’t expose pathname in its types
+  const pathname = (router as unknown as { pathname?: string }).pathname;
 
   const { threads } = useNotifications();
   const unreadMessages = threads.reduce((sum, t) => sum + t.unread_count, 0);


### PR DESCRIPTION
## Summary
- create a simple sticky chat input component with local state
- expose demo page under `/demo/sticky-input`
- fix MobileBottomNav lint error
- document new demo in README
- test StickyInputDemo component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843df9a5c10832eb53dac1a93edecd7