### PR TITLE
Fix api interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ NEXT_PUBLIC_API_URL=http://192.168.3.203:8000
 NEXT_PUBLIC_WS_URL=ws://192.168.3.203:8000
 ```
 
+The frontend automatically attaches an `Authorization` header when a token
+exists in the browser's `localStorage`. The request interceptor now verifies
+`typeof window !== 'undefined'` before accessing `localStorage`, so server-side
+rendering and tests that lack a `window` object no longer fail.
+
 ---
 
 ## Development

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,33 @@
+import api from '../api';
+import type { AxiosRequestConfig } from 'axios';
+
+describe('request interceptor', () => {
+  const handler = (api as any).interceptors.request.handlers[0].fulfilled;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('adds Authorization header when token present', () => {
+    localStorage.setItem('token', 'abc');
+    const config: AxiosRequestConfig = { headers: {} };
+    const result = handler(config);
+    expect(result.headers!.Authorization).toBe('Bearer abc');
+  });
+
+  it('removes Authorization header when token missing', () => {
+    const config: AxiosRequestConfig = { headers: { Authorization: 'old' } };
+    const result = handler(config);
+    expect(result.headers!.Authorization).toBeUndefined();
+  });
+
+  it('returns config when window is undefined', () => {
+    const g = global as any;
+    const win = g.window;
+    delete g.window;
+    const config: AxiosRequestConfig = { headers: {} };
+    expect(() => handler(config)).not.toThrow();
+    expect(config.headers!.Authorization).toBeUndefined();
+    g.window = win;
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,9 +31,13 @@ const api = axios.create({
 // Automatically attach the bearer token (if present) to every request
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      } else if (config.headers && 'Authorization' in config.headers) {
+        delete config.headers.Authorization;
+      }
     }
     return config;
   },


### PR DESCRIPTION
## Summary
- safely access localStorage in request interceptor
- document interceptor behavior in README
- add tests for the axios interceptor

## Testing
- `./scripts/test-all.sh` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6846eca92b00832ebd76b6e0ef27a55b