### PR TITLE
Fix long press drag issue

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -152,8 +152,9 @@ export default function DashboardPage() {
     event.preventDefault();
     // persist the event so we can use it after the long‑press delay
     event.persist();
+    const nativeEvent = event.nativeEvent;
     const timer = setTimeout(() => {
-      dragControls.start(event);
+      dragControls.start(nativeEvent);
     }, 300);
     setPressTimer(timer);
   };


### PR DESCRIPTION
## Summary
- restore drag handle by passing the native event after long press

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68443f6795b4832eae27aaf168342f3c