### PR TITLE
Remove unread label text

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ npm run build
 * `ChatThreadView` component for mobile-friendly chat threads.
 * Tap a booking request card to open `/bookings/[id]`.
 * Unread booking requests are highlighted in indigo so they stand out.
+* Cards no longer display a "1 new message" label to keep the list concise.
 
 ### Auth & Registration
 

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -49,6 +49,7 @@ describe('InboxPage unread badge', () => {
     });
     const card = container.querySelector('li div');
     expect(card?.className).toContain('bg-indigo-50');
+    expect(container.textContent).not.toContain('new message');
     root.unmount();
     container.remove();
   });

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -123,11 +123,6 @@ export default function InboxPage() {
               <span className="font-semibold text-sm">{b.senderName}</span>
               <span className="text-xs text-gray-500">{b.formattedDate}</span>
             </div>
-            {b.unread > 0 && (
-              <span className="text-xs text-indigo-600 font-semibold">
-                {b.unread} new message{b.unread > 1 && 's'}
-              </span>
-            )}
             <div className="text-sm text-gray-600">
               📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
             </div>


### PR DESCRIPTION
## Summary
- highlight unread booking request cards without the "new message" label
- document the streamlined cards in README
- test absence of the label in inbox cards

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684422212f74832eb1ac860b8af7bbb9