### PR TITLE
Add Recent Activity placeholder to dashboard

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { format } from "date-fns";
 import { normalizeService } from "@/lib/utils";
 import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
+import RecentActivity from "@/components/dashboard/RecentActivity";
 import Link from "next/link";
 
 export default function DashboardPage() {
@@ -34,6 +35,8 @@ export default function DashboardPage() {
   const [error, setError] = useState("");
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
+  // Future activity feed will populate this array with events
+  const [events] = useState<any[]>([]);
 
   useEffect(() => {
     if (!user) {
@@ -282,6 +285,9 @@ export default function DashboardPage() {
               Add Service
             </button>
           )}
+
+          {/* Recent Activity */}
+          <RecentActivity events={events} />
 
           {/* Booking Requests */}
           <div className="mt-8">

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,23 @@
+'use client';
+import React from 'react';
+
+interface RecentActivityProps {
+  events: any[];
+}
+
+export default function RecentActivity({ events }: RecentActivityProps) {
+  return (
+    <div className="mt-8">
+      <h2 className="text-lg font-medium text-gray-900">Recent Activity</h2>
+      {events.length === 0 ? (
+        <div className="bg-gray-50 text-sm text-gray-500 px-4 py-4 rounded-lg mt-6">
+          You have no recent activity yet.
+        </div>
+      ) : (
+        <div className="mt-6">
+          {/* TODO: render activity feed once events are available */}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/__tests__/RecentActivity.test.ts
+++ b/frontend/src/components/dashboard/__tests__/RecentActivity.test.ts
@@ -1,0 +1,27 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import RecentActivity from '../RecentActivity';
+import { act } from 'react-dom/test-utils';
+
+describe('RecentActivity component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('shows placeholder when there are no events', () => {
+    act(() => {
+      root.render(React.createElement(RecentActivity, { events: [] }));
+    });
+    expect(container.textContent).toContain('You have no recent activity yet.');
+  });
+});


### PR DESCRIPTION
## Summary
- add new `RecentActivity` component
- show recent activity placeholder on dashboard
- test the RecentActivity component

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843e7cb9124832eb7884b6f4a781e44