### PR TITLE
Fix jest test pattern

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,13 +1,22 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
   transform: {
-    '^.+\\.(ts|tsx)$': [
+    '^.+\\.[jt]sx?$': [
       'babel-jest',
-      { presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'] },
+      {
+        presets: [
+          '@babel/preset-env',
+          ['@babel/preset-react', { runtime: 'automatic' }],
+          '@babel/preset-typescript',
+        ],
+      },
     ],
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(react-calendar|@wojtekmaj/date-utils|get-user-locale|warning|memoize|mimic-function)/)',
+  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',


### PR DESCRIPTION
## Summary
- run Jest on `.test.tsx` files
- support React automatic runtime and transform required packages for ESM

## Testing
- `npm run lint --prefix frontend`
- `npm test --prefix frontend` *(fails: 9 failed, 11 passed, 20 total)*

------
https://chatgpt.com/codex/tasks/task_e_6845706f77f8832e8bc7a2c01f7f1167