### PR TITLE
Fix mobile booking buttons

### DIFF
--- a/frontend/src/components/booking/MobileActionBar.tsx
+++ b/frontend/src/components/booking/MobileActionBar.tsx
@@ -21,7 +21,7 @@ export default function MobileActionBar({
   submitting,
 }: Props) {
   return (
-    <div className="fixed bottom-0 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2">
+    <div className="fixed bottom-0 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2 z-[60]">
       {showBack ? (
         <Button variant="secondary" onClick={onBack} fullWidth>
           Back

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -58,16 +58,16 @@ describe('BookingWizard mobile scrolling', () => {
     expect(window.scrollTo).toHaveBeenCalled();
   });
 
-  it('renders inline next button on mobile', () => {
+  it('does not render inline next button on mobile', () => {
     const inline = container.querySelector('[data-testid="date-next-button"]');
-    expect(inline).not.toBeNull();
+    expect(inline).toBeNull();
   });
 
   it('shows step heading and updates on next', async () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;
     expect(heading()).toContain('Date & Time');
-    const next = container.querySelector('[data-testid="date-next-button"]') as HTMLButtonElement;
+    const next = container.querySelector('button') as HTMLButtonElement;
     await act(async () => {
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -75,31 +75,32 @@ describe('BookingWizard mobile scrolling', () => {
     expect(heading()).toContain('Location');
   });
 
-  it('shows confirm location button after advancing', async () => {
-    const inline = container.querySelector('[data-testid="date-next-button"]') as HTMLButtonElement;
+  it('advances to the location step without inline button', async () => {
+    const next = container.querySelector('button') as HTMLButtonElement;
     await act(async () => {
-      inline.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await new Promise((r) => setTimeout(r, 0));
-    const confirm = container.querySelector('[data-testid="location-next-button"]');
-    expect(confirm).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="location-next-button"]'),
+    ).toBeNull();
   });
 
-  it('shows inline buttons for all remaining steps', async () => {
-      const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
-    const expectButton = (testId: string) => {
-      expect(container.querySelector(`[data-testid="${testId}"]`)).not.toBeNull();
+  it('no inline action buttons exist for any step', async () => {
+    const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
+    const expectNoButton = (testId: string) => {
+      expect(container.querySelector(`[data-testid="${testId}"]`)).toBeNull();
     };
 
     await act(async () => { setStep(1); });
-    expectButton('location-next-button');
+    expectNoButton('location-next-button');
     await act(async () => { setStep(2); });
-    expectButton('guests-next-button');
+    expectNoButton('guests-next-button');
     await act(async () => { setStep(3); });
-    expectButton('venue-next-button');
+    expectNoButton('venue-next-button');
     await act(async () => { setStep(4); });
-    expectButton('notes-next-button');
+    expectNoButton('notes-next-button');
     await act(async () => { setStep(5); });
-    expectButton('review-submit-button');
+    expectNoButton('review-submit-button');
   });
 });

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -4,7 +4,6 @@ import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { format } from 'date-fns';
 import { enUS } from 'date-fns/locale';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 
 interface Props {
@@ -15,7 +14,6 @@ interface Props {
 }
 
 export default function DateTimeStep({ control, unavailable, watch, onNext }: Props) {
-  const isMobile = useIsMobile();
   const tileDisabled = ({ date }: { date: Date }) => {
     const day = format(date, 'yyyy-MM-dd');
     return unavailable.includes(day) || date < new Date();
@@ -46,13 +44,7 @@ export default function DateTimeStep({ control, unavailable, watch, onNext }: Pr
           )}
         />
       )}
-      {isMobile && (
-        <div>
-          <Button data-testid="date-next-button" onClick={onNext} fullWidth>
-            Next
-          </Button>
-        </div>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 
 interface Props {
@@ -9,7 +8,6 @@ interface Props {
 }
 
 export default function GuestsStep({ control, onNext }: Props) {
-  const isMobile = useIsMobile();
   return (
     <div className="space-y-2">
       <label className="block text-sm font-medium">Number of guests</label>
@@ -26,11 +24,7 @@ export default function GuestsStep({ control, onNext }: Props) {
           />
         )}
       />
-      {isMobile && (
-        <Button data-testid="guests-next-button" onClick={onNext} fullWidth>
-          Next
-        </Button>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -3,7 +3,6 @@ import { Controller, Control, FieldValues } from 'react-hook-form';
 import { GoogleMap, Marker, useLoadScript, Autocomplete } from '@react-google-maps/api';
 import { useRef, useState, useEffect } from 'react';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 
 interface Props {
@@ -28,7 +27,6 @@ export default function LocationStep({
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
   const [marker, setMarker] = useState<LatLng | null>(null);
   const [geoError, setGeoError] = useState<string | null>(null);
-  const isMobile = useIsMobile();
 
   useEffect(() => {
     (async () => {
@@ -96,11 +94,7 @@ export default function LocationStep({
         Use my location
       </button>
       {geoError && <p className="text-red-600 text-sm">{geoError}</p>}
-      {isMobile && (
-        <Button data-testid="location-next-button" onClick={onNext} fullWidth>
-          Confirm Location
-        </Button>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 import { uploadBookingAttachment } from '@/lib/api';
 
@@ -11,7 +10,6 @@ interface Props {
 }
 
 export default function NotesStep({ control, setValue, onNext }: Props) {
-  const isMobile = useIsMobile();
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -44,11 +42,7 @@ export default function NotesStep({ control, setValue, onNext }: Props) {
       />
       <label className="block text-sm font-medium">Attachment (optional)</label>
       <input type="file" onChange={handleFileChange} />
-      {isMobile && (
-        <Button data-testid="notes-next-button" onClick={onNext} fullWidth>
-          Next
-        </Button>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useBooking } from '@/contexts/BookingContext';
 import { format } from 'date-fns';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 
 interface Props {
@@ -16,7 +15,6 @@ export default function ReviewStep({
   submitting,
 }: Props) {
   const { details } = useBooking();
-  const isMobile = useIsMobile();
   return (
     <div className="space-y-2">
       <h3 className="text-lg font-medium">Review Details</h3>
@@ -51,27 +49,7 @@ export default function ReviewStep({
       <p className="text-gray-600 text-sm">
         Please confirm the information above before sending your request.
       </p>
-      {isMobile && (
-        <div className="flex space-x-2">
-          <Button
-            data-testid="review-save-button"
-            variant="secondary"
-            onClick={onSaveDraft}
-            fullWidth
-          >
-            Save Draft
-          </Button>
-          <Button
-            data-testid="review-submit-button"
-            onClick={onSubmit}
-            fullWidth
-            disabled={submitting}
-            className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
-          >
-            {submitting ? 'Submitting...' : 'Submit'}
-          </Button>
-        </div>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
-import useIsMobile from '@/hooks/useIsMobile';
 import Button from '../../ui/Button';
 
 interface Props {
@@ -9,7 +8,6 @@ interface Props {
 }
 
 export default function VenueStep({ control, onNext }: Props) {
-  const isMobile = useIsMobile();
   return (
     <div className="space-y-2">
       <label className="block text-sm font-medium">Venue type</label>
@@ -24,11 +22,7 @@ export default function VenueStep({ control, onNext }: Props) {
           </select>
         )}
       />
-      {isMobile && (
-        <Button data-testid="venue-next-button" onClick={onNext} fullWidth>
-          Next
-        </Button>
-      )}
+      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- prevent the mobile nav from covering booking wizard actions
- remove step-specific mobile buttons and update tests

## Testing
- `./scripts/test-all.sh` *(fails: npm install ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68471df05090832e93d67378ef1b5e90