### PR TITLE
Improve setup.sh error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Each cache also stores a SHA256 hash of its lock file
 these hashes to the current files and reinstalls the dependencies only when the
 hashes differ.
 
+`setup.sh` now verifies that both `pip install` and `npm ci` succeed before any
+marker files are created. If either step fails, the script prints an error and
+suggests running `./scripts/docker-test.sh` with network access to fetch the
+required packages. The marker files (`.install_complete`, `.req_hash`, and
+`.pkg_hash`) are written only after successful installs so failed downloads do
+not pollute the cache.
+
 **Important:** run `./setup.sh` or `./scripts/docker-test.sh` once with network
 access so these marker files are created. Subsequent offline runs reuse the
 cached `backend/venv` and `frontend/node_modules` directories.

--- a/setup.sh
+++ b/setup.sh
@@ -26,16 +26,26 @@ if [ -f "$INSTALL_MARKER" ]; then
     echo "Python dependencies already installed and up to date; skipping pip install."
   else
     echo "Requirements changed; reinstalling Python dependencies…"
-    pip install -r "$ROOT_DIR/backend/requirements.txt"
-    pip install -r "$ROOT_DIR/requirements-dev.txt"
-    echo "$CURRENT_REQ_HASH" > "$REQ_HASH_FILE"
+    if pip install -r "$ROOT_DIR/backend/requirements.txt" \
+        && pip install -r "$ROOT_DIR/requirements-dev.txt"; then
+      echo "$CURRENT_REQ_HASH" > "$REQ_HASH_FILE"
+    else
+      echo "\n❌ pip install failed. Check your internet connection or pre-built cache." >&2
+      echo "For offline environments, try running ./scripts/docker-test.sh with network access first." >&2
+      exit 1
+    fi
   fi
 else
   echo "Installing backend Python dependencies…"
-  pip install -r "$ROOT_DIR/backend/requirements.txt"
-  pip install -r "$ROOT_DIR/requirements-dev.txt"
-  echo "$CURRENT_REQ_HASH" > "$REQ_HASH_FILE"
-  touch "$INSTALL_MARKER"
+  if pip install -r "$ROOT_DIR/backend/requirements.txt" \
+       && pip install -r "$ROOT_DIR/requirements-dev.txt"; then
+    echo "$CURRENT_REQ_HASH" > "$REQ_HASH_FILE"
+    touch "$INSTALL_MARKER"
+  else
+    echo "\n❌ pip install failed. Check your internet connection or pre-built cache." >&2
+    echo "For offline environments, try running ./scripts/docker-test.sh with network access first." >&2
+    exit 1
+  fi
 fi
 
 echo "Installing frontend Node dependencies…"
@@ -59,7 +69,7 @@ if [ -f "$FRONTEND_MARKER" ]; then
       touch "$FRONTEND_MARKER"
     else
       echo "\n❌ npm ci failed. Ensure network access or a pre-built npm cache is available." >&2
-      echo "For offline environments, consider running ./scripts/docker-test.sh." >&2
+      echo "For offline environments, try running ./scripts/docker-test.sh with network access first." >&2
       popd > /dev/null
       exit 1
     fi
@@ -73,7 +83,7 @@ else
     touch "$FRONTEND_MARKER"
   else
     echo "\n❌ npm ci failed. Ensure network access or a pre-built npm cache is available." >&2
-    echo "For offline environments, consider running ./scripts/docker-test.sh." >&2
+    echo "For offline environments, try running ./scripts/docker-test.sh with network access first." >&2
     popd > /dev/null
     exit 1
   fi


### PR DESCRIPTION
## Summary
- validate `pip install` success before continuing
- show docker-test hint when installs fail
- document setup verification in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848099440d8832e9f2eee8585db8fb2