### PR TITLE
Update setup.sh npm install options

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -76,7 +76,7 @@ if [ -f "$FRONTEND_MARKER" ]; then
     echo "package-lock.json changed; reinstalling Node dependencies…"
     pushd "$FRONTEND_DIR" > /dev/null
     npm config set install-links true
-    if npm ci --no-progress; then
+    if npm ci --prefer-offline --no-audit --progress=false; then
       echo "$CURRENT_PKG_HASH" > "$PKG_HASH_FILE"
       touch "$FRONTEND_MARKER"
     else
@@ -90,7 +90,7 @@ if [ -f "$FRONTEND_MARKER" ]; then
 else
   pushd "$FRONTEND_DIR" > /dev/null
   npm config set install-links true
-  if npm ci --no-progress; then
+  if npm ci --prefer-offline --no-audit --progress=false; then
     echo "$CURRENT_PKG_HASH" > "$PKG_HASH_FILE"
     touch "$FRONTEND_MARKER"
   else


### PR DESCRIPTION
## Summary
- use `--prefer-offline --no-audit --progress=false` for npm installs in `setup.sh`

## Testing
- `./scripts/test-all.sh` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68488d6a0434832ea4fb063bc786aadb