### PR TITLE
Improve service deletion UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npm run build
 ### Service Management (Artist Dashboard)
 
 * Edit, delete, and reorder services with up/down arrows.
+* Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button below stats linking to `/services/new`.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
 * Improved dashboard stats layout with monthly earnings card.

--- a/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
@@ -1,0 +1,67 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import DashboardPage from '../page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { Service } from '@/types';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
+
+describe('Service deletion confirmation', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const service: Service = {
+    id: 1,
+    artist_id: 2,
+    title: 'Gig',
+    description: 'desc',
+    service_type: 'Live Performance',
+    duration_minutes: 60,
+    display_order: 1,
+    price: 100,
+    artist: {} as unknown as import('@/types').ArtistProfile,
+  };
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist' } });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [service] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
+    (api.deleteService as jest.Mock).mockResolvedValue({});
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('asks for confirmation before deleting', async () => {
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+    const deleteBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Delete'
+    ) as HTMLButtonElement;
+    expect(deleteBtn).toBeTruthy();
+    await act(async () => {
+      deleteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(window.confirm).toHaveBeenCalled();
+    expect(api.deleteService).toHaveBeenCalledWith(service.id);
+    window.confirm = originalConfirm;
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -612,14 +612,24 @@ export default function DashboardPage() {
                     </div>
                     <div className="sm:ml-4 flex items-center space-x-2">
                       <button
-                        className="text-sm text-indigo-600"
+                        type="button"
+                        className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
                         onClick={() => setEditingService(service)}
                       >
                         Edit
                       </button>
                       <button
-                        className="text-sm text-red-600"
-                        onClick={() => handleDeleteService(service.id)}
+                        type="button"
+                        className="text-sm font-medium text-red-600 hover:text-red-800"
+                        onClick={() => {
+                          if (
+                            window.confirm(
+                              'Delete this service? This action cannot be undone.'
+                            )
+                          ) {
+                            handleDeleteService(service.id);
+                          }
+                        }}
                       >
                         Delete
                       </button>


### PR DESCRIPTION
## Summary
- require confirmation before deleting a service on the dashboard
- tweak delete button styling
- document the new confirmation step
- add a unit test for the delete confirmation

## Testing
- `npm run lint`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684409ca1e68832e83270b5ab7f06f95