### PR TITLE
Improve mobile branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,10 @@ GET /api/v1/artist-profiles/{artist_id}/availability
 
 ```
 ```
+
+### Brand Colors
+
+The frontend uses a small **brand** palette defined in `tailwind.config.js`. The
+primary hue is purple (`#7c3aed`), with `brand-dark` and `brand-light` variants.
+Components reference these via utility classes such as `bg-brand` and
+`bg-brand-dark`.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,6 +4,9 @@
 
 :root {
   --font-sans: var(--font-inter);
+  --brand-color: #7c3aed;
+  --brand-color-dark: #6d28d9;
+  --brand-color-light: #c084fc;
 }
 
 @layer base {

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -238,11 +238,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           const isSelf = !isSystem && msg.sender_id === user?.id;
 
           const bubbleClass = isSelf
-            ? 'bg-purple-600 text-white self-end'
+            ? 'bg-brand text-white self-end'
             : isSystem
               ? 'bg-gray-200 text-gray-900 self-start'
-              : 'bg-gray-100 text-gray-900 self-start';
-          const bubbleBase = 'rounded-xl px-4 py-2 max-w-[75%] text-sm';
+              : 'bg-brand-light text-brand-dark self-start';
+          const bubbleBase = 'rounded-xl px-4 py-2 max-w-[80%] sm:max-w-[70%] text-sm';
 
           const avatar = isSystem
             ? artistName?.charAt(0)

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -2,11 +2,11 @@ import { buttonVariants } from '../buttonVariants';
 
 describe('buttonVariants', () => {
   it('provides classes for primary buttons', () => {
-    expect(buttonVariants.primary).toMatch('bg-indigo-600');
+    expect(buttonVariants.primary).toMatch('bg-brand');
   });
 
   it('provides classes for secondary buttons', () => {
-    expect(buttonVariants.secondary).toMatch('bg-gray-200');
+    expect(buttonVariants.secondary).toMatch('bg-brand-light');
   });
 
   it('provides classes for danger buttons', () => {

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,6 +1,7 @@
 export const buttonVariants = {
-  primary: 'bg-indigo-600 text-white hover:bg-indigo-700 focus:ring-indigo-500',
-  secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-400',
+  primary: 'bg-brand text-white hover:bg-brand-dark focus:ring-brand-dark',
+  secondary:
+    'bg-brand-light text-brand-dark hover:bg-brand focus:ring-brand-dark',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
 } as const;
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,6 +10,13 @@ module.exports = {
       fontFamily: {
         sans: ['var(--font-sans)'],
       },
+      colors: {
+        brand: {
+          DEFAULT: '#7c3aed',
+          dark: '#6d28d9',
+          light: '#c084fc',
+        },
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- update brand color palette using Tailwind
- document brand colors in README
- update button variants
- refine mobile chat bubbles

## Testing
- `./setup.sh`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684424aff2dc832e8f044b03eeb9f669