### PR TITLE
Highlight selected service card during reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm run build
 
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
 * Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up or cancel.
-* Each service card uses its own drag controller so the correct card moves even after reordering.
+* Each service card uses its own drag controller so the correct card moves even after reordering. A subtle ring highlight shows which card is active while dragging.
 * A short vibration cues the start of reordering on devices that support it, using a persisted pointer event for reliability.
 * The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
 * Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -200,14 +200,17 @@ describe('Service card drag handle', () => {
     const card = container.querySelector('[data-testid="service-item"]') as HTMLElement;
     const handle = card.querySelector('div[aria-hidden="true"]') as HTMLElement;
     expect(card.className).not.toMatch('select-none');
+    expect(card.className).not.toMatch('ring-2');
     await act(async () => {
       handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
     });
     expect(card.className).toMatch('select-none');
+    expect(card.className).toMatch('ring-2');
     await act(async () => {
       handle.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
     });
     expect(card.className).not.toMatch('select-none');
+    expect(card.className).not.toMatch('ring-2');
   });
 
   it('vibrates when reordering starts', async () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -83,7 +83,7 @@ function ServiceCard({
       dragControls={dragControls}
       dragConstraints={dragConstraints}
       data-testid="service-item"
-      className={`relative flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-3 rounded-lg border border-gray-300 bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:border-gray-400 ${pressing ? "select-none" : ""}`}
+      className={`relative flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-3 rounded-lg border border-gray-300 bg-white p-4 shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:border-gray-400 transition-colors ${pressing ? "select-none ring-2 ring-indigo-400 bg-indigo-50" : ""}`}
     >
       <div
         className="absolute right-2 top-2 cursor-grab active:cursor-grabbing text-gray-400 touch-none"


### PR DESCRIPTION
## Summary
- show a ring highlight while a service card is pressed for dragging
- document the new drag highlight
- test card highlight on long press

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684460741964832eb9cfcad94e92a3da