### PR TITLE
Fix e2e test invocation

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -6,5 +6,6 @@ cd "$DIR"
 pytest -q
 cd frontend
 npm test
-npm run test:e2e
 npm run lint >/dev/null
+cd ..
+npx --prefix frontend playwright test -c playwright.config.ts


### PR DESCRIPTION
## Summary
- update test script so Playwright runs using the repo config

## Testing
- `pytest -q`
- `npm test`
- `npm run lint`
- `npx --prefix frontend playwright test -c playwright.config.ts` *(fails: Playwright not found / next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2f90c40832e8f646726618b86c1