### PR TITLE
Enable React act env for tests

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,3 +1,6 @@
+// Enable React 18 act() environment
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
 import React from "react";
 
 jest.mock('next/navigation', () => {
@@ -42,3 +45,4 @@ jest.mock('@react-google-maps/api', () => {
     Autocomplete: (props: any) => React.createElement('div', null, props.children),
   };
 });
+


### PR DESCRIPTION
## Summary
- enable React 18 act environment in frontend tests
- run test-all script (frontend tests fail)

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 1 failed, 1 skipped, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6847efa8c02c832e8ecfa55b74d78d05