### PR TITLE
Hide navbar when logged out

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ npm run build
 
 ### Mobile Navigation & Inbox
 
-* Persistent bottom nav on small screens with compact 56px height so content isn’t hidden.
+* Persistent bottom nav on small screens (visible only when logged in) with compact 56px height so content isn’t hidden.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -173,7 +173,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
           {children}
         </div>
       </main>
-      <MobileBottomNav user={user} />
+      {user && <MobileBottomNav user={user} />}
     </div>
   );
 }

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -34,6 +34,9 @@ function classNames(...classes: (string | false | undefined)[]) {
 }
 
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
+  if (!user) {
+    return null;
+  }
   const router = useRouter();
   // Next.js App Router doesn’t expose pathname in its types, so we use a type assertion
   const pathname = (router as unknown as { pathname?: string }).pathname || '';
@@ -49,7 +52,6 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
     >
       <ul className="flex justify-around h-full">
         {items.map((item) => {
-          if (item.auth && !user) return null;
           const active = pathname === item.href;
           const showBadge = item.name === 'Messages' && unreadMessages > 0;
 

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -30,25 +30,25 @@ describe('MobileBottomNav', () => {
     container.remove();
   });
 
-  it('renders navigation links', () => {
+  it('does not render when not logged in', () => {
     mockUseRouter.mockReturnValue({ pathname: '/' });
     act(() => {
       root.render(
         React.createElement(MobileBottomNav, { user: null })
+      );
+    });
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders navigation links when logged in', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/' });
+    act(() => {
+      root.render(
+        React.createElement(MobileBottomNav, { user: {} as User })
       );
     });
     expect(container.textContent).toContain('Home');
     expect(container.textContent).toContain('Artists');
-  });
-
-  it('hides auth-only links when not logged in', () => {
-    mockUseRouter.mockReturnValue({ pathname: '/' });
-    act(() => {
-      root.render(
-        React.createElement(MobileBottomNav, { user: null })
-      );
-    });
-    expect(container.textContent).not.toContain('Dashboard');
   });
 
   it('shows unread message count badge', () => {
@@ -66,7 +66,7 @@ describe('MobileBottomNav', () => {
     mockUseRouter.mockReturnValue({ pathname: '/' });
     act(() => {
       root.render(
-        React.createElement(MobileBottomNav, { user: null })
+        React.createElement(MobileBottomNav, { user: {} as User })
       );
     });
     const activeLink = container.querySelector('a.text-indigo-600');


### PR DESCRIPTION
## Summary
- hide bottom nav for anonymous users
- update MobileBottomNav with early return
- document new behaviour in README
- update tests

## Testing
- `./scripts/test-all.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441393202c832e9b839ecd1e7dd395