### PR TITLE
Fix act import in frontend tests

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { waitFor } from '@testing-library/react';
 import DashboardPage from '../page';
 import * as api from '@/lib/api';

--- a/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import DashboardPage from '../page';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import InboxPage from '../page';
 import * as api from '@/lib/api';
 import useNotifications from '@/hooks/useNotifications';

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import BookingWizard from '../BookingWizard';
 import { BookingProvider, useBooking } from '@/contexts/BookingContext';
 import * as api from '@/lib/api';

--- a/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
+++ b/frontend/src/components/booking/__tests__/ChatThreadView.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import ChatThreadView from '../ChatThreadView';
 
 describe('ChatThreadView', () => {

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import MessageThread from '../MessageThread';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';

--- a/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
+++ b/frontend/src/components/booking/__tests__/MobileActionBar.test.ts
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import MobileActionBar from '../MobileActionBar';
 
 describe('MobileActionBar', () => {

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import VenueStep from '../VenueStep';
 

--- a/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
+++ b/frontend/src/components/chat/__tests__/StickyInputDemo.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import StickyInputDemo from '../StickyInputDemo';
 
 

--- a/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import DashboardTabs from '../DashboardTabs';
 
 describe('DashboardTabs', () => {

--- a/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/MobileSaveBar.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import MobileSaveBar from '../MobileSaveBar';
 
 describe('MobileSaveBar', () => {

--- a/frontend/src/components/dashboard/__tests__/OverviewAccordion.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/OverviewAccordion.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import OverviewAccordion from '../OverviewAccordion';
 
 describe('OverviewAccordion', () => {

--- a/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import SectionList from '../SectionList';
 
 describe('SectionList', () => {

--- a/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
+++ b/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import FullScreenNotificationModal from '../FullScreenNotificationModal';
 
 const baseProps = {

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import MobileBottomNav from '../MobileBottomNav';
 import type { User } from '@/types';
 

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 
 const nav = [{ name: 'Home', href: '/' }, { name: 'Artists', href: '/artists' }];

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import React from 'react';
 import Stepper from '../Stepper';
 

--- a/frontend/src/hooks/__tests__/useIsMobile.test.ts
+++ b/frontend/src/hooks/__tests__/useIsMobile.test.ts
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import useIsMobile from '../useIsMobile';
 import React from 'react';
 

--- a/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardOffset.test.ts
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import React from 'react';
 import useKeyboardOffset from '../useKeyboardOffset';
 


### PR DESCRIPTION
## Summary
- fix act imports in frontend tests to come from `react`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68483bb0c1d4832e8ba9c2e21e1d23e5