### PR TITLE
Improve mobile action bar responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * “Book Now” buttons on service cards.
 * New **Review** step showing cost breakdown and selections.
 * Success toasts when saving a draft or submitting a request.
+* Mobile action bar now adapts to scroll direction, staying above the bottom nav when visible and sliding down when the nav hides.
 
 ### Real-time Chat
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13,4 +13,7 @@
   body {
     @apply bg-white text-gray-900;
   }
-} 
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/frontend/src/components/booking/MobileActionBar.tsx
+++ b/frontend/src/components/booking/MobileActionBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from '../ui/Button';
+import useScrollDirection from '@/hooks/useScrollDirection';
 
 interface Props {
   showBack: boolean;
@@ -20,8 +21,12 @@ export default function MobileActionBar({
   onSubmit,
   submitting,
 }: Props) {
+  const scrollDir = useScrollDirection();
+  const bottomClass = scrollDir === 'down' ? 'bottom-0' : 'bottom-14';
   return (
-    <div className="fixed bottom-14 left-0 right-0 md:hidden bg-white border-t p-2 flex justify-between space-x-2 z-[70]">
+    <div
+      className={`fixed ${bottomClass} left-0 right-0 md:hidden bg-white border-t p-2 pb-safe flex justify-between space-x-2 z-[70]`}
+    >
       {showBack ? (
         <Button variant="secondary" onClick={onBack} fullWidth data-testid="mobile-back-button">
           Back

--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -52,4 +52,28 @@ describe('MobileActionBar', () => {
     expect(container.textContent).toContain('Save Draft');
     expect(container.textContent).toContain('Submit');
   });
+
+  it('moves to bottom when scrolling down', () => {
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    act(() => {
+      root.render(
+        React.createElement(MobileActionBar, {
+          showBack: false,
+          onBack: () => {},
+          showNext: true,
+          onNext: () => {},
+          onSaveDraft: () => {},
+          onSubmit: () => {},
+          submitting: false,
+        }),
+      );
+    });
+    const bar = container.querySelector('div');
+    expect(bar?.className).toContain('bottom-14');
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+    expect(bar?.className).toContain('bottom-0');
+  });
 });


### PR DESCRIPTION
## Summary
- adjust mobile action bar position based on scroll direction
- add safe area padding helper
- test mobile action bar scrolling behaviour
- document new behaviour in README

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68472f619898832e9d7d29ca1c39d1e0