### PR TITLE
Add collapsible lists on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ npm run build
 * **Add Service** button below stats linking to `/services/new`.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
+* Booking request and booking lists collapse after five items with a **Show All** toggle.
 * Improved dashboard stats layout with monthly earnings card.
 
 ### Artist Availability

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -90,3 +90,70 @@ describe('DashboardPage artist stats', () => {
     expect(container.textContent).toContain('120');
   });
 });
+
+describe('DashboardPage list toggles', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist' } });
+
+    const bookings = Array.from({ length: 6 }).map((_, i) => ({
+      id: i,
+      artist_id: 2,
+      client_id: 3,
+      service_id: 4,
+      start_time: new Date().toISOString(),
+      end_time: new Date().toISOString(),
+      status: 'completed',
+      total_price: 100,
+      notes: '',
+      artist: {} as ArtistProfile,
+      client: {} as User,
+      service: {} as Service,
+    }));
+
+    const requests = Array.from({ length: 6 }).map((_, i) => ({
+      id: i,
+      artist_id: 2,
+      client_id: 3,
+      service_id: 4,
+      created_at: new Date().toISOString(),
+      status: 'new',
+      artist: {} as ArtistProfile,
+      client: {} as User,
+      service: {} as Service,
+    }));
+
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: bookings });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: requests });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('toggles booking request list', async () => {
+    const toggleBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Show All'
+    ) as HTMLButtonElement;
+    expect(toggleBtn).toBeTruthy();
+    await act(async () => {
+      toggleBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(toggleBtn.textContent).toContain('Collapse');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -38,6 +38,8 @@ export default function DashboardPage() {
   const [editingService, setEditingService] = useState<Service | null>(null);
   // Future activity feed will populate this array with events
   const [events] = useState<unknown[]>([]);
+  const [showAllRequests, setShowAllRequests] = useState(false);
+  const [showAllBookings, setShowAllBookings] = useState(false);
 
   // Aggregated totals for dashboard statistics
   const servicesCount = services.length;
@@ -55,6 +57,13 @@ export default function DashboardPage() {
       );
     })
     .reduce((acc, booking) => acc + booking.total_price, 0);
+
+  const visibleRequests = showAllRequests
+    ? bookingRequests
+    : bookingRequests.slice(0, 5);
+  const visibleBookings = showAllBookings
+    ? bookings
+    : bookings.slice(0, 5);
 
   useEffect(() => {
     if (!user) {
@@ -343,7 +352,7 @@ export default function DashboardPage() {
             ) : (
               <>
                 <div className="sm:hidden mt-4 space-y-4">
-                  {bookingRequests.map((req) => (
+                  {visibleRequests.map((req) => (
                     <div
                       key={req.id}
                       className="bg-white p-4 shadow rounded-lg"
@@ -401,7 +410,7 @@ export default function DashboardPage() {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200 bg-white">
-                    {bookingRequests.map((req) => (
+                    {visibleRequests.map((req) => (
                       <tr key={req.id}>
                         <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                           <div className="font-medium text-gray-900">
@@ -431,6 +440,17 @@ export default function DashboardPage() {
                 </table>
               </div>
             </div>
+            {bookingRequests.length > 5 && (
+              <div className="mt-2 text-center">
+                <button
+                  type="button"
+                  onClick={() => setShowAllRequests((s) => !s)}
+                  className="text-sm text-indigo-600 hover:underline"
+                >
+                  {showAllRequests ? "Collapse" : "Show All"}
+                </button>
+              </div>
+            )}
             </>
             )}
           </details>
@@ -441,7 +461,7 @@ export default function DashboardPage() {
               Recent Bookings
             </summary>
             <div className="sm:hidden mt-4 space-y-4">
-              {bookings.map((booking) => (
+              {visibleBookings.map((booking) => (
                 <div key={booking.id} className="bg-white p-4 shadow rounded-lg">
                   <div className="font-medium text-gray-900">
                     {booking.client.first_name} {booking.client.last_name}
@@ -511,7 +531,7 @@ export default function DashboardPage() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 bg-white">
-                  {bookings.map((booking) => (
+                  {visibleBookings.map((booking) => (
                     <tr key={booking.id}>
                       <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                         <div className="flex items-center">
@@ -566,6 +586,17 @@ export default function DashboardPage() {
               </table>
             </div>
           </div>
+          {bookings.length > 5 && (
+            <div className="mt-2 text-center">
+              <button
+                type="button"
+                onClick={() => setShowAllBookings((s) => !s)}
+                className="text-sm text-indigo-600 hover:underline"
+              >
+                {showAllBookings ? "Collapse" : "Show All"}
+              </button>
+            </div>
+          )}
           </details>
 
           {/* Services (Artist Only) */}


### PR DESCRIPTION
## Summary
- collapse booking request and booking lists after five items
- add toggle buttons to expand or collapse lists
- test list toggle feature
- document new dashboard behavior in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684418dc5ae0832eb0d9ca604b16696e