### PR TITLE
Optimize DB utils

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -2,94 +2,80 @@ from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 
 
-def ensure_service_type_column(engine: Engine) -> None:
-    """Ensure the service_type column exists on the services table.
+def add_column_if_missing(engine: Engine, table: str, column: str, ddl: str) -> None:
+    """Add a column to *table* if it does not exist."""
 
-    Older SQLite databases created before the ServiceType enum was added will
-    be missing this column. This helper adds it with a sensible default so
-    queries referencing ``Service.service_type`` don't fail.
-    """
     inspector = inspect(engine)
-    if "services" not in inspector.get_table_names():
+    if table not in inspector.get_table_names():
         return
-    column_names = [col["name"] for col in inspector.get_columns("services")]
-    if "service_type" not in column_names:
+    column_names = [col["name"] for col in inspector.get_columns(table)]
+    if column not in column_names:
         with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "ALTER TABLE services ADD COLUMN service_type VARCHAR NOT NULL DEFAULT 'Live Performance'"
-                )
-            )
+            conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {ddl}"))
             conn.commit()
+
+
+def ensure_service_type_column(engine: Engine) -> None:
+    """Ensure the ``service_type`` column exists on the ``services`` table."""
+
+    add_column_if_missing(
+        engine,
+        "services",
+        "service_type",
+        "service_type VARCHAR NOT NULL DEFAULT 'Live Performance'",
+    )
 
 
 def ensure_message_type_column(engine: Engine) -> None:
-    """Add the message_type column if it's missing (for SQLite databases)."""
-    inspector = inspect(engine)
-    if "messages" not in inspector.get_table_names():
-        return
-    column_names = [col["name"] for col in inspector.get_columns("messages")]
-    if "message_type" not in column_names:
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "ALTER TABLE messages ADD COLUMN message_type VARCHAR NOT NULL DEFAULT 'text'"
-                )
-            )
-            conn.commit()
+    """Add the ``message_type`` column if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "messages",
+        "message_type",
+        "message_type VARCHAR NOT NULL DEFAULT 'text'",
+    )
 
 
 def ensure_attachment_url_column(engine: Engine) -> None:
-    """Add the attachment_url column if missing."""
-    inspector = inspect(engine)
-    if "messages" not in inspector.get_table_names():
-        return
-    column_names = [col["name"] for col in inspector.get_columns("messages")]
-    if "attachment_url" not in column_names:
-        with engine.connect() as conn:
-            conn.execute(text("ALTER TABLE messages ADD COLUMN attachment_url VARCHAR"))
-            conn.commit()
+    """Add the ``attachment_url`` column if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "messages",
+        "attachment_url",
+        "attachment_url VARCHAR",
+    )
 
 
 def ensure_display_order_column(engine: Engine) -> None:
-    """Add the display_order column to services if it's missing."""
-    inspector = inspect(engine)
-    if "services" not in inspector.get_table_names():
-        return
-    column_names = [col["name"] for col in inspector.get_columns("services")]
-    if "display_order" not in column_names:
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "ALTER TABLE services ADD COLUMN display_order INTEGER NOT NULL DEFAULT 0"
-                )
-            )
-            conn.commit()
+    """Add the ``display_order`` column to ``services`` if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "services",
+        "display_order",
+        "display_order INTEGER NOT NULL DEFAULT 0",
+    )
 
 
 def ensure_notification_link_column(engine: Engine) -> None:
-    """Add the link column to notifications if it's missing."""
-    inspector = inspect(engine)
-    if "notifications" not in inspector.get_table_names():
-        return
-    column_names = [col["name"] for col in inspector.get_columns("notifications")]
-    if "link" not in column_names:
-        with engine.connect() as conn:
-            conn.execute(
-                text(
-                    "ALTER TABLE notifications ADD COLUMN link VARCHAR NOT NULL DEFAULT ''"
-                )
-            )
-            conn.commit()
+    """Add the ``link`` column to ``notifications`` if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "notifications",
+        "link",
+        "link VARCHAR NOT NULL DEFAULT ''",
+    )
 
 
 def ensure_custom_subtitle_column(engine: Engine) -> None:
-    """Add the custom_subtitle column to artist_profiles if it's missing."""
-    inspector = inspect(engine)
-    if "artist_profiles" not in inspector.get_table_names():
-        return
-    column_names = [col["name"] for col in inspector.get_columns("artist_profiles")]
-    if "custom_subtitle" not in column_names:
-        with engine.connect() as conn:
-            conn.execute(text("ALTER TABLE artist_profiles ADD COLUMN custom_subtitle VARCHAR"))
-            conn.commit()
+    """Add the ``custom_subtitle`` column to ``artist_profiles`` if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "artist_profiles",
+        "custom_subtitle",
+        "custom_subtitle VARCHAR",
+    )


### PR DESCRIPTION
## Summary
- refactor repetitive DB utils into a single helper

## Testing
- `pytest -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684467b3d784832e982a99860e3edc29