### PR TITLE
Add collapsible mobile summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Stepper sticks below the header so progress is always visible while scrolling.
 * Venue picker uses a bottom-sheet on small screens to avoid keyboard overlap.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
+* Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
 
 ### Real-time Chat
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -302,7 +302,14 @@ export default function BookingWizard({
         />
       )}
       <div className="lg:hidden mt-4">
-        <SummarySidebar />
+        {isMobile ? (
+          <details open className="space-y-2">
+            <summary className="cursor-pointer text-sm underline">Booking Summary</summary>
+            <SummarySidebar />
+          </details>
+        ) : (
+          <SummarySidebar />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -105,4 +105,11 @@ describe('BookingWizard mobile scrolling', () => {
     await act(async () => { setStep(5); });
     expectNoButton('review-submit-button');
   });
+
+  it('wraps the summary sidebar in a details element on mobile', () => {
+    const details = container.querySelector('details');
+    const summary = container.querySelector('details summary');
+    expect(details).not.toBeNull();
+    expect(summary?.textContent).toContain('Booking Summary');
+  });
 });


### PR DESCRIPTION
## Summary
- wrap SummarySidebar with details element on mobile
- test that mobile summary is collapsible
- document new collapsible summary in README

## Testing
- `./scripts/test-all.sh` *(fails: Jest binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482ef5d56c832e98d153d023f58887