### PR TITLE
Improve mobile nav visibility

### DIFF
--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -94,4 +94,30 @@ describe('MobileBottomNav', () => {
     });
     expect(nav?.className).toContain('translate-y-0');
   });
+
+  it('remains visible once scrolled to the top', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/' });
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+    act(() => {
+      root.render(React.createElement(MobileBottomNav, { user: {} as User }));
+    });
+    const nav = container.querySelector('nav');
+
+    Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(nav?.className).toContain('translate-y-full');
+
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(nav?.className).toContain('translate-y-0');
+
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(nav?.className).toContain('translate-y-0');
+  });
 });

--- a/frontend/src/hooks/useScrollDirection.ts
+++ b/frontend/src/hooks/useScrollDirection.ts
@@ -12,6 +12,12 @@ export default function useScrollDirection(): 'up' | 'down' {
 
     const handleScroll = () => {
       const y = window.scrollY;
+      if (y <= 0) {
+        // Stay visible at the top of the page even if scroll "bounces"
+        setDirection('up');
+        lastY = 0;
+        return;
+      }
       if (Math.abs(y - lastY) < 5) return;
       setDirection(y > lastY ? 'down' : 'up');
       lastY = y;


### PR DESCRIPTION
## Summary
- keep mobile nav visible when the page is scrolled to the very top
- test nav visibility when reaching the top of the page

## Testing
- `npm test --silent`
- `npx eslint src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446c8c37c4832ea906c2e22d5a37fe