### PR TITLE
Make booking cards navigable

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ npm run build
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
 * `ChatThreadView` component for mobile-friendly chat threads.
+* Tap a booking request card to open `/bookings/[id]`.
 
 ### Auth & Registration
 

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -96,7 +96,7 @@ export default function InboxPage() {
     await markThread(id);
 
     if (activeTab === 'requests') {
-      router.push(`/booking-requests/${id}`);
+      router.push(`/bookings/${id}`);
     } else {
       router.push(`/messages/thread/${id}`);
     }
@@ -106,24 +106,24 @@ export default function InboxPage() {
     <ul className="space-y-3">
       {bookings.map((b) => (
         <li key={b.id}>
-          <button
-            type="button"
+          <div
+            role="button"
+            tabIndex={0}
             onClick={() => handleClick(b.id)}
-            className="w-full text-left cursor-pointer active:bg-gray-100 rounded"
+            onKeyPress={() => handleClick(b.id)}
+            className="bg-white shadow rounded-lg p-4 space-y-2 cursor-pointer active:bg-gray-100 transition"
           >
-            <div className="bg-white shadow rounded-lg p-4 space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="font-semibold text-sm">{b.senderName}</span>
-                <span className="text-xs text-gray-500">{b.formattedDate}</span>
-              </div>
-              <div className="text-sm text-gray-600">
-                📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
-              </div>
-              {b.notes && (
-                <div className="text-xs text-gray-500 truncate">📝 {b.notes}</div>
-              )}
+            <div className="flex justify-between items-center">
+              <span className="font-semibold text-sm">{b.senderName}</span>
+              <span className="text-xs text-gray-500">{b.formattedDate}</span>
             </div>
-          </button>
+            <div className="text-sm text-gray-600">
+              📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
+            </div>
+            {b.notes && (
+              <div className="text-xs text-gray-500 truncate">📝 {b.notes}</div>
+            )}
+          </div>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- link inbox cards to bookings via `useRouter().push('/bookings/[id]')`
- enable pointer & transition styles on inbox request cards
- document tapping booking request cards

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ef91abb8832e81803918d4a0c0c6