### PR TITLE
Update docker-test with auto bridge network

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@ so that `npm ci` runs reliably during the build.
    DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh
    ```
 
-   This pulls (or builds) the testing image and copies `backend/venv` and
-   `frontend/node_modules` from the container. If only the `*.tar.zst` archives
-   exist, the script extracts them so the directories are restored. This first
-   run is mandatory&mdash;`./scripts/test-all.sh` will fail until these caches
-   are populated.
+This pulls (or builds) the testing image and copies `backend/venv` and
+`frontend/node_modules` from the container. If only the `*.tar.zst` archives
+exist, the script extracts them so the directories are restored. This first
+run is mandatory&mdash;`./scripts/test-all.sh` will fail until these caches
+are populated.
+
+If `DOCKER_TEST_NETWORK` isn't set and the caches are missing, the script
+now automatically uses `--network bridge` and prints a notice so the
+dependencies can be fetched.
 
 2. **Run tests offline**
 
@@ -312,6 +316,9 @@ the container. If either cache is missing, it prints a warning like
 `DOCKER_TEST_NETWORK=bridge` so the dependencies can be copied over. Once the
 caches are in place, future runs with `--network none` complete quickly because
 the cached directories are reused.
+If `DOCKER_TEST_NETWORK` isn't set and these markers are absent, `docker-test.sh`
+automatically uses `bridge` and prints a notice so the caches are populated
+without failing.
 
 If `setup.sh` still tries to run `pip install` or `npm ci`, it means the marker
 files were not copied correctly. Rerun `scripts/docker-test.sh` with

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -29,6 +29,15 @@ decompress_cache() {
 decompress_cache "$HOST_REPO/backend/venv.tar.zst" "$HOST_REPO/backend/venv"
 decompress_cache "$HOST_REPO/frontend/node_modules.tar.zst" "$HOST_REPO/frontend/node_modules"
 
+# Automatically enable network access when dependency caches are missing and
+# DOCKER_TEST_NETWORK wasn't specified by the user. This helps first-time runs
+# populate `backend/venv` and `frontend/node_modules` without failing.
+if [ -z "${DOCKER_TEST_NETWORK+x}" ] && { [ ! -f "$HOST_REPO/backend/venv/.install_complete" ] || \ 
+     [ ! -f "$HOST_REPO/frontend/node_modules/.install_complete" ]; }; then
+  NETWORK=bridge
+  echo "Dependency caches missing. Using --network bridge to populate them."
+fi
+
 # Fallback to local tests when Docker is not installed. This allows CI
 # environments without Docker to still execute the full test suite.
 if ! command -v docker >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- automatically switch docker-test to bridge mode when caches are missing
- document the new fallback behavior in README

## Testing
- `bash -x ./scripts/test-all.sh > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6848904ec0f8832e8f56127bff462dce