### PR TITLE
Add test check for test-all script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,12 +126,16 @@ For setup instructions see [README.md](README.md).
   `./scripts/docker-test.sh`. Set `BOOKING_APP_IMAGE` to override the default
   registry path. The script runs the container with `--network none` by default;
   export `DOCKER_TEST_NETWORK=bridge` if tests require connectivity.
+* `scripts/tests/test-test-all.sh` clones the repository into a temporary
+  directory, runs `FORCE_TESTS=1 ./scripts/test-all.sh`, and verifies that both
+  backend and frontend test suites execute. Use this helper to confirm the test
+  runner works on a clean checkout.
 
 ---
 
 ## Last Updated
 
-2025-06-09
+2025-06-10
 
 ---
 

--- a/scripts/tests/test-test-all.sh
+++ b/scripts/tests/test-test-all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TMP_DIR="$(mktemp -d)"
+
+echo "Cloning repository to $TMP_DIR"
+
+git clone "$REPO_ROOT" "$TMP_DIR/booking-app" >/dev/null
+
+pushd "$TMP_DIR/booking-app" >/dev/null
+
+# Ensure working tree is clean
+output=$(FORCE_TESTS=1 ./scripts/test-all.sh 2>&1)
+
+echo "$output"
+
+if ! echo "$output" | grep -q "Running backend tests"; then
+  echo "❌ Backend tests did not run" >&2
+  exit 1
+fi
+
+if ! echo "$output" | grep -q "Running frontend tests"; then
+  echo "❌ Frontend tests did not run" >&2
+  exit 1
+fi
+
+popd >/dev/null
+rm -rf "$TMP_DIR"
+
+echo "✅ test-all.sh executed both suites"


### PR DESCRIPTION
## Summary
- add `test-test-all.sh` to verify running backend and frontend tests
- mention helper script in **AGENTS.md** and update the last updated date

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684817eb75e0832eabb974aa708daca4