### PR TITLE
Improve offline Playwright setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN cd frontend && npm ci --no-progress && npm cache clean --force
 COPY . .
 
 # Install Playwright browsers once at build time. PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
-# is normally set to skip downloads in CI, so override it here.
+# is normally set to skip downloads in CI, so override it here. The setup script
+# will reuse this cache if browsers are already present.
 RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx playwright install --with-deps
 
 EXPOSE 8000 3000

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ If your CI environment has no external network access, build the image ahead of
 time with connectivity so all dependencies and Playwright browsers are cached.
 The Dockerfile explicitly installs browsers during the build by overriding
 `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`, so offline containers have everything
-needed. You can then run the tests offline:
+needed. The `setup.sh` script installs browsers only when missing, so repeat runs
+are fast even when network access is blocked. You can then run the tests offline:
 
 ```bash
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import type { Control, FieldValues } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import * as yup from 'yup';
 import { format } from 'date-fns';
@@ -203,7 +204,7 @@ export default function BookingWizard({
       case 0:
         return (
           <DateTimeStep
-            control={control}
+            control={control as unknown as Control<FieldValues>}
             unavailable={unavailable}
             watch={watch}
             onNext={next}
@@ -212,18 +213,24 @@ export default function BookingWizard({
       case 1:
         return (
           <LocationStep
-            control={control}
+            control={control as unknown as Control<FieldValues>}
             artistLocation={artistLocation || undefined}
             setWarning={setWarning}
             onNext={next}
           />
         );
       case 2:
-        return <GuestsStep control={control} onNext={next} />;
+        return <GuestsStep control={control as unknown as Control<FieldValues>} onNext={next} />;
       case 3:
-        return <VenueStep control={control} onNext={next} />;
+        return <VenueStep control={control as unknown as Control<FieldValues>} onNext={next} />;
       case 4:
-        return <NotesStep control={control} setValue={setValue} onNext={next} />;
+        return (
+          <NotesStep
+            control={control as unknown as Control<FieldValues>}
+            setValue={setValue}
+            onNext={next}
+          />
+        );
       default:
         return (
           <ReviewStep

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,8 @@ if [ ! -d "$ROOT_DIR/frontend/.next" ]; then
   popd > /dev/null
 fi
 
-PLAYWRIGHT_SHELL="$(ls -d "$HOME"/.cache/ms-playwright/chromium* 2>/dev/null | head -n 1)/chrome-linux/headless_shell"
+PLAYWRIGHT_DIR=$(ls -d "$HOME"/.cache/ms-playwright/chromium* 2>/dev/null | head -n 1 || true)
+PLAYWRIGHT_SHELL="$PLAYWRIGHT_DIR/chrome-linux/headless_shell"
 if [ ! -f "$PLAYWRIGHT_SHELL" ]; then
   echo "Installing Playwright browsers..."
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null


### PR DESCRIPTION
## Summary
- check the browser cache more safely in `setup.sh`
- clarify browser cache usage in Dockerfile
- note offline install behavior in README
- cast React Hook Form control when rendering booking steps

## Testing
- `pytest -q` *(fails: KeyboardInterrupt due to environment)*
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ./scripts/test-all.sh` *(failed: npm warnings, no output)*

------
https://chatgpt.com/codex/tasks/task_e_6846c8290324832ea1fc6f1f78cd6432