### PR TITLE
Fix mobile drag boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ npm run build
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
 * Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up or cancel.
 * The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
+* Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a modal to create a new service. It appears after your services list on mobile and below stats on larger screens.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import MainLayout from "@/components/layout/MainLayout";
 import { useAuth } from "@/contexts/AuthContext";
@@ -146,6 +146,7 @@ export default function DashboardPage() {
 
   const [isReordering, setIsReordering] = useState(false);
   const dragControls = useDragControls();
+  const listRef = useRef<HTMLDivElement>(null);
   const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
   const [isPressing, setIsPressing] = useState(false);
 
@@ -643,6 +644,7 @@ export default function DashboardPage() {
                 </h2>
               </div>
               <Reorder.Group
+                ref={listRef}
                 axis="y"
                 values={services}
                 onReorder={handleReorder}
@@ -656,6 +658,7 @@ export default function DashboardPage() {
                     onDragEnd={handleDragEnd}
                     dragListener={false}
                     dragControls={dragControls}
+                    dragConstraints={listRef}
                     data-testid="service-item"
                     className={`relative flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-3 rounded-lg border border-gray-300 bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:border-gray-400 ${isPressing ? 'select-none' : ''}`}
                   >


### PR DESCRIPTION
## Summary
- keep drag actions within the service list so the top card can't overlap the heading
- document the drag boundary improvement

## Testing
- `./scripts/test-all.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68445459dedc832eb33e277569f87f94