### PR TITLE
Add theme customization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,7 @@ The frontend uses a small **brand** palette defined in `tailwind.config.js`. The
 primary hue is purple (`#7c3aed`), with `brand-dark` and `brand-light` variants.
 Components reference these via utility classes such as `bg-brand` and
 `bg-brand-dark`.
+
+Update these colors in `frontend/tailwind.config.js` and
+`frontend/src/app/globals.css` to adjust the site's look and feel. See
+`frontend/README.md` for detailed theming instructions.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,40 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 Reusable style constants are defined in `src/styles`. Button variants come from
 `buttonVariants.ts` so colors stay consistent across the app.
 
+### Customizing Brand Colors
+
+Brand colors are declared in `tailwind.config.js` and exposed as CSS variables in
+`globals.css`. Modify these values to change the entire palette:
+
+```javascript
+// tailwind.config.js
+colors: {
+  brand: {
+    DEFAULT: '#7c3aed',
+    dark: '#6d28d9',
+    light: '#c084fc',
+  },
+}
+```
+
+```css
+/* globals.css */
+:root {
+  --brand-color: #7c3aed;
+  --brand-color-dark: #6d28d9;
+  --brand-color-light: #c084fc;
+}
+```
+
+Updating these values automatically updates button variants and any classes such
+as `bg-brand` or `bg-brand-dark`.
+
+### Fonts & Global Styles
+
+`globals.css` also defines the base font family using CSS variables. The default
+font (`--font-inter`) is provided by `next/font`. Replace this variable to use a
+different typeface across the site.
+
 ### Booking Wizard URL Parameters
 
 The `/booking` page requires an `artist_id` query parameter and accepts an optional `service_id` to pre-select a service.


### PR DESCRIPTION
## Summary
- expand theming instructions in `frontend/README.md`
- mention where to update brand colors in root `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845af977660832e834a9255d7484354