### PR TITLE
Add skip option for docker-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ test script in one step:
 ```
 Set the `BOOKING_APP_IMAGE` environment variable if you want to use a different
 tag or registry location. Pass `DOCKER_TEST_NETWORK=bridge` if network access is
-needed during the test run.
+needed during the test run. Set `BOOKING_APP_SKIP_PULL=1` when the image is
+already available locally to skip the `docker pull` step.
 The script copies the image's pre-built `backend/venv` and `frontend/node_modules`
 into your working directory on first run so subsequent executions can run
 without network access.

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -13,8 +13,12 @@ if ! command -v docker >/dev/null 2>&1; then
   exit $?
 fi
 
-echo "Pulling $IMAGE"
-docker pull "$IMAGE"
+if [ -z "${BOOKING_APP_SKIP_PULL:-}" ]; then
+  echo "Pulling $IMAGE"
+  docker pull "$IMAGE"
+else
+  echo "Skipping docker pull because BOOKING_APP_SKIP_PULL is set"
+fi
 
 echo "Running tests in $IMAGE"
 docker run --rm --network "$NETWORK" -v "$(pwd)":$WORKDIR "$IMAGE" \


### PR DESCRIPTION
## Summary
- allow skipping the `docker pull` step in `docker-test.sh`
- document `BOOKING_APP_SKIP_PULL` in the Docker testing section

## Testing
- `./scripts/test-all.sh` *(fails: Cannot find module 'next/navigation')*

------
https://chatgpt.com/codex/tasks/task_e_6847f4bfea9c832ebccc4e0c4bd345f0