### PR TITLE
Improve mobile artist profile editing UX

### DIFF
--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
+import MobileSaveBar from '@/components/dashboard/MobileSaveBar';
 import { useAuth } from '@/contexts/AuthContext';
 import { ArtistProfile } from '@/types';
 import {
@@ -122,6 +123,7 @@ export default function EditArtistProfilePage() {
   const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
   const [aspect] = useState<number | undefined>(1);
   const imgRef = useRef<HTMLImageElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
   const [showCropper, setShowCropper] = useState(false);
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
   const [uploadingImage, setUploadingImage] = useState(false);
@@ -237,6 +239,10 @@ export default function EditArtistProfilePage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleSaveClick = () => {
+    formRef.current?.requestSubmit();
   };
 
   const handleImageFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -533,7 +539,11 @@ export default function EditArtistProfilePage() {
           </div>
         </section>
 
-        <form onSubmit={handleSubmit} className="space-y-8 divide-y divide-gray-200">
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          className="space-y-8 divide-y divide-gray-200"
+        >
           <div className="space-y-6 pt-8 sm:space-y-5">
             <section>
               <h2 className="text-xl font-medium text-gray-700 mb-6">Business Details</h2>
@@ -642,7 +652,7 @@ export default function EditArtistProfilePage() {
             </section>
           </div>
 
-          <div className="pt-8 flex justify-end">
+          <div className="pt-8 hidden sm:flex justify-end">
             <button
               type="submit"
               className={primaryButtonClasses}
@@ -653,6 +663,7 @@ export default function EditArtistProfilePage() {
           </div>
         </form>
       </div>
+      <MobileSaveBar onSave={handleSaveClick} isSaving={loading} />
     </MainLayout>
   );
 }

--- a/frontend/src/components/dashboard/MobileSaveBar.tsx
+++ b/frontend/src/components/dashboard/MobileSaveBar.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+import Button from '../ui/Button';
+
+interface MobileSaveBarProps {
+  onSave: () => void;
+  isSaving?: boolean;
+}
+
+export default function MobileSaveBar({ onSave, isSaving = false }: MobileSaveBarProps) {
+  return (
+    <div className="fixed bottom-14 left-0 right-0 z-40 sm:hidden bg-white border-t p-2 flex justify-end">
+      <Button onClick={onSave} isLoading={isSaving} fullWidth>
+        Save Changes
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
@@ -1,0 +1,40 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import MobileSaveBar from '../MobileSaveBar';
+
+describe('MobileSaveBar', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('triggers onSave when clicked', () => {
+    const onSave = jest.fn();
+    act(() => {
+      root.render(React.createElement(MobileSaveBar, { onSave, isSaving: false }));
+    });
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('disables button when isSaving', () => {
+    act(() => {
+      root.render(React.createElement(MobileSaveBar, { onSave: () => {}, isSaving: true }));
+    });
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `MobileSaveBar` component for quick actions on small screens
- connect `MobileSaveBar` to artist profile edit page
- hide standard save button on mobile and add form submission helper
- test new save bar behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844334d2ba0832ea97c3616c24f6f87