### PR TITLE
Fix long‑press pointer capture on service drag handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ npm run build
 ### Service Management (Artist Dashboard)
 
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
-* Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up.
-* Text selection is disabled only while reordering so you can still highlight service details normally.
+* Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up or cancel.
+* The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a modal to create a new service. It appears after your services list on mobile and below stats on larger screens.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -152,14 +152,10 @@ export default function DashboardPage() {
   const startDrag = (event: React.PointerEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    // persist the event so it survives the long‑press delay
-    event.persist();
-    const nativeEvent = event.nativeEvent;
-    // capture pointer so other handlers don't interfere
     (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
     setIsPressing(true);
     const timer = setTimeout(() => {
-      dragControls.start(nativeEvent);
+      dragControls.start(event);
     }, 300);
     setPressTimer(timer);
   };
@@ -668,6 +664,9 @@ export default function DashboardPage() {
                       aria-hidden="true"
                       onPointerDown={startDrag}
                       onPointerUp={cancelDrag}
+                      onPointerLeave={cancelDrag}
+                      onPointerCancel={cancelDrag}
+                      onContextMenu={(e) => e.preventDefault()}
                     >
                       <Bars3Icon className="h-5 w-5" />
                     </div>


### PR DESCRIPTION
## Summary
- keep pointer capture active until pointer up or cancel
- block context menu so long press doesn't highlight text
- document improved drag handle behavior

## Testing
- `./scripts/test-all.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684451e04444832e9dbd589427d155bf