### PR TITLE
Fix multiple service drag and add vibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ npm run build
 
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
 * Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up or cancel.
+* A short vibration cues the start of reordering on devices that support it.
 * The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
 * Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.
 * Service deletion now requires confirmation to prevent mistakes.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -209,4 +209,20 @@ describe('Service card drag handle', () => {
     });
     expect(card.className).not.toMatch('select-none');
   });
+
+  it('vibrates when reordering starts', async () => {
+    jest.useFakeTimers();
+    const card = container.querySelector('[data-testid="service-item"]') as HTMLElement;
+    const handle = card.querySelector('div[aria-hidden="true"]') as HTMLElement;
+    const vibrateSpy = jest.fn();
+    Object.defineProperty(navigator, 'vibrate', { value: vibrateSpy, configurable: true });
+    await act(async () => {
+      handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(vibrateSpy).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -156,6 +156,9 @@ export default function DashboardPage() {
     (event.currentTarget as HTMLElement).setPointerCapture?.(event.pointerId);
     setIsPressing(true);
     const timer = setTimeout(() => {
+      if (typeof navigator !== "undefined" && navigator.vibrate) {
+        navigator.vibrate(10);
+      }
       dragControls.start(event);
     }, 300);
     setPressTimer(timer);
@@ -667,7 +670,6 @@ export default function DashboardPage() {
                       aria-hidden="true"
                       onPointerDown={startDrag}
                       onPointerUp={cancelDrag}
-                      onPointerLeave={cancelDrag}
                       onPointerCancel={cancelDrag}
                       onContextMenu={(e) => e.preventDefault()}
                     >


### PR DESCRIPTION
## Summary
- allow handle to be dragged multiple times without cancelling on pointer leave
- give subtle vibration feedback when reordering begins
- test the vibration behaviour
- document the new feedback cue

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68445ae629b0832ea2d76fd9b884f079