### PR TITLE
Fix notification modal tests

### DIFF
--- a/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
+++ b/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
@@ -15,7 +15,7 @@ const baseProps = {
   hasMore: false,
 };
 
-describe.skip('FullScreenNotificationModal', () => {
+describe('FullScreenNotificationModal', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -34,13 +34,13 @@ describe.skip('FullScreenNotificationModal', () => {
     act(() => {
       root.render(React.createElement(FullScreenNotificationModal, baseProps));
     });
-    expect(container.textContent).toContain("You're all caught up!");
+    expect(document.body.textContent).toContain("You're all caught up!");
   });
 
   it('renders mark all button', () => {
     act(() => {
       root.render(React.createElement(FullScreenNotificationModal, baseProps));
     });
-    expect(container.textContent).toContain('Mark All as Read');
+    expect(document.body.textContent).toContain('Mark All as Read');
   });
 });


### PR DESCRIPTION
## Summary
- update FullScreenNotificationModal test expectations to query `document.body`
- enable modal tests

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68459b67e7e0832ea1512da09c866e5a