### PR TITLE
Fix newline at EOF for backend modules

### DIFF
--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -6,4 +6,4 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password) 
+    return pwd_context.verify(plain_password, hashed_password)

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,4 +2,4 @@ from app.main import app
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True) 
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- add missing newline at end of `backend/main.py`
- add missing newline at end of `backend/app/utils/auth.py`

## Testing
- `./scripts/test-all.sh` *(failed: Dependencies install timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68485b612dc8832e8c2cd233822c6982