### PR TITLE
Fix drag selection highlight reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm run build
 
 * Edit, delete, and reorder services by long‑pressing the handle in the top-right corner and dragging the card. Text selection is disabled for smoother reordering.
 * Drag handle now reliably activates on mobile by disabling default touch actions, capturing the pointer, and persisting the event during the long press until pointer up or cancel.
-* Each service card uses its own drag controller so the correct card moves even after reordering. A subtle ring highlight shows which card is active while dragging.
+* Each service card uses its own drag controller so the correct card moves even after reordering. A subtle ring highlight shows which card is active while dragging, and it disappears when the card is dropped.
 * A short vibration cues the start of reordering on devices that support it, using a persisted pointer event for reliability.
 * The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
 * Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -74,11 +74,16 @@ function ServiceCard({
     setPressing(false);
   };
 
+  const handleDragEndItem = () => {
+    cancelDrag();
+    onDragEnd();
+  };
+
   return (
     <Reorder.Item
       key={service.id}
       value={service}
-      onDragEnd={onDragEnd}
+      onDragEnd={handleDragEndItem}
       dragListener={false}
       dragControls={dragControls}
       dragConstraints={dragConstraints}


### PR DESCRIPTION
## Summary
- clear drag highlight after service card reorder
- document highlight behavior

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68446199d9a8832e85d90325a2490130