### PR TITLE
Add heading above booking requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ npm run build
 * Unread message counts badge on Messages icon.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
+* Booking Requests tab shows a "🧾 Booking Requests" heading above the list.
 * `ChatThreadView` component for mobile-friendly chat threads.
 
 ### Auth & Registration

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -37,7 +37,8 @@ export default function DashboardPage() {
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
   // Future activity feed will populate this array with events
-  const [events] = useState<any[]>([]);
+  // Using `unknown[]` to avoid explicit any until event type is defined
+  const [events] = useState<unknown[]>([]);
 
   useEffect(() => {
     if (!user) {

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -103,30 +103,35 @@ export default function InboxPage() {
   };
 
   const renderBookings = () => (
-    <ul className="space-y-3">
-      {bookings.map((b) => (
-        <li key={b.id}>
-          <button
-            type="button"
-            onClick={() => handleClick(b.id)}
-            className="w-full text-left cursor-pointer active:bg-gray-100 rounded"
-          >
-            <div className="bg-white shadow rounded-lg p-4 space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="font-semibold text-sm">{b.senderName}</span>
-                <span className="text-xs text-gray-500">{b.formattedDate}</span>
+    <>
+      <h2 className="text-base font-semibold text-gray-800 px-4 mt-6 mb-2">
+        🧾 Booking Requests
+      </h2>
+      <ul className="space-y-3">
+        {bookings.map((b) => (
+          <li key={b.id}>
+            <button
+              type="button"
+              onClick={() => handleClick(b.id)}
+              className="w-full text-left cursor-pointer active:bg-gray-100 rounded"
+            >
+              <div className="bg-white shadow rounded-lg p-4 space-y-2">
+                <div className="flex justify-between items-center">
+                  <span className="font-semibold text-sm">{b.senderName}</span>
+                  <span className="text-xs text-gray-500">{b.formattedDate}</span>
+                </div>
+                <div className="text-sm text-gray-600">
+                  📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
+                </div>
+                {b.notes && (
+                  <div className="text-xs text-gray-500 truncate">📝 {b.notes}</div>
+                )}
               </div>
-              <div className="text-sm text-gray-600">
-                📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
-              </div>
-              {b.notes && (
-                <div className="text-xs text-gray-500 truncate">📝 {b.notes}</div>
-              )}
-            </div>
-          </button>
-        </li>
-      ))}
-    </ul>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
   );
 
   const renderChats = () => (

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 
 interface RecentActivityProps {
-  events: any[];
+  // TODO: define a proper event type
+  events: unknown[];
 }
 
 export default function RecentActivity({ events }: RecentActivityProps) {


### PR DESCRIPTION
## Summary
- show heading on inbox booking list
- keep typescript lint happy by replacing `any[]`
- note updated heading in README

## Testing
- `./scripts/test-all.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843ef87cd58832e96a2d337c0c0f638