### PR TITLE
Fix mobile action bar position

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * “Book Now” buttons on service cards.
 * New **Review** step showing cost breakdown and selections.
 * Success toasts when saving a draft or submitting a request.
-* Mobile action bar now adapts to scroll direction, staying above the bottom nav when visible, sliding down when the nav hides, and respecting safe-area insets via the `.pb-safe` utility.
+* Mobile action bar now adapts to scroll direction and lifts above the on-screen keyboard when inputs are focused, staying above the bottom nav when visible, sliding down when the nav hides, and respecting safe-area insets via the `.pb-safe` utility.
 
 ### Real-time Chat
 

--- a/frontend/src/components/booking/MobileActionBar.tsx
+++ b/frontend/src/components/booking/MobileActionBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '../ui/Button';
 import useScrollDirection from '@/hooks/useScrollDirection';
+import useKeyboardOffset from '@/hooks/useKeyboardOffset';
 
 interface Props {
   showBack: boolean;
@@ -22,10 +23,13 @@ export default function MobileActionBar({
   submitting,
 }: Props) {
   const scrollDir = useScrollDirection();
+  const keyboardOffset = useKeyboardOffset();
   const bottomClass = scrollDir === 'down' ? 'bottom-0' : 'bottom-14';
+  const style = keyboardOffset > 0 ? { transform: `translateY(-${keyboardOffset}px)` } : undefined;
   return (
     <div
       className={`fixed ${bottomClass} left-0 right-0 md:hidden bg-white border-t p-2 pb-safe flex justify-between space-x-2 z-[70]`}
+      style={style}
     >
       {showBack ? (
         <Button variant="secondary" onClick={onBack} fullWidth data-testid="mobile-back-button">

--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -94,4 +94,41 @@ describe('MobileActionBar', () => {
     const bar = container.querySelector('div');
     expect(bar?.className).toContain('pb-safe');
   });
+
+  it('translates up when the keyboard is visible', () => {
+    const resizeHandlers: Record<string, (() => void)[]> = {};
+    const vv = {
+      height: 800,
+      offsetTop: 0,
+      addEventListener: (event: string, cb: () => void) => {
+        resizeHandlers[event] = resizeHandlers[event] || [];
+        resizeHandlers[event].push(cb);
+      },
+      removeEventListener: () => {},
+    } as any;
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
+    Object.defineProperty(window, 'visualViewport', { value: vv, writable: true });
+
+    act(() => {
+      root.render(
+        React.createElement(MobileActionBar, {
+          showBack: false,
+          onBack: () => {},
+          showNext: true,
+          onNext: () => {},
+          onSaveDraft: () => {},
+          onSubmit: () => {},
+          submitting: false,
+        }),
+      );
+    });
+    const bar = container.querySelector('div') as HTMLDivElement;
+    expect(bar.style.transform).toBe('');
+
+    vv.height = 500;
+    resizeHandlers.resize.forEach((cb) => cb());
+    act(() => {}); // flush useEffect
+
+    expect(bar.style.transform).toBe('translateY(-300px)');
+  });
 });

--- a/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
@@ -1,0 +1,52 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import useKeyboardOffset from '../useKeyboardOffset';
+
+let result = 0;
+
+function Test() {
+  result = useKeyboardOffset();
+  return null;
+}
+
+describe('useKeyboardOffset', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    root.unmount();
+    container.remove();
+  });
+
+  it('returns keyboard height when visualViewport shrinks', () => {
+    const handlers: (() => void)[] = [];
+    const vv = {
+      height: 800,
+      offsetTop: 0,
+      addEventListener: (_: string, cb: () => void) => { handlers.push(cb); },
+      removeEventListener: () => {},
+    } as any;
+
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
+    Object.defineProperty(window, 'visualViewport', { value: vv, writable: true });
+
+    act(() => {
+      root.render(React.createElement(Test));
+    });
+    act(() => {}); // flush useEffect
+    expect(result).toBe(0);
+
+    vv.height = 600;
+    handlers.forEach((cb) => cb());
+    act(() => {});
+    expect(result).toBe(200);
+  });
+});
+

--- a/frontend/src/hooks/useKeyboardOffset.ts
+++ b/frontend/src/hooks/useKeyboardOffset.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Returns the height of the on-screen keyboard in pixels if visible.
+ * Useful for shifting fixed elements so they remain above the keyboard.
+ */
+export default function useKeyboardOffset(): number {
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const update = () => {
+      const keyboard = window.innerHeight - vv.height - vv.offsetTop;
+      setOffset(keyboard > 0 ? keyboard : 0);
+    };
+
+    update();
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    return () => {
+      vv.removeEventListener('resize', update);
+      vv.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  return offset;
+}
+


### PR DESCRIPTION
## Summary
- adjust mobile action bar to account for keyboard height
- add `useKeyboardOffset` hook with tests
- update tests for action bar behaviour
- document keyboard behaviour in README

## Testing
- `./scripts/test-all.sh` *(fails: npm install ECONNRESET)*
- `./scripts/docker-test.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847349178fc832e90143e14f517a9e1