### PR TITLE
Add setup script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ from any directory and automatically installs backend and frontend packages:
 ./setup.sh
 ```
 
-It installs Python requirements from `backend/requirements.txt` and
-JavaScript dependencies under `frontend/`.
+This script installs Python requirements from `backend/requirements.txt` **and**
+`requirements-dev.txt`, then runs `npm install` inside `frontend/`.
 
 ### Linting
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,3 +10,5 @@ pip install -r "$ROOT_DIR/requirements-dev.txt"
 
 echo "Installing frontend Node dependencies..."
 cd "$ROOT_DIR/frontend" && npm install
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- streamline setup instructions to include requirements-dev
- print completion message in `setup.sh`

## Testing
- `pytest -q`
- `npm test --silent` *(fails: 9 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68458993aba0832eae07e82abc4f947d