### PR TITLE
Fix lint errors in tests

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -15,7 +15,7 @@ jest.mock('next/navigation', () => ({
 }));
 
 if (typeof global.PointerEvent === 'undefined') {
-  // @ts-ignore
+  // @ts-expect-error - jsdom lacks PointerEvent so we fall back to MouseEvent
   global.PointerEvent = window.MouseEvent;
 }
 

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -16,11 +16,12 @@ function Wrapper() {
   );
 }
 
-function ExposeSetter() {
-  const { setStep } = useBooking();
-  (window as any).__setStep = setStep;
-  return null;
-}
+  function ExposeSetter() {
+    const { setStep } = useBooking();
+    // Cast to unknown first to avoid eslint no-explicit-any complaint
+    (window as unknown as { __setStep: (step: number) => void }).__setStep = setStep;
+    return null;
+  }
 
 describe('BookingWizard mobile scrolling', () => {
   let container: HTMLDivElement;
@@ -85,7 +86,7 @@ describe('BookingWizard mobile scrolling', () => {
   });
 
   it('shows inline buttons for all remaining steps', async () => {
-    const setStep = (window as any).__setStep as (s: number) => void;
+      const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
     const expectButton = (testId: string) => {
       expect(container.querySelector(`[data-testid="${testId}"]`)).not.toBeNull();
     };


### PR DESCRIPTION
## Summary
- use `@ts-expect-error` for PointerEvent polyfill
- avoid `any` type when exposing and using `__setStep`
- update tests to satisfy ESLint rules

## Testing
- `pytest -q`
- `CI=true npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845aa4f0e90832ea8e25cacef976f93