### PR TITLE
Wrap React root unmounts in act

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -48,7 +48,9 @@ describe('DashboardPage empty state', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });
@@ -135,7 +137,9 @@ describe('DashboardPage artist stats', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });
@@ -269,7 +273,9 @@ describe('DashboardPage list toggles', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });
@@ -322,7 +328,9 @@ describe('Service card drag handle', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });

--- a/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
@@ -56,7 +56,9 @@ describe('Service deletion confirmation', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -55,7 +55,9 @@ describe('InboxPage unread badge', () => {
     const card = container.querySelector('li div');
     expect(card?.className).toContain('bg-indigo-50');
     expect(container.textContent).not.toContain('new message');
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 });
@@ -77,7 +79,9 @@ describe('InboxPage navigation', () => {
       card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(push).toHaveBeenCalledWith('/booking-requests/1');
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 });

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -45,7 +45,9 @@ describe('BookingWizard mobile scrolling', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });

--- a/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
+++ b/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
@@ -14,7 +14,9 @@ describe('ChatThreadView', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -35,7 +35,9 @@ describe('MessageThread component', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -14,7 +14,9 @@ describe('MobileActionBar', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
+++ b/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
@@ -17,7 +17,9 @@ describe('StickyInputDemo', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
     jest.clearAllMocks();
   });

--- a/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
@@ -14,7 +14,9 @@ describe('DashboardTabs', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
@@ -14,7 +14,9 @@ describe('MobileSaveBar', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/dashboard/__tests__/OverviewAccordion.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/OverviewAccordion.test.tsx
@@ -14,7 +14,9 @@ describe('OverviewAccordion', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
@@ -14,7 +14,9 @@ describe('SectionList', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
+++ b/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
@@ -26,7 +26,9 @@ describe('FullScreenNotificationModal', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -27,7 +27,9 @@ describe('MobileBottomNav', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -16,7 +16,9 @@ describe('MobileMenuDrawer', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -14,7 +14,9 @@ describe('Stepper responsive layout', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/hooks/__tests__/useIsMobile.test.ts
+++ b/frontend/src/hooks/__tests__/useIsMobile.test.ts
@@ -20,7 +20,9 @@ describe('useIsMobile', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 

--- a/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
@@ -21,7 +21,9 @@ describe('useKeyboardOffset', () => {
   });
 
   afterEach(() => {
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     container.remove();
   });
 


### PR DESCRIPTION
## Summary
- update frontend unit tests to unmount React roots inside `act()`
- rerun tests to verify the warnings are gone

## Testing
- `FORCE_TESTS=1 ./scripts/test-all.sh` *(fails: ESLint error about unused `motion` in dashboard/page.tsx)*
- `npm test -w=1`

------
https://chatgpt.com/codex/tasks/task_e_684807c3f55c832eb1699b4c714b852b