### PR TITLE
Improve setup.sh logging and node install

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ This script runs `pytest`, executes Jest using Node, and finally
 `node_modules/.bin` links are not created. `setup.sh` skips dependency
 installation when packages are already present so repeated test runs are much
 faster.
+The script drops a marker file `frontend/node_modules/.install_complete` after a
+successful `npm ci` so subsequent runs skip reinstalling dependencies unless
+that file is removed.
 
 You can also run the tests inside the Docker image if you prefer not to install
 anything locally:

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 echo "--- STARTING test-all.sh ---"
+echo "Using Node $(node --version) and npm $(npm --version)"
 DIR=$(dirname "$0")/..
 cd "$DIR"
 ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -11,10 +11,13 @@ if ! python -c "import fastapi" >/dev/null 2>&1; then
   pip install -r "$ROOT_DIR/requirements-dev.txt"
 fi
 
+echo "Node version: $(node --version), npm version: $(npm --version)"
 echo "Installing frontend Node dependencies..."
-if [ ! -d "$ROOT_DIR/frontend/node_modules/.bin" ]; then
+if [ ! -f "$ROOT_DIR/frontend/node_modules/.install_complete" ]; then
   pushd "$ROOT_DIR/frontend" > /dev/null
-  npm ci --silent
+  rm -rf node_modules
+  npm ci --no-progress
+  touch node_modules/.install_complete
   popd > /dev/null
 fi
 


### PR DESCRIPTION
## Summary
- add Node version logging and better node_modules handling in setup.sh
- show node/npm versions in test-all script
- document `.install_complete` marker in README

## Testing
- `./scripts/test-all.sh` *(fails: cannot find module '@jest/core')*

------
https://chatgpt.com/codex/tasks/task_e_6846ff6ec14c832e8264fdf467575c76