### PR TITLE
Fix dashboard link to filter services by artist

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ npm run build
 * Edit, delete, and reorder services with up/down arrows.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button below stats linking to `/services/new`.
+* "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
 * Improved dashboard stats layout with monthly earnings card.
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -255,7 +255,7 @@ export default function DashboardPage() {
                   cards.push(
                     <Link
                       key="services"
-                      href="/services"
+                      href={user ? `/services?artist=${user.id}` : '/services'}
                       className="flex items-center justify-between gap-4 p-4 rounded-lg bg-white shadow-sm min-h-[64px] overflow-hidden cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition"
                     >
                       <div className="flex items-center space-x-2">

--- a/frontend/src/app/services/page.tsx
+++ b/frontend/src/app/services/page.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { Service } from '@/types';
-import { getAllServices } from '@/lib/api';
+import { getAllServices, getArtistServices } from '@/lib/api';
 
 export default function ServicesPage() {
+  const params = useSearchParams();
+  const artistIdParam = params.get('artist');
+  const artistId = artistIdParam ? Number(artistIdParam) : null;
   const [services, setServices] = useState<Service[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
@@ -14,7 +18,9 @@ export default function ServicesPage() {
   useEffect(() => {
     const fetch = async () => {
       try {
-        const res = await getAllServices();
+        const res = artistId
+          ? await getArtistServices(artistId)
+          : await getAllServices();
         setServices(res.data);
       } catch (err) {
         console.error('Failed to load services', err);
@@ -23,7 +29,7 @@ export default function ServicesPage() {
       }
     };
     fetch();
-  }, []);
+  }, [artistId]);
 
   const filtered = services.filter((s) =>
     s.title.toLowerCase().includes(search.toLowerCase()) ||
@@ -33,7 +39,9 @@ export default function ServicesPage() {
   return (
     <MainLayout>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">Explore Services</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">
+          {artistId ? 'My Services' : 'Explore Services'}
+        </h1>
         <input
           type="text"
           placeholder="Search by title or location"


### PR DESCRIPTION
## Summary
- ensure 'Total Services' card on Dashboard filters by the logged-in artist
- allow the Services page to filter by `?artist=` query param
- document new link behavior in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68440df16040832e941c60432b377000