### PR TITLE
Allow configurable Jest workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ that file is removed. It also detects which files changed in Git and only runs
 the backend or frontend tests when necessary; documentation-only changes cause
 the script to exit immediately without running any tests.
 
+You can override the number of parallel Jest workers by setting the
+`JEST_WORKERS` environment variable:
+
+```bash
+JEST_WORKERS=75% ./scripts/test-all.sh
+```
+
 You can also run the tests inside the Docker image if you prefer not to install
 anything locally:
 

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -54,7 +54,9 @@ fi
 JEST_PATH=$(realpath "$JEST")
 echo "Using Jest at $JEST_PATH"
 node "$JEST_PATH" --version
-node "$JEST_PATH" --maxWorkers=50%
+JEST_WORKERS=${JEST_WORKERS:-50%}
+echo "Running frontend tests with --maxWorkers=$JEST_WORKERS"
+node "$JEST_PATH" --maxWorkers="$JEST_WORKERS"
 npm run lint >/dev/null
 popd >/dev/null
 fi


### PR DESCRIPTION
## Summary
- expose `JEST_WORKERS` env var in `test-all.sh`
- document how to use `JEST_WORKERS` in README

## Testing
- `./scripts/test-all.sh` *(fails: npm ci step interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68470a5f1c04832e9e5aec9bac25d7c7