### PR TITLE
Highlight unread booking requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ npm run build
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
 * `ChatThreadView` component for mobile-friendly chat threads.
 * Tap a booking request card to open `/bookings/[id]`.
+* Unread booking requests are highlighted in indigo so they stand out.
 
 ### Auth & Registration
 

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -1,0 +1,55 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import InboxPage from '../page';
+import * as api from '@/lib/api';
+import useNotifications from '@/hooks/useNotifications';
+
+jest.mock('@/lib/api');
+jest.mock('@/hooks/useNotifications');
+
+function setup(unread = 0) {
+  (useNotifications as jest.Mock).mockReturnValue({
+    threads: [
+      { booking_request_id: 1, name: 'Alice', unread_count: unread, timestamp: new Date().toISOString(), last_message: 'Hi' },
+    ],
+    loading: false,
+    error: null,
+    markThread: jest.fn(),
+  });
+  (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+    data: [
+      {
+        id: 1,
+        booking_request_id: 1,
+        sender_id: 2,
+        sender_type: 'artist',
+        content: 'Booking details:\nLocation: Test',
+        message_type: 'system',
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('InboxPage unread badge', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('highlights unread booking requests', async () => {
+    const { container, root } = setup(2);
+    await act(async () => {
+      root.render(<InboxPage />);
+    });
+    const card = container.querySelector('li div');
+    expect(card?.className).toContain('bg-indigo-50');
+    root.unmount();
+    container.remove();
+  });
+});

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 import MainLayout from '@/components/layout/MainLayout';
@@ -111,12 +112,22 @@ export default function InboxPage() {
             tabIndex={0}
             onClick={() => handleClick(b.id)}
             onKeyPress={() => handleClick(b.id)}
-            className="bg-white shadow rounded-lg p-4 space-y-2 cursor-pointer active:bg-gray-100 transition"
+            className={clsx(
+              'shadow rounded-lg p-4 space-y-2 cursor-pointer active:bg-gray-100 transition',
+              b.unread > 0
+                ? 'bg-indigo-50 border-l-4 border-indigo-500'
+                : 'bg-white'
+            )}
           >
             <div className="flex justify-between items-center">
               <span className="font-semibold text-sm">{b.senderName}</span>
               <span className="text-xs text-gray-500">{b.formattedDate}</span>
             </div>
+            {b.unread > 0 && (
+              <span className="text-xs text-indigo-600 font-semibold">
+                {b.unread} new message{b.unread > 1 && 's'}
+              </span>
+            )}
             <div className="text-sm text-gray-600">
               📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
             </div>


### PR DESCRIPTION
## Summary
- highlight unread booking request cards in `/inbox`
- test inbox highlight behaviour
- document the inbox highlight in README

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68441fe2dc98832eafbe303f8fff176e