### PR TITLE
Add JEST_WORKERS support in test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ the script to exit immediately without running any tests. Set `FORCE_TESTS=1`
 to run the full suite even when only documentation files have changed.
 
 You can override the number of parallel Jest workers by setting the
-`JEST_WORKERS` environment variable:
+`JEST_WORKERS` environment variable. `test-all.sh` passes this value to
+`npm test` using Jest's `--maxWorkers` flag, so you can control concurrency:
 
 ```bash
 JEST_WORKERS=75% ./scripts/test-all.sh

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -77,7 +77,12 @@ if [ -n "$FRONTEND_CHANGES" ]; then
   fi
   echo "Jest $($JEST_BIN --version) at $JEST_BIN"
 
-  npm test
+  if [ -n "${JEST_WORKERS:-}" ]; then
+    echo "▶️  Using JEST_WORKERS=$JEST_WORKERS"
+    npm test -- --maxWorkers="$JEST_WORKERS"
+  else
+    npm test
+  fi
   npm run lint --silent
   popd >/dev/null
 else


### PR DESCRIPTION
## Summary
- allow `scripts/test-all.sh` to read `JEST_WORKERS` and pass `--maxWorkers`
- document the new option under the Testing section

## Testing
- `FORCE_TESTS=1 JEST_WORKERS=2 ./scripts/test-all.sh` *(fails: Test Suites: 1 failed, 1 skipped, 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6847f29cbe58832ea49378225b18369a