### PR TITLE
Add Docker-based test script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@ For setup instructions see [README.md](README.md).
 * Run `./scripts/test-all.sh` before committing changes to ensure backend and
   frontend tests pass. The script calls Jest via Node so it works even when
   `node_modules/.bin` is missing.
+* If network access is limited, use the pre-built Docker image by running
+  `./scripts/docker-test.sh`. Set `BOOKING_APP_IMAGE` to override the default
+  registry path.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 
 ## Docker Setup
 
-Build the image and run the development servers inside a container:
+Pull the pre-built image or build it yourself, then run the development
+servers inside a container:
+
+```bash
+docker pull ghcr.io/example-org/booking-app-ci:latest # optional pre-built image
+docker run --rm -p 3000:3000 -p 8000:8000 ghcr.io/example-org/booking-app-ci:latest
+```
+
+If you prefer to build locally instead, run:
 
 ```bash
 docker build -t booking-app:latest .
@@ -162,9 +170,11 @@ docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 ### Offline Testing with Docker
 
 If `setup.sh` fails because dependencies cannot be installed (such as in an
-isolated CI environment), build the Docker image once with network access and
-reuse it for subsequent test runs. The image caches Python packages and Node
-modules so `test-all.sh` can run entirely offline:
+isolated CI environment), you can pull a pre-built image that already contains
+all Python and Node dependencies. This avoids the slow `npm ci` step.
+Alternatively, build the image once with network access and reuse it for
+subsequent test runs. The image caches Python packages and Node modules so
+`test-all.sh` can run entirely offline:
 
 ```bash
 docker build -t booking-app:latest .  # build once with connectivity
@@ -173,6 +183,15 @@ docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 When running tests from this pre-built image, `setup.sh` detects the cached
 Python packages and Node modules and therefore skips any downloads. This
 allows repeated test executions without network access.
+
+You can also pull a pre-built image from our container registry and run the
+test script in one step:
+
+```bash
+./scripts/docker-test.sh
+```
+Set the `BOOKING_APP_IMAGE` environment variable if you want to use a different
+tag or registry location.
 
 ### Build
 

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+IMAGE=${BOOKING_APP_IMAGE:-ghcr.io/example-org/booking-app-ci:latest}
+SCRIPT=${TEST_SCRIPT:-./scripts/test-all.sh}
+
+echo "Pulling $IMAGE"
+docker pull "$IMAGE"
+
+echo "Running tests in $IMAGE"
+docker run --rm -v "$(pwd)":/app "$IMAGE" bash -lc "$SCRIPT"


### PR DESCRIPTION
## Summary
- add a `docker-test.sh` helper
- document pre-built Docker image usage in README and AGENTS docs

## Testing
- `./scripts/test-all.sh` *(fails: Installing frontend Node dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_684724c834e8832ea7bb5f3ffc7544ef