### PR TITLE
Add Playwright mobile test

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ npm run lint
 ./scripts/test-all.sh
 ```
 
-This runs `pytest`, `npm test`, and `npm run lint`. You can also run each step manually.
+This runs `pytest`, `npm test`, `npm run test:e2e`, and `npm run lint`. You can also run each step manually.
+
+End-to-end tests live in `frontend/e2e` and are powered by [Playwright](https://playwright.dev/). They launch the Next.js development server in a mobile viewport and walk through the Booking Wizard.
+
 Make sure you've run `./setup.sh` at least once beforehand so all Node and Python
 packages are installed; otherwise the tests may fail with `next not found` or
 similar dependency errors.

--- a/frontend/e2e/mobile-booking.spec.ts
+++ b/frontend/e2e/mobile-booking.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Booking Wizard mobile flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/v1/artists/1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ location: 'NYC' }),
+      });
+    });
+    await page.route('**/api/v1/artists/1/availability', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ unavailable_dates: [] }),
+      });
+    });
+  });
+
+  test('advances to location step', async ({ page }) => {
+    await page.goto('/booking?artist_id=1&service_id=1');
+    await expect(page.getByTestId('step-heading')).toHaveText(/Date & Time/);
+    await page.getByTestId('date-next-button').click();
+    await expect(page.getByTestId('step-heading')).toHaveText(/Location/);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@eslint/eslintrc": "^3.3.1",
+        "@playwright/test": "^1.52.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.10.0",
         "@types/react": "^18.2.38",
@@ -3010,6 +3011,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-google-maps/api": {
@@ -9131,6 +9148,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "pretest": "npm install",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
@@ -18,6 +19,7 @@
     "axios": "^1.6.2",
     "clsx": "^2.1.0",
     "date-fns": "^2.30.0",
+    "framer-motion": "^12.16.0",
     "next": "^14.2.29",
     "react": "^18.2.0",
     "react-calendar": "^6.0.0",
@@ -26,14 +28,14 @@
     "react-hot-toast": "^2.4.1",
     "react-image-crop": "^11.0.10",
     "react-swipeable-list": "^1.10.0",
-    "yup": "^1.3.2",
-    "framer-motion": "^12.16.0"
+    "yup": "^1.3.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@eslint/eslintrc": "^3.3.1",
+    "@playwright/test": "^1.52.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.38",
@@ -45,12 +47,12 @@
     "babel-jest": "^29.7.0",
     "eslint": "^8.54.0",
     "eslint-config-next": "14.0.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.2",
-    "identity-obj-proxy": "^3.0.0"
+    "typescript": "^5.3.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './frontend/e2e',
+  use: {
+    browserName: 'chromium',
+    viewport: devices['Pixel 5'].viewport,
+  },
+  webServer: {
+    command: 'npm run dev -- -p 3000',
+    cwd: './frontend',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -6,4 +6,5 @@ cd "$DIR"
 pytest -q
 cd frontend
 npm test
+npm run test:e2e
 npm run lint >/dev/null


### PR DESCRIPTION
## Summary
- install Playwright and add basic mobile e2e test
- document how to run e2e tests
- run Playwright test in `scripts/test-all.sh`

## Testing
- `./scripts/test-all.sh` *(fails: playwright browsers could not download in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0c1aebc832e937ddd9a0f732ea6