### PR TITLE
Fix Playwright browser install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN cd frontend && npm ci --no-progress && npm cache clean --force
 # Copy source code
 COPY . .
 
-# Install Playwright browsers
-RUN npx playwright install --with-deps
+# Install Playwright browsers once at build time. PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
+# is normally set to skip downloads in CI, so override it here.
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx playwright install --with-deps
 
 EXPOSE 8000 3000
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ docker build -t booking-app:latest .
 docker run --rm -p 3000:3000 -p 8000:8000 booking-app:latest
 ```
 
-The container installs all Python and Node dependencies, including Playwright browsers. Use a volume mount to iterate locally:
+The container installs all Python and Node dependencies. Playwright browsers are
+downloaded during the image build so tests can run offline. Use a volume mount
+to iterate locally:
 
 ```bash
 docker run --rm -v "$(pwd)":/app -p 3000:3000 -p 8000:8000 booking-app:latest
@@ -130,7 +132,9 @@ docker run --rm booking-app:latest ./scripts/test-all.sh
 
 If your CI environment has no external network access, build the image ahead of
 time with connectivity so all dependencies and Playwright browsers are cached.
-You can then run the tests offline:
+The Dockerfile explicitly installs browsers during the build by overriding
+`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`, so offline containers have everything
+needed. You can then run the tests offline:
 
 ```bash
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -155,7 +155,11 @@ export default function DashboardPage() {
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
   // Future activity feed will populate this array with events
-  const [events] = useState<unknown[]>([]);
+  const [events] = useState<Array<{
+    id: string | number;
+    timestamp: string;
+    description: string;
+  }>>([]);
   const [showAllRequests, setShowAllRequests] = useState(false);
   const [showAllBookings, setShowAllBookings] = useState(false);
 
@@ -397,9 +401,14 @@ export default function DashboardPage() {
                       </div>
                       <span className="text-2xl font-semibold text-gray-900">{servicesCount}</span>
                     </Link>,
-                    servicesCount === 0 && (
-                      <p className="text-xs text-gray-400 mt-2">No services added yet</p>
-                    ),
+                  );
+                  if (servicesCount === 0) {
+                    cards.push(
+                      <p key="services-empty" className="text-xs text-gray-400 mt-2">No services added yet</p>,
+                    );
+                  }
+
+                  cards.push(
                     <Link
                       key="earnings"
                       href="/earnings"
@@ -413,9 +422,14 @@ export default function DashboardPage() {
                         {'$' + totalEarnings.toFixed(2)}
                       </span>
                     </Link>,
-                    totalEarnings === 0 && (
-                      <p className="text-xs text-gray-400 mt-2">No earnings this month</p>
-                    ),
+                  );
+                  if (totalEarnings === 0) {
+                    cards.push(
+                      <p key="earnings-empty" className="text-xs text-gray-400 mt-2">No earnings this month</p>,
+                    );
+                  }
+
+                  cards.push(
                     <Link
                       key="earnings-month"
                       href="/earnings"
@@ -429,10 +443,12 @@ export default function DashboardPage() {
                         {'$' + earningsThisMonth.toFixed(2)}
                       </span>
                     </Link>,
-                    earningsThisMonth === 0 && (
-                      <p className="text-xs text-gray-400 mt-2">No earnings yet</p>
-                    )
                   );
+                  if (earningsThisMonth === 0) {
+                    cards.push(
+                      <p key="earnings-month-empty" className="text-xs text-gray-400 mt-2">No earnings yet</p>,
+                    );
+                  }
                 }
                 return cards.map((card, i) => (
                   <motion.div

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,14 +7,16 @@ export default defineConfig({
     viewport: devices['Pixel 5'].viewport,
   },
   webServer: {
-    command: 'npm run dev -- -p 3000',
+    // Use the production build for faster startup in Docker.
+    command: 'npm run start -- -p 3000',
     cwd: './frontend',
     port: 3000,
-    timeout: 120 * 1000,
+    timeout: 60 * 1000,
     reuseExistingServer: true,
     env: {
       NEXT_TELEMETRY_DISABLED: '1',
     },
     // TODO: verify no external calls are made during tests when CI blocks network
+    // TODO: stub all API requests here to keep tests fully offline
   },
 });

--- a/setup.sh
+++ b/setup.sh
@@ -25,9 +25,10 @@ if [ ! -d "$ROOT_DIR/frontend/.next" ]; then
   popd > /dev/null
 fi
 
-if [ ! -d "$HOME/.cache/ms-playwright" ]; then
+PLAYWRIGHT_SHELL="$(ls -d "$HOME"/.cache/ms-playwright/chromium* 2>/dev/null | head -n 1)/chrome-linux/headless_shell"
+if [ ! -f "$PLAYWRIGHT_SHELL" ]; then
   echo "Installing Playwright browsers..."
-  npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null
 fi
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- ensure browsers install during Docker build
- document that browsers are cached during the build
- speed up Playwright server startup
- check browser install in setup
- fix event typing in dashboard

## Testing
- `NEXT_TELEMETRY_DISABLED=1 npm run build` *(fails: could not find a production build)*
- `./scripts/test-all.sh` *(failed: browser missing)*


------
https://chatgpt.com/codex/tasks/task_e_6846be5b540c832ead46bfbb4ce22288