### PR TITLE
Fix skipped booking and layout tests

### DIFF
--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -18,7 +18,7 @@ class StubSocket {
 // @ts-expect-error jsdom does not implement WebSocket
 global.WebSocket = StubSocket;
 
-describe.skip('MessageThread component', () => {
+describe('MessageThread component', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -44,7 +44,10 @@ describe.skip('MessageThread component', () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
     await new Promise((r) => setTimeout(r, 0));
-    const scrollContainer = container.querySelector('.overflow-y-auto') as HTMLElement;
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const scrollContainer = document.querySelector('.overflow-y-auto') as HTMLElement;
 
     // Simulate a scrollable container
     Object.defineProperty(scrollContainer, 'scrollHeight', { value: 200, configurable: true });
@@ -67,7 +70,7 @@ describe.skip('MessageThread component', () => {
           booking_request_id: 1,
           sender_id: 2,
           sender_type: 'artist',
-          content: 'Hello',
+          content: 'Hello there',
           message_type: 'text',
           timestamp: new Date().toISOString(),
           unread: true,
@@ -78,7 +81,10 @@ describe.skip('MessageThread component', () => {
     await act(async () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
-
+    
+    await act(async () => {
+      await Promise.resolve();
+    });
     const highlightedRow = container.querySelector('.bg-purple-50');
     const senderName = container.querySelector('span.font-semibold');
     expect(highlightedRow).not.toBeNull();

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -5,7 +5,7 @@ import MobileMenuDrawer from '../MobileMenuDrawer';
 
 const nav = [{ name: 'Home', href: '/' }, { name: 'Artists', href: '/artists' }];
 
-describe.skip('MobileMenuDrawer', () => {
+describe('MobileMenuDrawer', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -20,8 +20,8 @@ describe.skip('MobileMenuDrawer', () => {
     container.remove();
   });
 
-  it('renders navigation items when open', () => {
-    act(() => {
+  it('renders navigation items when open', async () => {
+    await act(async () => {
       root.render(
         React.createElement(MobileMenuDrawer, {
           open: true,
@@ -33,7 +33,11 @@ describe.skip('MobileMenuDrawer', () => {
         }),
       );
     });
-    expect(container.textContent).toContain('Home');
-    expect(container.textContent).toContain('Artists');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const bodyText = document.body.textContent || '';
+    expect(bodyText).toContain('Home');
+    expect(bodyText).toContain('Artists');
   });
 });


### PR DESCRIPTION
## Summary
- reenable MessageThread and MobileMenuDrawer tests
- update tests to wait for portal rendering and message fetching
- ensure message content is long enough for filter logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68459ce66da8832ebb7ae4a56038af6f