### PR TITLE
Improve dashboard stats layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ npm run build
 * Edit, delete, and reorder services with up/down arrows.
 * **Add Service** button below stats linking to `/services/new`.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
+* Improved dashboard stats layout with monthly earnings card.
 
 ### Artist Availability
 

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -5,6 +5,7 @@ import DashboardPage from '../page';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from 'next/navigation';
+import { ArtistProfile, User, Service } from '@/types';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
@@ -37,5 +38,55 @@ describe('DashboardPage empty state', () => {
 
   it('shows placeholder when there are no bookings', () => {
     expect(container.textContent).toContain('No bookings yet');
+  });
+});
+
+describe('DashboardPage artist stats', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist' } });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          artist_id: 2,
+          client_id: 3,
+          service_id: 4,
+          start_time: new Date().toISOString(),
+          end_time: new Date().toISOString(),
+          status: 'completed',
+          total_price: 120,
+          notes: '',
+          artist: {} as ArtistProfile,
+          client: {} as User,
+          service: {} as Service,
+        },
+      ],
+    });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('renders monthly earnings card', () => {
+    expect(container.textContent).toContain('Earnings This Month');
+    expect(container.textContent).toContain('120');
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -44,6 +44,17 @@ export default function DashboardPage() {
   const totalEarnings = bookings
     .filter((booking) => booking.status === "completed")
     .reduce((acc, booking) => acc + booking.total_price, 0);
+  const earningsThisMonth = bookings
+    .filter((booking) => {
+      if (booking.status !== "completed") return false;
+      const date = new Date(booking.start_time);
+      const now = new Date();
+      return (
+        date.getMonth() === now.getMonth() &&
+        date.getFullYear() === now.getFullYear()
+      );
+    })
+    .reduce((acc, booking) => acc + booking.total_price, 0);
 
   useEffect(() => {
     if (!user) {
@@ -222,8 +233,8 @@ export default function DashboardPage() {
           )}
 
           {/* Stats */}
-          <div className="mt-8">
-            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-8">
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
               {(() => {
                 const cards = [
                   <Link
@@ -279,11 +290,29 @@ export default function DashboardPage() {
                           <span>Total Earnings</span>
                         </div>
                       </dt>
-                      <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+                    <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
                         ${totalEarnings.toFixed(2)}
-                      </dd>
-                      {totalEarnings === 0 && (
+                    </dd>
+                    {totalEarnings === 0 && (
                         <p className="text-xs text-gray-400 mt-2">No earnings this month</p>
+                    )}
+                    </Link>,
+                    <Link
+                      key="earnings-month"
+                      href="/earnings"
+                      className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition"
+                    >
+                      <dt className="truncate text-sm font-medium text-gray-500">
+                        <div className="flex items-center space-x-2">
+                          <span role="img" aria-label="calendar-money">📅</span>
+                          <span>Earnings This Month</span>
+                        </div>
+                      </dt>
+                      <dd className="mt-1 text-3xl font-semibold tracking-tight text-gray-900">
+                        ${earningsThisMonth.toFixed(2)}
+                      </dd>
+                      {earningsThisMonth === 0 && (
+                        <p className="text-xs text-gray-400 mt-2">No earnings yet</p>
                       )}
                     </Link>
                   );


### PR DESCRIPTION
## Summary
- show monthly earnings in dashboard stats
- adapt stats grid for four metrics
- document improved stats in README
- test monthly earnings card render

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68440438ef94832eb7062213fe2ef418