### PR TITLE
Adjust mobile action bar position

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -244,7 +244,7 @@ export default function BookingWizard({
 
   return (
     <div className="lg:flex lg:space-x-4">
-      <div className="flex-1 space-y-4 pb-16 lg:pb-0">
+      <div className="flex-1 space-y-4 pb-32 lg:pb-0">
         <Stepper steps={steps} currentStep={step} />
         <h2 className="text-xl font-semibold" data-testid="step-heading">
           {steps[step]}

--- a/frontend/src/components/booking/MobileActionBar.tsx
+++ b/frontend/src/components/booking/MobileActionBar.tsx
@@ -21,21 +21,21 @@ export default function MobileActionBar({
   submitting,
 }: Props) {
   return (
-    <div className="fixed bottom-0 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2 z-[60]">
+    <div className="fixed bottom-14 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2 z-[70]">
       {showBack ? (
-        <Button variant="secondary" onClick={onBack} fullWidth>
+        <Button variant="secondary" onClick={onBack} fullWidth data-testid="mobile-back-button">
           Back
         </Button>
       ) : (
         <div className="flex-1" />
       )}
       {showNext ? (
-        <Button onClick={onNext} fullWidth>
+        <Button onClick={onNext} fullWidth data-testid="mobile-next-button">
           Next
         </Button>
       ) : (
         <div className="flex flex-1 space-x-2">
-          <Button variant="secondary" onClick={onSaveDraft} fullWidth>
+          <Button variant="secondary" onClick={onSaveDraft} fullWidth data-testid="mobile-save-button">
             Save Draft
           </Button>
           <Button
@@ -43,6 +43,7 @@ export default function MobileActionBar({
             disabled={submitting}
             className="bg-green-600 hover:bg-green-700 focus:ring-green-500"
             fullWidth
+            data-testid="mobile-submit-button"
           >
             {submitting ? 'Submitting...' : 'Submit'}
           </Button>

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -51,7 +51,7 @@ describe('BookingWizard mobile scrolling', () => {
   });
 
   it('scrolls to top when advancing steps', async () => {
-    const nextButton = container.querySelector('button') as HTMLButtonElement;
+    const nextButton = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
     await act(async () => {
       nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -67,7 +67,7 @@ describe('BookingWizard mobile scrolling', () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;
     expect(heading()).toContain('Date & Time');
-    const next = container.querySelector('button') as HTMLButtonElement;
+    const next = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
     await act(async () => {
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -76,7 +76,7 @@ describe('BookingWizard mobile scrolling', () => {
   });
 
   it('advances to the location step without inline button', async () => {
-    const next = container.querySelector('button') as HTMLButtonElement;
+    const next = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
     await act(async () => {
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });


### PR DESCRIPTION
## Summary
- keep the BookingWizard mobile action bar above the bottom nav
- add test IDs to MobileActionBar buttons
- update tests to use the fixed action bar

## Testing
- `./scripts/test-all.sh` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6847224764e8832e9bf2fafc0bd14a69