### PR TITLE
Fix failing test workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,13 +114,15 @@ For setup instructions see [README.md](README.md).
 * Place new logic in an appropriate backend API/service or frontend component/hook/context.
 * Update this file to keep documentation current for all automation and agent logic.
 * Ensure each new agent is integrated with relevant booking, notification, or chat workflows as needed.
-* Run `./scripts/test-all.sh` before committing changes to ensure backend and frontend tests pass.
+* Run `./scripts/test-all.sh` before committing changes to ensure backend and
+  frontend tests pass. The script now calls Jest and Playwright via Node so it
+  works even when `node_modules/.bin` is missing.
 
 ---
 
 ## Last Updated
 
-2025-06-08
+2025-06-09
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir -r requirements-dev.txt
 
 # Install Node dependencies
-RUN cd frontend && npm ci && npm cache clean --force
+RUN cd frontend && npm ci --no-progress && npm cache clean --force
 
 # Copy source code
 COPY . .

--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ npm run lint
 ```bash
 ./scripts/test-all.sh
 ```
-This script runs `pytest`, `npm test`, `npx playwright test`, and `npm run lint`.
-`setup.sh` now skips dependency installation when `frontend/node_modules` and the
-required Python packages are already present, so repeated test runs are much
-faster. End-to-end tests in `frontend/e2e` use [Playwright](https://playwright.dev/)
-to launch the Next.js development server and walk through the Booking Wizard.
+This script runs `pytest`, executes Jest and Playwright using Node, and finally
+`npm run lint`. Running the CLIs directly avoids missing binary errors when
+`node_modules/.bin` links are not created. `setup.sh` skips dependency
+installation when packages are already present so repeated test runs are much
+faster. End-to-end tests in `frontend/e2e` use
+[Playwright](https://playwright.dev/) to launch the Next.js development server
+and walk through the Booking Wizard.
 
 You can also run the tests inside the Docker image if you prefer not to install
 anything locally:

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -5,7 +5,9 @@ cd "$DIR"
 ./setup.sh >/dev/null
 pytest -q
 cd frontend
-npm test
+# Use node directly so tests run even when node_modules/.bin is missing
+node node_modules/jest/bin/jest.js --runInBand --silent
 npm run lint >/dev/null
 cd ..
-npx --prefix frontend playwright test -c playwright.config.ts
+# Run Playwright with NODE_PATH so the config can import the package
+NODE_PATH="$(pwd)/frontend/node_modules" npx --prefix frontend playwright test -c playwright.config.ts

--- a/setup.sh
+++ b/setup.sh
@@ -11,10 +11,15 @@ if ! python -c "import fastapi" >/dev/null 2>&1; then
 fi
 
 echo "Installing frontend Node dependencies..."
-if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
+if [ ! -d "$ROOT_DIR/frontend/node_modules/.bin" ]; then
   pushd "$ROOT_DIR/frontend" > /dev/null
-  npm ci
+  npm ci --silent
   popd > /dev/null
+fi
+
+if [ ! -d "$HOME/.cache/ms-playwright" ]; then
+  echo "Installing Playwright browsers..."
+  npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null
 fi
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- ensure Playwright browsers get installed in setup script
- run Jest and Playwright directly from node_modules in scripts/test-all.sh
- add NODE_PATH so Playwright config resolves dependencies
- update Dockerfile to reduce npm output
- document new workflow in README and AGENTS docs

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846ae2db1f4832ebb41286f8def93ef