### PR TITLE
Enhance mobile dashboard UI

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -329,7 +329,7 @@ export default function DashboardPage() {
             <button
               type="button"
               onClick={() => router.push("/services/new")}
-              className="w-full bg-purple-600 text-white text-sm py-3 rounded-lg mt-4"
+              className="w-full sm:w-auto bg-brand text-white text-base py-3 rounded-lg mt-4 shadow-md hover:bg-brand-dark"
             >
               Add Service
             </button>
@@ -609,7 +609,7 @@ export default function DashboardPage() {
                 <button
                   type="button"
                   onClick={() => setIsAddServiceModalOpen(true)}
-                  className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                  className="w-full sm:w-auto rounded-md bg-brand px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
                 >
                   Add Service
                 </button>

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -138,7 +138,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="px-4 py-2 bg-indigo-600 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
               >
                 {isSubmitting ? 'Adding...' : 'Add Service'}
               </button>

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -212,7 +212,7 @@ export default function EditServiceModal({
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="px-4 py-2 bg-indigo-600 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
               >
                 {isSubmitting ? "Saving..." : "Save Changes"}
               </button>


### PR DESCRIPTION
## Summary
- improve "Add Service" button styling in dashboard
- use brand colors for service modal actions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`
- `npx eslint src`

------
https://chatgpt.com/codex/tasks/task_e_68442c5174bc832e81d81c9fecb321e4