### PR TITLE
Fix keyboard offset tests

### DIFF
--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -126,8 +126,9 @@ describe('MobileActionBar', () => {
     expect(bar.style.transform).toBe('');
 
     vv.height = 500;
-    resizeHandlers.resize.forEach((cb) => cb());
-    act(() => {}); // flush useEffect
+    act(() => {
+      resizeHandlers.resize.forEach((cb) => cb());
+    });
 
     expect(bar.style.transform).toBe('translateY(-300px)');
   });

--- a/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
@@ -44,8 +44,9 @@ describe('useKeyboardOffset', () => {
     expect(result).toBe(0);
 
     vv.height = 600;
-    handlers.forEach((cb) => cb());
-    act(() => {});
+    act(() => {
+      handlers.forEach((cb) => cb());
+    });
     expect(result).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- update hooks tests to wrap callbacks with `act`
- ensure mobile action bar keyboard tests also run inside `act`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847457bbbc8832ea18f457f533dc69a