### PR TITLE
Refined booking wizard UI

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -39,7 +39,7 @@ This document outlines key friction points in the current booking wizard and pro
   - Confirm submission with toast and inline message.
 
 ## Global Recommendations
-* Keep the progress <code>Stepper</code> fixed below the header for quick navigation.
+* Show a simple progress bar above the form steps. The bar scrolls naturally with the page instead of sticking under the header.
 * Ensure all buttons have at least 44×44 px tappable area and sufficient contrast.
 * Defer maps and heavy images until after the initial step loads.
 * Provide skeleton loaders for availability checks and quote calculations.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -235,10 +235,10 @@ export default function BookingWizard({
   };
 
   return (
-    <div className="lg:flex lg:space-x-4">
-      <div className="flex-1 space-y-4">
-        <Stepper steps={steps} currentStep={step} />
-        <h2 className="text-xl font-semibold" data-testid="step-heading">
+    <div className="px-4">
+      <Stepper steps={steps} currentStep={step} />
+      <div className="max-w-md mx-auto p-4 bg-white rounded-lg shadow-sm space-y-6">
+        <h2 className="text-2xl font-bold" data-testid="step-heading">
           {steps[step]}
         </h2>
 
@@ -248,7 +248,7 @@ export default function BookingWizard({
           <p className="text-red-600 text-sm">Please fix the errors above.</p>
         )}
         {error && <p className="text-red-600 text-sm">{error}</p>}
-        <div className="flex flex-col sm:flex-row justify-between gap-2 mt-6">
+        <div className="flex flex-col sm:flex-row gap-2 mt-6">
           {step > 0 && (
             <Button
               variant="secondary"
@@ -268,22 +268,27 @@ export default function BookingWizard({
             Save Draft
           </Button>
           {step < steps.length - 1 ? (
-            <Button type="button" onClick={next} className="w-full sm:w-auto">
+            <Button
+              variant="primary"
+              type="button"
+              onClick={next}
+              className="w-full sm:w-auto"
+            >
               Next
             </Button>
           ) : (
             <Button
+              variant="primary"
               type="button"
               onClick={submitRequest}
               disabled={submitting}
-              className="bg-green-600 hover:bg-green-700 focus:ring-green-500 w-full sm:w-auto"
+              className="w-full sm:w-auto"
             >
               {submitting ? 'Submitting...' : 'Submit Request'}
             </Button>
           )}
         </div>
       </div>
-      
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -8,28 +8,30 @@ interface Props {
 export default function SoundStep({ control }: Props) {
   return (
     <div className="space-y-4">
-      <label className="block text-sm font-medium mb-2">Is sound needed?</label>
+      <label className="block mb-2 font-medium">Is sound needed?</label>
       <Controller
         name="sound"
         control={control}
         render={({ field }) => (
-          <div className="space-x-4">
-            <label className="inline-flex items-center">
+          <div className="space-y-2">
+            <label>
               <input
                 type="radio"
+                name={field.name}
                 value="yes"
                 checked={field.value === 'yes'}
-                onChange={() => field.onChange('yes')}
+                onChange={(e) => field.onChange(e.target.value)}
                 className="mr-1"
               />
               Yes
             </label>
-            <label className="inline-flex items-center">
+            <label>
               <input
                 type="radio"
+                name={field.name}
                 value="no"
                 checked={field.value === 'no'}
-                onChange={() => field.onChange('no')}
+                onChange={(e) => field.onChange(e.target.value)}
                 className="mr-1"
               />
               No

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -8,38 +8,41 @@ interface Props {
 export default function VenueStep({ control }: Props) {
   return (
     <div className="space-y-4">
-      <label className="block text-sm font-medium mb-2">Venue Type</label>
+      <label className="block mb-2 font-medium">Venue Type</label>
       <Controller
         name="venueType"
         control={control}
         render={({ field }) => (
-          <div className="space-x-4">
-            <label className="inline-flex items-center">
+          <div className="space-y-2">
+            <label>
               <input
                 type="radio"
+                name={field.name}
                 value="indoor"
                 checked={field.value === 'indoor'}
-                onChange={() => field.onChange('indoor')}
+                onChange={(e) => field.onChange(e.target.value)}
                 className="mr-1"
               />
               Indoor
             </label>
-            <label className="inline-flex items-center">
+            <label>
               <input
                 type="radio"
+                name={field.name}
                 value="outdoor"
                 checked={field.value === 'outdoor'}
-                onChange={() => field.onChange('outdoor')}
+                onChange={(e) => field.onChange(e.target.value)}
                 className="mr-1"
               />
               Outdoor
             </label>
-            <label className="inline-flex items-center">
+            <label>
               <input
                 type="radio"
+                name={field.name}
                 value="hybrid"
                 checked={field.value === 'hybrid'}
-                onChange={() => field.onChange('hybrid')}
+                onChange={(e) => field.onChange(e.target.value)}
                 className="mr-1"
               />
               Hybrid

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,9 +1,8 @@
 'use client';
 import React from 'react';
-// Simplified progress bar that highlights the current step and shows
-// past steps as semi-active. The bar sticks below the header on mobile
-// so progress stays visible while scrolling.
-import useIsMobile from '@/hooks/useIsMobile';
+// Lightweight horizontal progress indicator used by the booking wizard.
+// Each step is represented by a small circle and label. The current step
+// is highlighted in black while the remaining steps appear gray.
 
 interface StepperProps {
   steps: string[];
@@ -11,36 +10,24 @@ interface StepperProps {
 }
 
 export default function Stepper({ steps, currentStep }: StepperProps) {
-  const isMobile = useIsMobile();
-
   return (
-    <div className={`sticky top-16 z-30 bg-white py-2 ${isMobile ? '' : 'mb-4'}`}> 
-      <div className="flex items-center" aria-label="Progress">
-        {steps.map((label, i) => {
-          const state = i < currentStep ? 'past' : i === currentStep ? 'current' : 'future';
-          const circleClass =
-            state === 'current'
-              ? 'bg-indigo-600 text-white'
-              : state === 'past'
-                ? 'bg-indigo-100 text-indigo-600'
-                : 'bg-gray-200 text-gray-400';
-          const textClass =
-            state === 'current'
-              ? 'font-bold text-gray-900'
-              : state === 'past'
-                ? 'text-gray-700'
-                : 'text-gray-400';
-          return (
-            <div key={label} className="flex items-center flex-1">
-              <div className={`h-4 w-4 rounded-full ${circleClass}`} />
-              <span className={`ml-2 text-xs sm:text-sm ${textClass}`}>{label}</span>
-              {i < steps.length - 1 && (
-                <div className="flex-1 border-t border-gray-300 mx-2" />
-              )}
-            </div>
-          );
-        })}
-      </div>
+    <div className="flex justify-center space-x-4 my-6" aria-label="Progress">
+      {steps.map((label, index) => (
+        <div key={label} className="flex flex-col items-center text-xs">
+          <div
+            className={`w-4 h-4 rounded-full ${
+              index === currentStep ? 'bg-black' : 'bg-gray-300'
+            }`}
+          />
+          <span
+            className={`mt-1 ${
+              index === currentStep ? 'font-semibold text-black' : 'text-gray-400'
+            }`}
+          >
+            {label}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -20,22 +20,12 @@ describe('Stepper progress bar', () => {
     container.remove();
   });
 
-  it('is sticky on mobile', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
-    act(() => {
-      root.render(<Stepper steps={["One", "Two"]} currentStep={0} />);
-    });
-    const div = container.querySelector('div');
-    expect(div?.className).toContain('sticky');
-  });
-
   it('shows step names and highlights the current one', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
     act(() => {
       root.render(<Stepper steps={["One", "Two", "Three"]} currentStep={1} />);
     });
     const spans = container.querySelectorAll('span');
-    expect(spans[1].className).toContain('font-bold');
+    expect(spans[1].className).toContain('font-semibold');
     expect(container.textContent).toContain('Three');
   });
 });

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -2,11 +2,11 @@ import { buttonVariants } from '../buttonVariants';
 
 describe('buttonVariants', () => {
   it('provides classes for primary buttons', () => {
-    expect(buttonVariants.primary).toMatch('bg-brand');
+    expect(buttonVariants.primary).toMatch('bg-blue-600');
   });
 
   it('provides classes for secondary buttons', () => {
-    expect(buttonVariants.secondary).toMatch('bg-brand-light');
+    expect(buttonVariants.secondary).toMatch('bg-gray-100');
   });
 
   it('provides classes for danger buttons', () => {

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,7 +1,6 @@
 export const buttonVariants = {
-  primary: 'bg-brand text-white hover:bg-brand-dark focus:ring-brand-dark',
-  secondary:
-    'bg-brand-light text-brand-dark hover:bg-brand focus:ring-brand-dark',
+  primary: 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-700',
+  secondary: 'bg-gray-100 text-black hover:bg-gray-200 focus:ring-gray-300',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
 } as const;
 


### PR DESCRIPTION
## Summary
- modernize wizard progress UI and form container
- style buttons with simple blue/gray themes
- update Venue and Sound steps to use radio groups
- adjust Stepper tests and button variant tests
- update mobile UX docs to match new progress bar behavior
- ensure "Next" and "Submit Request" buttons use the blue primary style

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68489edd7f2c832ebf65383f390999f6