### PR TITLE
Add empty bookings placeholder

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,41 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import DashboardPage from '../page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
+
+describe('DashboardPage empty state', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' } });
+    (api.getMyClientBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getMyBookingRequests as jest.Mock).mockResolvedValue({ data: [] });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('shows placeholder when there are no bookings', () => {
+    expect(container.textContent).toContain('No bookings yet');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -322,9 +322,11 @@ export default function DashboardPage() {
               Booking Requests
             </h2>
             {bookingRequests.length === 0 ? (
-              <p className="mt-2 text-sm text-gray-500">
-                No booking requests yet.
-              </p>
+              <div className="mt-4 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
+                <div className="text-sm text-gray-500 px-4 py-6 text-center">
+                  No bookings yet
+                </div>
+              </div>
             ) : (
               <div className="mt-4 overflow-hidden shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg">
                 <table className="min-w-full divide-y divide-gray-300">


### PR DESCRIPTION
## Summary
- show a placeholder card when no booking requests exist
- test dashboard page empty state

## Testing
- `pytest -q`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843f0413224832eaeaf3c2e0e0f5363