### PR TITLE
Extend useKeyboardOffset fallback

### DIFF
--- a/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
@@ -51,5 +51,34 @@ describe('useKeyboardOffset', () => {
     });
     expect(result).toBe(200);
   });
+
+  it('falls back to resize events when visualViewport is missing', () => {
+    Object.defineProperty(window, 'visualViewport', { value: undefined, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
+
+    act(() => {
+      root.render(React.createElement(Test));
+    });
+    act(() => {});
+    expect(result).toBe(0);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    });
+
+    Object.defineProperty(window, 'innerHeight', { value: 700, writable: true });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(result).toBe(100);
+
+    act(() => {
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+    });
+    expect(result).toBe(0);
+    input.remove();
+  });
 });
 

--- a/frontend/src/hooks/useKeyboardOffset.ts
+++ b/frontend/src/hooks/useKeyboardOffset.ts
@@ -9,19 +9,50 @@ export default function useKeyboardOffset(): number {
 
   useEffect(() => {
     const vv = window.visualViewport;
-    if (!vv) return;
 
-    const update = () => {
-      const keyboard = window.innerHeight - vv.height - vv.offsetTop;
-      setOffset(keyboard > 0 ? keyboard : 0);
+    if (vv) {
+      const update = () => {
+        const keyboard = window.innerHeight - vv.height - vv.offsetTop;
+        setOffset(keyboard > 0 ? keyboard : 0);
+      };
+
+      update();
+      vv.addEventListener('resize', update);
+      vv.addEventListener('scroll', update);
+      return () => {
+        vv.removeEventListener('resize', update);
+        vv.removeEventListener('scroll', update);
+      };
+    }
+
+    // Fallback for browsers without the VisualViewport API
+    let baseline = window.innerHeight;
+    const updateWin = () => {
+      const diff = baseline - window.innerHeight;
+      setOffset(diff > 0 ? diff : 0);
     };
+    const handleFocusIn = (e: FocusEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (
+        t instanceof HTMLInputElement ||
+        t instanceof HTMLTextAreaElement ||
+        (t instanceof HTMLElement && t.isContentEditable)
+      ) {
+        baseline = window.innerHeight;
+        window.addEventListener('resize', updateWin);
+      }
+    };
+    const handleFocusOut = () => {
+      window.removeEventListener('resize', updateWin);
+      setOffset(0);
+    };
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
 
-    update();
-    vv.addEventListener('resize', update);
-    vv.addEventListener('scroll', update);
     return () => {
-      vv.removeEventListener('resize', update);
-      vv.removeEventListener('scroll', update);
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+      window.removeEventListener('resize', updateWin);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- improve `useKeyboardOffset` hook to handle browsers without `visualViewport`
- test the new fallback behaviour for keyboard offset detection

## Testing
- `pytest -q --maxfail=1 --disable-warnings`
- `node node_modules/jest/bin/jest.js src/hooks/__tests__/useKeyboardOffset.test.ts --runInBand` *(fails: Cannot find module 'next/navigation')*

------
https://chatgpt.com/codex/tasks/task_e_684833a6a200832ea67d34922e4aabcb