### PR TITLE
Improve dependency caching in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ exits with a helpful message if the binary is missing (for example, when
 `npm ci` was interrupted).
 The script drops a marker file `frontend/node_modules/.install_complete` after a
 successful `npm ci` so subsequent runs skip reinstalling dependencies unless
-that file is removed. It also detects which files changed in Git and only runs
+that file is removed. After installing Python requirements, `setup.sh` creates
+`backend/venv/.install_complete` so it can skip `pip install` on future runs.
+It also detects which files changed in Git and only runs
 the backend or frontend tests when necessary; documentation-only changes cause
 the script to exit immediately without running any tests.
 
@@ -187,8 +189,10 @@ docker build -t booking-app:latest .  # build once with connectivity
 docker run --rm --network none booking-app:latest ./scripts/test-all.sh
 ```
 When running tests from this pre-built image, `setup.sh` detects the cached
-Python packages and Node modules and therefore skips any downloads. This
-allows repeated test executions without network access.
+Python packages and Node modules and therefore skips any downloads. It looks
+for marker files in `backend/venv/.install_complete` and
+`frontend/node_modules/.install_complete` to know when installation can be
+skipped. This allows repeated test executions without network access.
 
 You can also pull a pre-built image from our container registry and run the
 test script in one step:

--- a/setup.sh
+++ b/setup.sh
@@ -13,9 +13,15 @@ fi
 # shellcheck source=/dev/null
 source "$VENV_DIR/bin/activate"
 
-echo "Installing backend Python dependencies…"
-pip install -r "$ROOT_DIR/backend/requirements.txt"
-pip install -r "$ROOT_DIR/requirements-dev.txt"
+INSTALL_MARKER="$VENV_DIR/.install_complete"
+if [ -f "$INSTALL_MARKER" ]; then
+  echo "Python dependencies already installed; skipping pip install."
+else
+  echo "Installing backend Python dependencies…"
+  pip install -r "$ROOT_DIR/backend/requirements.txt"
+  pip install -r "$ROOT_DIR/requirements-dev.txt"
+  touch "$INSTALL_MARKER"
+fi
 
 echo "Installing frontend Node dependencies…"
 pushd "$ROOT_DIR/frontend" > /dev/null


### PR DESCRIPTION
## Summary
- cache backend Python packages in `setup.sh`
- document new caching behaviour in `README`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847d972b644832e821218f19f5e6cdb