### PR TITLE
Add TODO markers for future artist feature upgrades

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -80,6 +80,7 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
         )
 
 
+# TODO: Add rate limiting and lockout after repeated failures
 @router.post("/login")
 def login(
     form_data: OAuth2PasswordRequestForm = Depends(),

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -155,6 +155,7 @@ export default function DashboardPage() {
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
   // Future activity feed will populate this array with events
+  // TODO: Display artist analytics like monthly bookings and earnings trends
   const [events] = useState<Array<{
     id: string | number;
     timestamp: string;

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -7,6 +7,7 @@ import MainLayout from '@/components/layout/MainLayout';
 import MobileSaveBar from '@/components/dashboard/MobileSaveBar';
 import { useAuth } from '@/contexts/AuthContext';
 import { ArtistProfile } from '@/types';
+// TODO: allow multiple portfolio images with drag-and-drop reordering
 import {
   getArtistProfileMe,
   updateMyArtistProfile,

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,4 +1,7 @@
+
 'use client';
+
+// TODO: Add multi-factor auth and "remember me" option for persistent sessions
 
 // Login form uses shared auth components and offers optional social login
 


### PR DESCRIPTION
## Summary
- add a reminder for multi-factor login
- note rate limiting in backend auth
- earmark analytics section in dashboard
- flag future portfolio uploader features

## Testing
- `./scripts/test-all.sh` *(fails: Installing frontend Node dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd2c6a40832eab1d357f558115c4