### PR TITLE
Simplify booking wizard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,14 +360,14 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 
 ### Booking Wizard
 
-* Reusable `Stepper` and `useBookingForm` hook.
+* Reusable progress bar and `useBookingForm` hook.
 * “Book Now” buttons on service cards.
 * New **Review** step showing cost breakdown and selections.
 * Success toasts when saving a draft or submitting a request.
-* Mobile action bar now adapts to scroll direction and lifts above the on-screen keyboard when inputs are focused, staying above the bottom nav when visible, sliding down when the nav hides, and respecting safe-area insets via the `.pb-safe` utility.
+* Simplified buttons are inline below each step instead of a floating action bar.
 * Collapsible sections for date/time and notes keep steps short on phones.
 * Mobile devices use native date and time pickers for faster input.
-* Stepper sticks below the header so progress is always visible while scrolling.
+* The progress bar sticks below the header so progress is always visible while scrolling.
 * Venue picker uses a bottom-sheet on small screens to avoid keyboard overlap.
   The sheet now traps focus for accessibility and closes when you press
   `Escape` or tap outside.

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -23,7 +23,7 @@ function Wrapper() {
     return null;
   }
 
-describe('BookingWizard mobile scrolling', () => {
+describe('BookingWizard flow', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -53,23 +53,18 @@ describe('BookingWizard mobile scrolling', () => {
   });
 
   it('scrolls to top when advancing steps', async () => {
-    const nextButton = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
+    const nextButton = container.querySelectorAll('button[type="button"]')[1] as HTMLButtonElement;
     await act(async () => {
       nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(window.scrollTo).toHaveBeenCalled();
   });
 
-  it('does not render inline next button on mobile', () => {
-    const inline = container.querySelector('[data-testid="date-next-button"]');
-    expect(inline).toBeNull();
-  });
-
   it('shows step heading and updates on next', async () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;
     expect(heading()).toContain('Date & Time');
-    const next = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
+    const next = container.querySelectorAll('button[type="button"]')[1] as HTMLButtonElement;
     await act(async () => {
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -77,39 +72,13 @@ describe('BookingWizard mobile scrolling', () => {
     expect(heading()).toContain('Location');
   });
 
-  it('advances to the location step without inline button', async () => {
-    const next = container.querySelector('[data-testid="mobile-next-button"]') as HTMLButtonElement;
-    await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(
-      container.querySelector('[data-testid="location-next-button"]'),
-    ).toBeNull();
-  });
-
-  it('no inline action buttons exist for any step', async () => {
+  it('shows summary only on the review step', async () => {
+    expect(container.querySelector('h2')?.textContent).toContain('Date & Time');
+    expect(container.textContent).not.toContain('Summary');
     const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
-    const expectNoButton = (testId: string) => {
-      expect(container.querySelector(`[data-testid="${testId}"]`)).toBeNull();
-    };
-
-    await act(async () => { setStep(1); });
-    expectNoButton('location-next-button');
-    await act(async () => { setStep(2); });
-    expectNoButton('guests-next-button');
-    await act(async () => { setStep(3); });
-    expectNoButton('venue-next-button');
-    await act(async () => { setStep(4); });
-    expectNoButton('notes-next-button');
     await act(async () => { setStep(5); });
-    expectNoButton('review-submit-button');
-  });
-
-  it('wraps the summary sidebar in a details element on mobile', () => {
-    const details = container.querySelector('details');
-    const summary = container.querySelector('details summary');
-    expect(details).not.toBeNull();
-    expect(summary?.textContent).toContain('Booking Summary');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector('h2')?.textContent).toContain('Review');
+    expect(container.textContent).toContain('Summary');
   });
 });

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -1,7 +1,5 @@
 'use client';
-// Collapsible sections reduce vertical space so mobile users don't need to
-// scroll as much when picking a date and time.
-import { Controller, Control, UseFormWatch, FieldValues } from 'react-hook-form';
+import { Controller, Control, FieldValues } from 'react-hook-form';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { format } from 'date-fns';
@@ -11,10 +9,9 @@ import useIsMobile from '@/hooks/useIsMobile';
 interface Props {
   control: Control<FieldValues>;
   unavailable: string[];
-  watch: UseFormWatch<FieldValues>;
 }
 
-export default function DateTimeStep({ control, unavailable, watch }: Props) {
+export default function DateTimeStep({ control, unavailable }: Props) {
   const isMobile = useIsMobile();
   const tileDisabled = ({ date }: { date: Date }) => {
     const day = format(date, 'yyyy-MM-dd');
@@ -25,48 +22,28 @@ export default function DateTimeStep({ control, unavailable, watch }: Props) {
   return (
     <div className="space-y-4">
       <p className="text-sm text-gray-600">When should we perform?</p>
-      <details open className="space-y-2">
-        <summary className="cursor-pointer font-medium">Select date</summary>
-        <Controller
-          name="date"
-          control={control}
-          render={({ field }) => (
-            isMobile ? (
-              <input
-                type="date"
-                className="border p-2 rounded w-full"
-                min={format(new Date(), 'yyyy-MM-dd')}
-                {...field}
-              />
-            ) : (
-              <Calendar
-                {...field}
-                locale="en-US"
-                formatLongDate={formatLongDate}
-                onChange={field.onChange}
-                tileDisabled={tileDisabled}
-              />
-            )
-          )}
-        />
-      </details>
-      {watch('date') && (
-        <details open className="space-y-2">
-          <summary className="cursor-pointer font-medium">Select time</summary>
-          <Controller
-            name="time"
-            control={control}
-            render={({ field }) => (
-              <input
-                type="time"
-                className="border p-2 rounded w-full"
-                {...field}
-              />
-            )}
-          />
-        </details>
-      )}
-      {/* Mobile action buttons are handled by MobileActionBar */}
+      <Controller
+        name="date"
+        control={control}
+        render={({ field }) => (
+          isMobile ? (
+            <input
+              type="date"
+              className="border p-2 rounded w-full"
+              min={format(new Date(), 'yyyy-MM-dd')}
+              {...field}
+            />
+          ) : (
+            <Calendar
+              {...field}
+              locale="en-US"
+              formatLongDate={formatLongDate}
+              onChange={field.onChange}
+              tileDisabled={tileDisabled}
+            />
+          )
+        )}
+      />
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -1,9 +1,7 @@
 'use client';
-// Optional notes are collapsed by default so the step stays short. A toast
-// confirms when an attachment uploads successfully.
+// Notes and optional attachment upload.
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import useIsMobile from '@/hooks/useIsMobile';
-import { useState } from 'react';
 import { uploadBookingAttachment } from '@/lib/api';
 import toast from '../../ui/Toast';
 
@@ -14,7 +12,6 @@ interface Props {
 
 export default function NotesStep({ control, setValue }: Props) {
   const isMobile = useIsMobile();
-  const [showNotes, setShowNotes] = useState(false);
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -29,30 +26,19 @@ export default function NotesStep({ control, setValue }: Props) {
   return (
     <div className="space-y-2">
       <p className="text-sm text-gray-600">Anything else we should know?</p>
-      <button
-        type="button"
-        className="text-sm text-indigo-600 underline"
-        onClick={() => setShowNotes(!showNotes)}
-      >
-        {showNotes ? 'Hide notes' : 'Add notes'}
-      </button>
-      {showNotes && (
-        <>
-          <label className="block text-sm font-medium">Extra notes</label>
-          <Controller
-            name="notes"
-            control={control}
-            render={({ field }) => (
-              <textarea
-                rows={3}
-                className="border p-2 rounded w-full"
-                {...field}
-                autoFocus={!isMobile}
-              />
-            )}
+      <label className="block text-sm font-medium">Extra notes</label>
+      <Controller
+        name="notes"
+        control={control}
+        render={({ field }) => (
+          <textarea
+            rows={3}
+            className="border p-2 rounded w-full"
+            {...field}
+            autoFocus={!isMobile}
           />
-        </>
-      )}
+        )}
+      />
       <Controller
         name="attachment_url"
         control={control}
@@ -60,7 +46,6 @@ export default function NotesStep({ control, setValue }: Props) {
       />
       <label className="block text-sm font-medium">Attachment (optional)</label>
       <input type="file" onChange={handleFileChange} />
-      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -1,51 +1,14 @@
 'use client';
-// Final review step with a sticky header and collapsible details so the submit
-// button stays visible on mobile.
-import { useBooking } from '@/contexts/BookingContext';
-import { format } from 'date-fns';
+// Final review step showing a summary of all selections.
+import SummarySidebar from '../SummarySidebar';
 
 export default function ReviewStep() {
-  const { details } = useBooking();
   return (
-    <div className="space-y-2">
-      <div className="sticky top-16 bg-white z-20 py-2">
-        <h3 className="text-lg font-medium">Review Details</h3>
-      </div>
-      <details open className="space-y-1">
-        <summary className="cursor-pointer text-sm underline">Show details</summary>
-        <ul className="text-sm space-y-1 mt-1">
-        {details.date && (
-          <li>
-            <strong>Date:</strong> {format(details.date, 'PP')}
-            {details.time && ` ${details.time}`}
-          </li>
-        )}
-        {details.location && (
-          <li>
-            <strong>Location:</strong> {details.location}
-          </li>
-        )}
-        {details.guests && (
-          <li>
-            <strong>Guests:</strong> {details.guests}
-          </li>
-        )}
-        {details.venueType && (
-          <li>
-            <strong>Venue:</strong> {details.venueType}
-          </li>
-        )}
-        {details.notes && (
-          <li>
-            <strong>Notes:</strong> {details.notes}
-          </li>
-        )}
-        </ul>
-      </details>
+    <div className="space-y-4">
+      <SummarySidebar />
       <p className="text-gray-600 text-sm">
         Please confirm the information above before sending your request.
       </p>
-      {/* Mobile action buttons are handled by MobileActionBar */}
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { Control, Controller, FieldValues } from 'react-hook-form';
+
+interface Props {
+  control: Control<FieldValues>;
+}
+
+export default function SoundStep({ control }: Props) {
+  return (
+    <div className="space-y-4">
+      <label className="block text-sm font-medium mb-2">Is sound needed?</label>
+      <Controller
+        name="sound"
+        control={control}
+        render={({ field }) => (
+          <div className="space-x-4">
+            <label className="inline-flex items-center">
+              <input
+                type="radio"
+                value="yes"
+                checked={field.value === 'yes'}
+                onChange={() => field.onChange('yes')}
+                className="mr-1"
+              />
+              Yes
+            </label>
+            <label className="inline-flex items-center">
+              <input
+                type="radio"
+                value="no"
+                checked={field.value === 'no'}
+                onChange={() => field.onChange('no')}
+                className="mr-1"
+              />
+              No
+            </label>
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,8 +1,8 @@
 'use client';
-// Keep progress visible on small screens by sticking the stepper below the
-// header. This helps users understand where they are in the flow while
-// scrolling.
 import React from 'react';
+// Simplified progress bar that highlights the current step and shows
+// past steps as semi-active. The bar sticks below the header on mobile
+// so progress stays visible while scrolling.
 import useIsMobile from '@/hooks/useIsMobile';
 
 interface StepperProps {
@@ -12,61 +12,34 @@ interface StepperProps {
 
 export default function Stepper({ steps, currentStep }: StepperProps) {
   const isMobile = useIsMobile();
-  const progress = (currentStep / (steps.length - 1)) * 100;
-
-  if (isMobile) {
-    return (
-      <div className="space-y-1 sticky top-16 z-30 bg-white py-2">
-        <div className="flex justify-between text-sm">
-          <span>{steps[currentStep]}</span>
-          <span>
-            {currentStep + 1}/{steps.length}
-          </span>
-        </div>
-        <div
-          className="w-full bg-gray-200 rounded h-2"
-          role="progressbar"
-          aria-valuenow={currentStep}
-          aria-valuemin={0}
-          aria-valuemax={steps.length - 1}
-        >
-          <div
-            className="bg-indigo-600 h-2 rounded"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-      </div>
-    );
-  }
 
   return (
-    <div className="space-y-2">
+    <div className={`sticky top-16 z-30 bg-white py-2 ${isMobile ? '' : 'mb-4'}`}> 
       <div className="flex items-center" aria-label="Progress">
-        {steps.map((label, i) => (
-          <div key={label} className="flex items-center flex-1">
-            <div
-              className={`h-6 w-6 rounded-full flex items-center justify-center text-xs font-medium ${i <= currentStep ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-600'}`}
-            >
-              {i + 1}
+        {steps.map((label, i) => {
+          const state = i < currentStep ? 'past' : i === currentStep ? 'current' : 'future';
+          const circleClass =
+            state === 'current'
+              ? 'bg-indigo-600 text-white'
+              : state === 'past'
+                ? 'bg-indigo-100 text-indigo-600'
+                : 'bg-gray-200 text-gray-400';
+          const textClass =
+            state === 'current'
+              ? 'font-bold text-gray-900'
+              : state === 'past'
+                ? 'text-gray-700'
+                : 'text-gray-400';
+          return (
+            <div key={label} className="flex items-center flex-1">
+              <div className={`h-4 w-4 rounded-full ${circleClass}`} />
+              <span className={`ml-2 text-xs sm:text-sm ${textClass}`}>{label}</span>
+              {i < steps.length - 1 && (
+                <div className="flex-1 border-t border-gray-300 mx-2" />
+              )}
             </div>
-            <span className="ml-2 text-sm">{label}</span>
-            {i < steps.length - 1 && (
-              <div className="flex-1 border-t border-gray-200 mx-2" />
-            )}
-          </div>
-        ))}
-      </div>
-      <div
-        className="w-full bg-gray-200 rounded h-2"
-        role="progressbar"
-        aria-valuenow={currentStep}
-        aria-valuemin={0}
-        aria-valuemax={steps.length - 1}
-      >
-        <div
-          className="bg-indigo-600 h-2 rounded"
-          style={{ width: `${progress}%` }}
-        />
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react';
 import React from 'react';
 import Stepper from '../Stepper';
 
-describe('Stepper responsive layout', () => {
+describe('Stepper progress bar', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
@@ -20,14 +20,6 @@ describe('Stepper responsive layout', () => {
     container.remove();
   });
 
-  it('renders mobile progress when width < 640px', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
-    act(() => {
-      root.render(<Stepper steps={["One", "Two"]} currentStep={0} />);
-    });
-    expect(container.textContent).toContain('1/2');
-  });
-
   it('is sticky on mobile', () => {
     Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
     act(() => {
@@ -37,11 +29,13 @@ describe('Stepper responsive layout', () => {
     expect(div?.className).toContain('sticky');
   });
 
-  it('renders desktop layout when width >= 640px', () => {
+  it('shows step names and highlights the current one', () => {
     Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
     act(() => {
-      root.render(<Stepper steps={["One", "Two"]} currentStep={1} />);
+      root.render(<Stepper steps={["One", "Two", "Three"]} currentStep={1} />);
     });
-    expect(container.textContent).toContain('Two');
+    const spans = container.querySelectorAll('span');
+    expect(spans[1].className).toContain('font-bold');
+    expect(container.textContent).toContain('Three');
   });
 });

--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -2,10 +2,9 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 
 export interface EventDetails {
   date: Date;
-  time?: string;
   location: string;
-  guests: number;
   venueType: 'indoor' | 'outdoor' | 'hybrid';
+  sound: 'yes' | 'no';
   notes?: string;
   attachment_url?: string;
 }
@@ -27,10 +26,9 @@ export const BookingProvider = ({ children }: { children: ReactNode }) => {
   const [step, setStep] = useState(0);
   const [details, setDetails] = useState<EventDetails>({
     date: new Date(),
-    time: '',
     location: '',
-    guests: 1,
     venueType: 'indoor',
+    sound: 'yes',
     attachment_url: '',
   });
   const [serviceId, setServiceId] = useState<number | undefined>(undefined);


### PR DESCRIPTION
## Summary
- swap Stepper for a simplified progress bar and update tests
- streamline BookingWizard flow and remove MobileActionBar
- add SoundStep and drop guests/time fields
- simplify Notes and Date steps
- show summary only on ReviewStep

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684853ce13d0832e87041a66dbc8a4b9