### PR TITLE
Remove Playwright from tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,8 +115,8 @@ For setup instructions see [README.md](README.md).
 * Update this file to keep documentation current for all automation and agent logic.
 * Ensure each new agent is integrated with relevant booking, notification, or chat workflows as needed.
 * Run `./scripts/test-all.sh` before committing changes to ensure backend and
-  frontend tests pass. The script now calls Jest and Playwright via Node so it
-  works even when `node_modules/.bin` is missing.
+  frontend tests pass. The script calls Jest via Node so it works even when
+  `node_modules/.bin` is missing.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
 COPY frontend/package.json frontend/package-lock.json ./frontend/
 WORKDIR /app/frontend
 RUN npm ci --silent && npm run build --silent
-RUN npx playwright install --with-deps
 
 # final stage
 FROM python:3.11-slim

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ docker build -t booking-app:latest .
 docker run --rm -p 3000:3000 -p 8000:8000 booking-app:latest
 ```
 
-The container installs all Python and Node dependencies. Playwright browsers are
-downloaded during the image build so tests can run offline. Use a volume mount
+The container installs all Python and Node dependencies. Use a volume mount
 to iterate locally:
 
 ```bash
@@ -119,13 +118,11 @@ npm run lint
 ```bash
 ./scripts/test-all.sh
 ```
-This script runs `pytest`, executes Jest and Playwright using Node, and finally
+This script runs `pytest`, executes Jest using Node, and finally
 `npm run lint`. Running the CLIs directly avoids missing binary errors when
 `node_modules/.bin` links are not created. `setup.sh` skips dependency
 installation when packages are already present so repeated test runs are much
-faster. End-to-end tests in `frontend/e2e` use
-[Playwright](https://playwright.dev/) to launch the Next.js development server
-and walk through the Booking Wizard.
+faster.
 
 You can also run the tests inside the Docker image if you prefer not to install
 anything locally:
@@ -136,11 +133,9 @@ docker run --rm booking-app:latest ./scripts/test-all.sh
 ```
 
 If your CI environment has no external network access, build the image ahead of
-time with connectivity so all dependencies and Playwright browsers are cached.
-The Dockerfile explicitly installs browsers during the build by overriding
-`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`, so offline containers have everything
-needed. The `setup.sh` script installs browsers only when missing, so repeat runs
-are fast even when network access is blocked. You can then run the tests offline:
+time with connectivity so all dependencies are cached. The `setup.sh` script
+skips downloads when packages are already present, so repeat runs are fast even
+when network access is blocked. You can then run the tests offline:
 
 ```bash
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh
@@ -150,16 +145,16 @@ docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 
 If `setup.sh` fails because dependencies cannot be installed (such as in an
 isolated CI environment), build the Docker image once with network access and
-reuse it for subsequent test runs. The image caches Python packages, Node
-modules, and Playwright browsers so `test-all.sh` can run entirely offline:
+reuse it for subsequent test runs. The image caches Python packages and Node
+modules so `test-all.sh` can run entirely offline:
 
 ```bash
 docker build -t booking-app:latest .  # build once with connectivity
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 ```
 When running tests from this pre-built image, `setup.sh` detects the cached
-Python packages, Node modules, and Playwright browsers and therefore skips
-any downloads. This allows repeated test executions without network access.
+Python packages and Node modules and therefore skips any downloads. This
+allows repeated test executions without network access.
 
 ### Build
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,6 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@eslint/eslintrc": "^3.3.1",
-        "@playwright/test": "^1.52.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.10.0",
         "@types/react": "^18.2.38",
@@ -3017,8 +3016,9 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
       "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "playwright": "1.52.0"
       },
@@ -9154,8 +9154,9 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
       "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.52.0"
       },
@@ -9173,8 +9174,9 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
       "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9186,13 +9188,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "pretest": "test -d node_modules || npm install",
-    "test": "jest",
-    "test:e2e": "playwright test"
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
@@ -35,7 +34,6 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@eslint/eslintrc": "^3.3.1",
-    "@playwright/test": "^1.52.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.38",

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -10,7 +10,3 @@ cd frontend
 node node_modules/jest/bin/jest.js --maxWorkers=50%
 npm run lint >/dev/null
 cd ..
-# Run Playwright with NODE_PATH so the config can import the package
-NODE_PATH="$(pwd)/frontend/node_modules" \
-NEXT_TELEMETRY_DISABLED=1 \
-  npx --prefix frontend playwright test --workers=2 -c playwright.config.ts

--- a/setup.sh
+++ b/setup.sh
@@ -18,19 +18,6 @@ if [ ! -d "$ROOT_DIR/frontend/node_modules/.bin" ]; then
   popd > /dev/null
 fi
 
-# Build Next.js once so Playwright can run offline
-if [ ! -d "$ROOT_DIR/frontend/.next" ]; then
-  echo "Building frontend..."
-  pushd "$ROOT_DIR/frontend" > /dev/null
-  NEXT_TELEMETRY_DISABLED=1 npm run build --silent
-  popd > /dev/null
-fi
 
-PLAYWRIGHT_DIR=$(ls -d "$HOME"/.cache/ms-playwright/chromium* 2>/dev/null | head -n 1 || true)
-PLAYWRIGHT_SHELL="$PLAYWRIGHT_DIR/chrome-linux/headless_shell"
-if [ ! -f "$PLAYWRIGHT_SHELL" ]; then
-  echo "Installing Playwright browsers..."
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx --prefix "$ROOT_DIR/frontend" playwright install --with-deps >/dev/null
-fi
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- drop Playwright install from Dockerfile and setup
- update test-all script to only run pytest, jest and lint
- remove Playwright from frontend package.json and lockfile
- scrub Playwright notes from documentation

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846ef572050832e87b49230f4a6e3b4