### PR TITLE
Improve docker test helper usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ For setup instructions see [README.md](README.md).
   `node_modules/.bin` is missing.
 * If network access is limited, use the pre-built Docker image by running
   `./scripts/docker-test.sh`. Set `BOOKING_APP_IMAGE` to override the default
-  registry path.
+  registry path. The script runs the container with `--network none` by default;
+  export `DOCKER_TEST_NETWORK=bridge` if tests require connectivity.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ docker pull ghcr.io/example-org/booking-app-ci:latest # optional pre-built image
 docker run --rm -p 3000:3000 -p 8000:8000 ghcr.io/example-org/booking-app-ci:latest
 ```
 
+To develop using the pre-built image without reinstalling dependencies, mount the repository and expose the ports:
+
+```bash
+docker run --rm -v "$(pwd)":/app -p 3000:3000 -p 8000:8000 ghcr.io/example-org/booking-app-ci:latest
+```
+
 If you prefer to build locally instead, run:
 
 ```bash
@@ -191,7 +197,8 @@ test script in one step:
 ./scripts/docker-test.sh
 ```
 Set the `BOOKING_APP_IMAGE` environment variable if you want to use a different
-tag or registry location.
+tag or registry location. Pass `DOCKER_TEST_NETWORK=bridge` if network access is
+needed during the test run.
 
 ### Build
 

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -2,9 +2,10 @@
 set -euxo pipefail
 IMAGE=${BOOKING_APP_IMAGE:-ghcr.io/example-org/booking-app-ci:latest}
 SCRIPT=${TEST_SCRIPT:-./scripts/test-all.sh}
+NETWORK=${DOCKER_TEST_NETWORK:-none}
 
 echo "Pulling $IMAGE"
 docker pull "$IMAGE"
 
 echo "Running tests in $IMAGE"
-docker run --rm -v "$(pwd)":/app "$IMAGE" bash -lc "$SCRIPT"
+docker run --rm --network "$NETWORK" -v "$(pwd)":/app "$IMAGE" bash -lc "$SCRIPT"


### PR DESCRIPTION
## Summary
- document how to run pre-built Docker image with volume mount
- explain optional network flag for docker tests
- enhance docker-test script to allow network configuration

## Testing
- `./scripts/test-all.sh` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684727ee5bec832ebca7d7f6f679753f