### PR TITLE
Improve mobile bottom sheet accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Mobile devices use native date and time pickers for faster input.
 * Stepper sticks below the header so progress is always visible while scrolling.
 * Venue picker uses a bottom-sheet on small screens to avoid keyboard overlap.
+  The sheet now traps focus for accessibility and closes when you press
+  `Escape` or tap outside.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
 * Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
 

--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -24,6 +24,8 @@ This document outlines key friction points in the current booking wizard and pro
 * **Pain Points:** Drop‑down overlaps with keyboard.
 * **Improvements:**
   - Convert to bottom sheet style selector on mobile.
+  - Trap focus inside the sheet and close it with Escape or by tapping the
+    overlay.
 
 ## Notes
 * **Pain Points:** Large textarea forces users to scroll.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -252,6 +252,14 @@ export default function BookingWizard({
         <h2 className="text-xl font-semibold" data-testid="step-heading">
           {steps[step]}
         </h2>
+        <div className="lg:hidden">
+          {isMobile && (
+            <details open className="space-y-2">
+              <summary className="cursor-pointer text-sm underline">Booking Summary</summary>
+              <SummarySidebar />
+            </details>
+          )}
+        </div>
         {renderStep()}
         {warning && <p className="text-orange-600 text-sm">{warning}</p>}
         {Object.values(errors).length > 0 && (
@@ -301,16 +309,6 @@ export default function BookingWizard({
           submitting={submitting}
         />
       )}
-      <div className="lg:hidden mt-4">
-        {isMobile ? (
-          <details open className="space-y-2">
-            <summary className="cursor-pointer text-sm underline">Booking Summary</summary>
-            <SummarySidebar />
-          </details>
-        ) : (
-          <SummarySidebar />
-        )}
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -4,6 +4,7 @@
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import { useState } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
+import useFocusTrap from '@/hooks/useFocusTrap';
 
 interface Props {
   control: Control<FieldValues>;
@@ -12,6 +13,7 @@ interface Props {
 export default function VenueStep({ control }: Props) {
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
+  const sheetRef = useFocusTrap(open, () => setOpen(false));
   const options = [
     { label: 'Indoor', value: 'indoor' },
     { label: 'Outdoor', value: 'outdoor' },
@@ -37,8 +39,17 @@ export default function VenueStep({ control }: Props) {
                 </button>
                 {open && (
                   <div className="fixed inset-0 z-50 flex flex-col">
-                    <div className="flex-1 bg-black/30" onClick={() => setOpen(false)} />
-                    <div className="bg-white p-4 space-y-2 rounded-t-lg">
+                    <div
+                      className="flex-1 bg-black/30"
+                      onClick={() => setOpen(false)}
+                      data-testid="overlay"
+                    />
+                    <div
+                      ref={sheetRef}
+                      role="dialog"
+                      aria-modal="true"
+                      className="bg-white p-4 space-y-2 rounded-t-lg"
+                    >
                       {options.map((o) => (
                         <button
                           key={o.value}

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -1,0 +1,71 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { useForm, Control, FieldValues } from 'react-hook-form';
+import VenueStep from '../VenueStep';
+
+function Wrapper() {
+  const { control } = useForm();
+  return <VenueStep control={control as unknown as Control<FieldValues>} />;
+}
+
+describe('VenueStep bottom sheet', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+  });
+
+  function openSheet() {
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  }
+
+  it('focus is trapped and sheet closes on Escape', () => {
+    act(() => {
+      root.render(React.createElement(Wrapper));
+    });
+    openSheet();
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('closes when clicking the overlay', () => {
+    act(() => {
+      root.render(React.createElement(Wrapper));
+    });
+    openSheet();
+    const overlay = container.querySelector('[data-testid="overlay"]') as HTMLDivElement;
+    act(() => {
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('uses dialog semantics', () => {
+    act(() => {
+      root.render(React.createElement(Wrapper));
+    });
+    openSheet();
+    const dialog = container.querySelector('[role="dialog"]') as HTMLDivElement;
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+
+export default function useFocusTrap(active: boolean, onClose: () => void) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return undefined;
+
+    const el = ref.current;
+    if (!el) return undefined;
+
+    const focusableSelectors =
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusable = Array.from(
+      el.querySelectorAll<HTMLElement>(focusableSelectors),
+    );
+
+    if (focusable.length) {
+      focusable[0].focus();
+    } else {
+      // fallback focus on container
+      el.tabIndex = -1;
+      el.focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+      if (e.key === 'Tab' && focusable.length) {
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [active, onClose]);
+
+  return ref;
+}
+


### PR DESCRIPTION
## Summary
- trap focus inside VenueStep sheet
- close sheet on Escape or outside click
- document new screen reader behavior
- export `useFocusTrap` hook
- refactor BookingWizard mobile summary placement
- test VenueStep interactions

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848325ff9f4832ebdcc67a48733d70f