### PR TITLE
Add FORCE_TESTS override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ For setup instructions see [README.md](README.md).
 * Ensure each new agent is integrated with relevant booking, notification, or chat workflows as needed.
 * Run `./scripts/test-all.sh` before committing changes to ensure backend and
   frontend tests pass. The script calls Jest via Node so it works even when
-  `node_modules/.bin` is missing.
+  `node_modules/.bin` is missing. Documentation-only commits skip testing by
+  default; set `FORCE_TESTS=1` to run the full suite anyway.
 * If network access is limited, use the pre-built Docker image by running
   `./scripts/docker-test.sh`. Set `BOOKING_APP_IMAGE` to override the default
   registry path. The script runs the container with `--network none` by default;

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ that file is removed. After installing Python requirements, `setup.sh` creates
 `backend/venv/.install_complete` so it can skip `pip install` on future runs.
 It also detects which files changed in Git and only runs
 the backend or frontend tests when necessary; documentation-only changes cause
-the script to exit immediately without running any tests.
+the script to exit immediately without running any tests. Set `FORCE_TESTS=1`
+to run the full suite even when only documentation files have changed.
 
 You can override the number of parallel Jest workers by setting the
 `JEST_WORKERS` environment variable:

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -8,7 +8,7 @@ CHANGED_FILES=$(git diff --name-only HEAD)
 
 # 2. Drop docs-only changes
 NON_DOC_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.(md|rst|txt)$|^docs/' || true)
-if [ -z "$NON_DOC_CHANGES" ]; then
+if [ -z "$NON_DOC_CHANGES" ] && [ "${FORCE_TESTS:-}" != "1" ]; then
   echo "📄 Only docs changed. Skipping setup and tests."
   exit 0
 fi


### PR DESCRIPTION
## Summary
- make docs-only checks respect new `FORCE_TESTS` env var
- document how to force a test run in README and AGENTS docs

## Testing
- `./scripts/test-all.sh` *(fails: jest not found)*
- `CI=true npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e31bbbb8832ebacf951999215692