### PR TITLE
Add cache archiving to docker-test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,9 @@ This command builds (or pulls) the image and copies `backend/venv` and
 `frontend/node_modules` from the container. After it finishes you should have
 `backend/venv/.install_complete` and
 `frontend/node_modules/.install_complete` in your working tree. It also
-compresses these directories into `backend/venv.tar.zst` and
-`frontend/node_modules.tar.zst` so they can be restored later without Docker.
+archives these directories using `tar --use-compress-program=zstd` into
+`backend/venv.tar.zst` and `frontend/node_modules.tar.zst` so they can be
+restored later without Docker.
 
 2. **Run tests offline**
 

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -76,3 +76,18 @@ docker run --rm --network "$NETWORK" -v "$(pwd)":$WORKDIR "$IMAGE" \
                fi; \
              fi && \
              cd $WORKDIR && ./setup.sh && $SCRIPT"
+
+# After the Docker run completes, archive the dependency caches so future
+# offline runs can extract them without Docker. Archives are compressed using
+# `zstd` for speed and smaller size.
+compress_cache() {
+  local src=$1
+  local archive=$2
+  if [ -d "$src" ]; then
+    echo "Archiving $(basename "$src") to $(basename "$archive")"
+    tar -C "$(dirname "$src")" --use-compress-program=zstd -cf "$archive" "$(basename "$src")"
+  fi
+}
+
+compress_cache "$HOST_REPO/backend/venv" "$HOST_REPO/backend/venv.tar.zst"
+compress_cache "$HOST_REPO/frontend/node_modules" "$HOST_REPO/frontend/node_modules.tar.zst"


### PR DESCRIPTION
## Summary
- archive backend `venv` and frontend `node_modules` after docker-test run
- document use of `tar --use-compress-program=zstd` in README

## Testing
- `./scripts/test-all.sh` *(fails: Installing frontend Node dependencies…)*
- `BOOKING_APP_BUILD=1 DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh` *(fails: Docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488b454ec8832ea436620394eb2e1c