### PR TITLE
Add scroll-aware mobile nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ npm run build
 
 ### Mobile Navigation & Inbox
 
-* Persistent bottom nav on small screens (visible only when logged in) with compact 56px height so content isn’t hidden.
+* Persistent bottom nav on small screens (visible only when logged in) with compact 56px height.
+* Bottom nav auto-hides when you scroll down and reappears when scrolling up.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -10,6 +10,7 @@ import {
 } from '@heroicons/react/24/outline';
 import type { User } from '@/types';
 import useNotifications from '@/hooks/useNotifications';
+import useScrollDirection from '@/hooks/useScrollDirection';
 
 interface MobileBottomNavProps {
   user: User | null;
@@ -36,6 +37,7 @@ function classNames(...classes: (string | false | undefined)[]) {
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   const router = useRouter();
   const { threads } = useNotifications();
+  const scrollDir = useScrollDirection();
   if (!user) {
     return null;
   }
@@ -46,7 +48,10 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
 
   return (
     <nav
-      className="fixed bottom-0 w-full h-[56px] py-1 bg-white border-t shadow z-50 sm:hidden"
+      className={classNames(
+        'fixed bottom-0 w-full h-[56px] py-1 bg-white border-t shadow z-50 sm:hidden transition-transform',
+        scrollDir === 'down' ? 'translate-y-full' : 'translate-y-0',
+      )}
       aria-label="Mobile navigation"
     >
       <ul className="flex justify-around h-full">

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -72,4 +72,26 @@ describe('MobileBottomNav', () => {
     const activeLink = container.querySelector('a.text-brand-dark');
     expect(activeLink).not.toBeNull();
   });
+
+  it('hides on scroll down and shows on scroll up', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/' });
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    act(() => {
+      root.render(React.createElement(MobileBottomNav, { user: {} as User }));
+    });
+    const nav = container.querySelector('nav');
+    expect(nav?.className).toContain('translate-y-0');
+
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(nav?.className).toContain('translate-y-full');
+
+    Object.defineProperty(window, 'scrollY', { value: 20, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(nav?.className).toContain('translate-y-0');
+  });
 });

--- a/frontend/src/hooks/useScrollDirection.ts
+++ b/frontend/src/hooks/useScrollDirection.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Detects the scroll direction of the window.
+ * Returns 'up' or 'down' depending on the last scroll movement.
+ */
+export default function useScrollDirection(): 'up' | 'down' {
+  const [direction, setDirection] = useState<'up' | 'down'>('up');
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+
+    const handleScroll = () => {
+      const y = window.scrollY;
+      if (Math.abs(y - lastY) < 5) return;
+      setDirection(y > lastY ? 'down' : 'up');
+      lastY = y;
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return direction;
+}
+


### PR DESCRIPTION
## Summary
- hide `MobileBottomNav` when user scrolls down
- show the nav when scrolling up
- document new auto-hide behavior in README
- test nav visibility changes with scroll events

## Testing
- `npm --prefix frontend run lint --silent`
- `npm --prefix frontend test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844653e0228832eb02b2b31ec125313