### PR TITLE
Fix bottom nav badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ npm run build
 ### Mobile Navigation & Inbox
 
 * Persistent bottom nav on small screens with extra padding so content isn’t hidden.
-* Unread message counts badge on Messages icon.
+* Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
 * `ChatThreadView` component for mobile-friendly chat threads.

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -66,7 +66,7 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
                   <item.icon className="h-6 w-6" aria-hidden="true" />
                   {showBadge && (
                     <span
-                      className="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
+                      className="absolute top-0 right-0 inline-flex translate-x-1/2 -translate-y-1/2 items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
                     >
                       {badgeCount}
                     </span>


### PR DESCRIPTION
## Summary
- keep unread message badge anchored over icon on mobile
- document improved badge alignment

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68440f9b17c0832ea00c898796f802bf