### PR TITLE
Add collapsible booking requests list

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ npm run build
 * Open Graph meta tags and fallback avatars.
 * Accessibility and animation improvements.
 * Dashboard stats now animate on load using **framer-motion**.
+* Booking Requests list collapses to five items with a **Show All**/Collapse toggle.
 
 ### Service Management (Artist Dashboard)
 

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,65 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import DashboardPage from '../page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+function mockRequests(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    client: { first_name: 'A', last_name: 'B' },
+    artist: { first_name: 'A', last_name: 'B' },
+    service: { title: 'S' },
+    status: 'pending',
+    created_at: new Date().toISOString(),
+  }));
+}
+
+describe('DashboardPage booking requests toggle', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(async () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: mockRequests(7) });
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(DashboardPage));
+    });
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('collapses and expands the booking request list', async () => {
+    expect(container.querySelectorAll('tbody tr').length).toBe(5);
+    const btn = container.querySelector('button[data-testid="requests-toggle"]') as HTMLButtonElement;
+    expect(btn.textContent).toBe('Show All');
+
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll('tbody tr').length).toBe(7);
+    expect(btn.textContent).toBe('Collapse');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -32,6 +32,7 @@ export default function DashboardPage() {
     null
   );
   const [bookingRequests, setBookingRequests] = useState<BookingRequest[]>([]);
+  const [showAllRequests, setShowAllRequests] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
@@ -44,6 +45,9 @@ export default function DashboardPage() {
   const totalEarnings = bookings
     .filter((booking) => booking.status === "completed")
     .reduce((acc, booking) => acc + booking.total_price, 0);
+  const displayedRequests = showAllRequests
+    ? bookingRequests
+    : bookingRequests.slice(0, 5);
 
   useEffect(() => {
     if (!user) {
@@ -357,7 +361,7 @@ export default function DashboardPage() {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200 bg-white">
-                    {bookingRequests.map((req) => (
+                    {displayedRequests.map((req) => (
                       <tr key={req.id}>
                         <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                           <div className="font-medium text-gray-900">
@@ -385,6 +389,18 @@ export default function DashboardPage() {
                     ))}
                   </tbody>
                 </table>
+                {bookingRequests.length > 5 && (
+                  <div className="bg-gray-50 px-4 py-2 text-center">
+                    <button
+                      type="button"
+                      data-testid="requests-toggle"
+                      className="text-indigo-600 hover:underline text-sm"
+                      onClick={() => setShowAllRequests((prev) => !prev)}
+                    >
+                      {showAllRequests ? "Collapse" : "Show All"}
+                    </button>
+                  </div>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- collapse booking requests to the first five by default on the dashboard
- show a button to toggle the full list
- document this dashboard improvement
- test the new Show All/Collapse behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843efab9eb0832e811919d3d9acde72