### PR TITLE
Update CI scripts and Playwright configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ cd frontend
 npm run build
 ```
 
+## Docker CI
+
+```bash
+# Build once (with network)
+docker build -t booking-app:ci .
+
+# Run all tests offline (unit & e2e, Chrome/Firefox/WebKit)
+docker run --rm --network none booking-app:ci
+```
+
+Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
+
 ---
 
 ## New Features

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,13 +2,16 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './frontend/e2e',
-  use: {
-    browserName: 'chromium',
-    viewport: devices['Pixel 5'].viewport,
-  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox',  use: { browserName: 'firefox'  } },
+    { name: 'webkit',   use: { browserName: 'webkit'   } },
+  ],
+  workers: 2,
+  use: { headless: true, video: 'off', screenshot: 'off' },
   webServer: {
-    // Use the dev server so type errors don't stop tests.
-    command: 'npm run dev -- -p 3000',
+    // Use a production build for reliable offline testing.
+    command: 'npm run build && npm run start -- -p 3000',
     cwd: './frontend',
     port: 3000,
     timeout: 60 * 1000,

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,15 +1,16 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euxo pipefail
+echo "--- STARTING test-all.sh ---"
 DIR=$(dirname "$0")/..
 cd "$DIR"
-./setup.sh >/dev/null
+./setup.sh
 pytest -q
 cd frontend
 # Use node directly so tests run even when node_modules/.bin is missing
-node node_modules/jest/bin/jest.js --runInBand --silent
+node node_modules/jest/bin/jest.js --maxWorkers=50%
 npm run lint >/dev/null
 cd ..
 # Run Playwright with NODE_PATH so the config can import the package
 NODE_PATH="$(pwd)/frontend/node_modules" \
 NEXT_TELEMETRY_DISABLED=1 \
-  npx --prefix frontend playwright test -c playwright.config.ts
+  npx --prefix frontend playwright test --workers=2 -c playwright.config.ts

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -euxo pipefail
+echo "--- STARTING setup.sh ---"
 
 # Determine the repository root so the script works from any directory.
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
- show startup logs in `setup.sh` and `test-all.sh`
- run Jest and Playwright in parallel
- expand Playwright config for multiple browsers
- convert to multi-stage Dockerfile for offline CI
- document Docker CI usage

## Testing
- `./scripts/test-all.sh` *(fails: Next.js build type error)*

------
https://chatgpt.com/codex/tasks/task_e_6846e813c6b0832e83584b2116f5faad