### PR TITLE
Fix long press drag handle

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -152,9 +152,8 @@ export default function DashboardPage() {
     event.preventDefault();
     // persist the event so we can use it after the long‑press delay
     event.persist();
-    const nativeEvent = event.nativeEvent;
     const timer = setTimeout(() => {
-      dragControls.start(nativeEvent);
+      dragControls.start(event);
     }, 300);
     setPressTimer(timer);
   };


### PR DESCRIPTION
## Summary
- restore dragControls.start(event) when activating drag after long-press

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68443d54ad6c832eb992f0870e55d8f1