### PR TITLE
Fix pointer capture for long press

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ npm run build
 
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
 * Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up.
+* Text selection is disabled only while reordering so you can still highlight service details normally.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a modal to create a new service. It appears after your services list on mobile and below stats on larger screens.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -196,8 +196,17 @@ describe('Service card drag handle', () => {
     jest.clearAllMocks();
   });
 
-  it('applies select-none to service items', () => {
-    const card = container.querySelector('.select-none');
-    expect(card).toBeTruthy();
+  it('temporarily disables text selection during long press', async () => {
+    const card = container.querySelector('[data-testid="service-item"]') as HTMLElement;
+    const handle = card.querySelector('div[aria-hidden="true"]') as HTMLElement;
+    expect(card.className).not.toMatch('select-none');
+    await act(async () => {
+      handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    });
+    expect(card.className).toMatch('select-none');
+    await act(async () => {
+      handle.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+    });
+    expect(card.className).not.toMatch('select-none');
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -147,6 +147,7 @@ export default function DashboardPage() {
   const [isReordering, setIsReordering] = useState(false);
   const dragControls = useDragControls();
   const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
+  const [isPressing, setIsPressing] = useState(false);
 
   const startDrag = (event: React.PointerEvent) => {
     event.preventDefault();
@@ -156,6 +157,7 @@ export default function DashboardPage() {
     const nativeEvent = event.nativeEvent;
     // capture pointer so other handlers don't interfere
     (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
+    setIsPressing(true);
     const timer = setTimeout(() => {
       dragControls.start(nativeEvent);
     }, 300);
@@ -170,6 +172,7 @@ export default function DashboardPage() {
     if (event) {
       (event.currentTarget as HTMLElement).releasePointerCapture?.(event.pointerId);
     }
+    setIsPressing(false);
   };
 
   const persistServiceOrder = async (ordered: Service[]) => {
@@ -657,7 +660,8 @@ export default function DashboardPage() {
                     onDragEnd={handleDragEnd}
                     dragListener={false}
                     dragControls={dragControls}
-                    className="select-none relative flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-3 rounded-lg border border-gray-300 bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:border-gray-400"
+                    data-testid="service-item"
+                    className={`relative flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-3 rounded-lg border border-gray-300 bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:border-gray-400 ${isPressing ? 'select-none' : ''}`}
                   >
                     <div
                       className="absolute right-2 top-2 cursor-grab active:cursor-grabbing text-gray-400 touch-none"


### PR DESCRIPTION
## Summary
- ensure drag handle keeps text selectable when not reordering
- disable selection only while a card is being long‑pressed
- document long‑press behaviour in the README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68444fd72990832eb6c9b249b4d21bb8