### PR TITLE
Add Jest setup and root test script

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -22,4 +22,5 @@ module.exports = {
     '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',
     '\\.module\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,24 @@
+
+jest.mock('next/navigation', () => {
+  return {
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: jest.fn(),
+      refresh: jest.fn(),
+      pathname: '/',
+    }),
+    usePathname: () => '/',
+  };
+});
+
+jest.mock('@/contexts/AuthContext', () => {
+  const mock = jest.fn(() => ({
+    user: null,
+    token: null,
+    loading: false,
+    login: jest.fn(),
+    register: jest.fn(),
+    logout: jest.fn(),
+  }));
+  return { useAuth: mock };
+});

--- a/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
+++ b/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
@@ -34,6 +34,6 @@ describe('ChatThreadView', () => {
     expect(header?.textContent).toBe('Alice');
     expect(messageContainer).not.toBeNull();
     expect(inputBar).not.toBeNull();
-    expect(container.firstChild).toHaveClass('h-screen');
+    expect((container.firstChild as HTMLElement)?.className).toContain('h-screen');
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "booking-app-root",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix frontend test --silent"
+  }
+}


### PR DESCRIPTION
## Summary
- include Jest setup file to mock router and auth context
- wire jest.setup.ts into jest.config.js
- tweak ChatThreadView test for standard assertions
- expose `npm test` at repo root to run frontend tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458b1edef8832e87b51fb639a0b6e0