### PR TITLE
Add clarifying note on offline test caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ modules, and Playwright browsers so `test-all.sh` can run entirely offline:
 docker build -t booking-app:latest .  # build once with connectivity
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 ```
+When running tests from this pre-built image, `setup.sh` detects the cached
+Python packages, Node modules, and Playwright browsers and therefore skips
+any downloads. This allows repeated test executions without network access.
 
 ### Build
 


### PR DESCRIPTION
## Summary
- clarify how `setup.sh` reuses cached dependencies when tests run from the Docker image

## Testing
- `n/a` (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6846dc38ab54832e8ad77a001c653464