### PR TITLE
Improve offline test setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && apt-get install -y curl gnupg && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Disable Next.js telemetry and Playwright downloads for offline CI
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 WORKDIR /app
 
 # Copy package manifests separately for caching

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ docker build -t booking-app:latest .
 docker run --rm booking-app:latest ./scripts/test-all.sh
 ```
 
+If your CI environment has no external network access, build the image ahead of
+time with connectivity so all dependencies and Playwright browsers are cached.
+You can then run the tests offline:
+
+```bash
+docker run --rm --network none booking-app:latest ./scripts/test-all.sh
+```
+
 ### Build
 
 ```bash

--- a/frontend/e2e/mobile-booking.spec.ts
+++ b/frontend/e2e/mobile-booking.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '@playwright/test';
 
+// TODO: Add additional request stubs here when new endpoints are introduced.
+// Keeping tests fully offline ensures they run in restricted Docker networks.
+
 test.describe('Booking Wizard mobile flow', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/v1/artists/1', async (route) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,5 +12,9 @@ export default defineConfig({
     port: 3000,
     timeout: 120 * 1000,
     reuseExistingServer: true,
+    env: {
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+    // TODO: verify no external calls are made during tests when CI blocks network
   },
 });

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -10,4 +10,6 @@ node node_modules/jest/bin/jest.js --runInBand --silent
 npm run lint >/dev/null
 cd ..
 # Run Playwright with NODE_PATH so the config can import the package
-NODE_PATH="$(pwd)/frontend/node_modules" npx --prefix frontend playwright test -c playwright.config.ts
+NODE_PATH="$(pwd)/frontend/node_modules" \
+NEXT_TELEMETRY_DISABLED=1 \
+  npx --prefix frontend playwright test -c playwright.config.ts

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,14 @@ if [ ! -d "$ROOT_DIR/frontend/node_modules/.bin" ]; then
   popd > /dev/null
 fi
 
+# Build Next.js once so Playwright can run offline
+if [ ! -d "$ROOT_DIR/frontend/.next" ]; then
+  echo "Building frontend..."
+  pushd "$ROOT_DIR/frontend" > /dev/null
+  NEXT_TELEMETRY_DISABLED=1 npm run build --silent
+  popd > /dev/null
+fi
+
 if [ ! -d "$HOME/.cache/ms-playwright" ]; then
   echo "Installing Playwright browsers..."
   npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null


### PR DESCRIPTION
## Summary
- disable Next.js telemetry and Playwright downloads in Docker
- build frontend during setup for offline tests
- allow offline Playwright runs
- note offline test workflow in README
- hint at additional request stubbing

## Testing
- `./scripts/test-all.sh` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1169/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_6846b45b6290832e9d8956cc13907c9f