### PR TITLE
Refactor booking steps button layout

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -3,11 +3,10 @@
 // marked TODO highlight planned mobile UX enhancements like collapsible
 // sections and sticky progress indicators.
 import { useEffect, useState } from 'react';
-import type { Control, FieldValues, UseFormWatch } from 'react-hook-form';
+import type { Control, FieldValues } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import * as yup from 'yup';
 import { format } from 'date-fns';
-import Button from '../ui/Button';
 import Stepper from '../ui/Stepper'; // progress indicator
 import toast from '../ui/Toast';
 import {
@@ -76,7 +75,6 @@ export default function BookingWizard({
     control,
     handleSubmit,
     trigger,
-    watch,
     setValue,
     errors,
   } = useBookingForm(schema, details, setDetails);
@@ -198,7 +196,10 @@ export default function BookingWizard({
           <DateTimeStep
             control={control as unknown as Control<FieldValues>}
             unavailable={unavailable}
-            watch={watch as unknown as UseFormWatch<FieldValues>}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
             onNext={next}
           />
         );
@@ -208,24 +209,53 @@ export default function BookingWizard({
             control={control as unknown as Control<FieldValues>}
             artistLocation={artistLocation || undefined}
             setWarning={setWarning}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
             onNext={next}
           />
         );
       case 2:
-        return <VenueStep control={control as unknown as Control<FieldValues>} onNext={next} />;
+        return (
+          <VenueStep
+            control={control as unknown as Control<FieldValues>}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
+            onNext={next}
+          />
+        );
       case 3:
-        return <SoundStep control={control as unknown as Control<FieldValues>} onNext={next} />;
+        return (
+          <SoundStep
+            control={control as unknown as Control<FieldValues>}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
+            onNext={next}
+          />
+        );
       case 4:
         return (
           <NotesStep
             control={control as unknown as Control<FieldValues>}
             setValue={setValue as unknown as (name: string, value: unknown) => void}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
             onNext={next}
           />
         );
       default:
         return (
           <ReviewStep
+            step={step}
+            steps={steps}
+            onBack={prev}
             onSaveDraft={saveDraft}
             onSubmit={submitRequest}
             submitting={submitting}
@@ -248,48 +278,6 @@ export default function BookingWizard({
           <p className="text-red-600 text-sm">Please fix the errors above.</p>
         )}
         {error && <p className="text-red-600 text-sm">{error}</p>}
-        <div className="flex justify-between items-center mt-6">
-          {step > 0 && (
-            <Button
-              variant="secondary"
-              type="button"
-              onClick={prev}
-              className="w-full sm:w-auto"
-            >
-              Back
-            </Button>
-          )}
-          <div className="flex gap-2">
-            <Button
-              variant="secondary"
-              type="button"
-              onClick={saveDraft}
-              className="w-full sm:w-auto"
-            >
-              Save Draft
-            </Button>
-            {step < steps.length - 1 ? (
-              <Button
-                variant="primary"
-                type="button"
-                onClick={next}
-                className="w-full sm:w-auto"
-              >
-                Next
-              </Button>
-            ) : (
-              <Button
-                variant="primary"
-                type="button"
-                onClick={submitRequest}
-                disabled={submitting}
-                className="w-full sm:w-auto"
-              >
-                {submitting ? 'Submitting...' : 'Submit Request'}
-              </Button>
-            )}
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -52,8 +52,14 @@ describe('BookingWizard flow', () => {
     jest.clearAllMocks();
   });
 
+  function getButton(label: string): HTMLButtonElement {
+    return Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes(label),
+    ) as HTMLButtonElement;
+  }
+
   it('scrolls to top when advancing steps', async () => {
-    const nextButton = container.querySelectorAll('button[type="button"]')[1] as HTMLButtonElement;
+    const nextButton = getButton('Next');
     await act(async () => {
       nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -64,7 +70,7 @@ describe('BookingWizard flow', () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;
     expect(heading()).toContain('Date & Time');
-    const next = container.querySelectorAll('button[type="button"]')[1] as HTMLButtonElement;
+    const next = getButton('Next');
     await act(async () => {
       next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -9,9 +9,22 @@ import useIsMobile from '@/hooks/useIsMobile';
 interface Props {
   control: Control<FieldValues>;
   unavailable: string[];
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
-export default function DateTimeStep({ control, unavailable }: Props) {
+export default function DateTimeStep({
+  control,
+  unavailable,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
+}: Props) {
   const isMobile = useIsMobile();
   const tileDisabled = ({ date }: { date: Date }) => {
     const day = format(date, 'yyyy-MM-dd');
@@ -53,6 +66,34 @@ export default function DateTimeStep({ control, unavailable }: Props) {
           );
         }}
       />
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -17,6 +17,11 @@ interface Props {
   control: Control<FieldValues>;
   artistLocation?: string | null;
   setWarning: (w: string | null) => void;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
 const containerStyle = { width: '100%', height: '250px' };
@@ -73,6 +78,11 @@ export default function LocationStep({
   control,
   artistLocation,
   setWarning,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
 }: Props): JSX.Element {
   const { isLoaded } = useLoadScript({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
@@ -145,6 +155,34 @@ export default function LocationStep({
         ?
       </span>
       {geoError && <p className="text-red-600 text-sm">{geoError}</p>}
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -8,9 +8,22 @@ import toast from '../../ui/Toast';
 interface Props {
   control: Control<FieldValues>;
   setValue: (name: string, value: unknown) => void;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
-export default function NotesStep({ control, setValue }: Props) {
+export default function NotesStep({
+  control,
+  setValue,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
+}: Props) {
   const isMobile = useIsMobile();
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -46,6 +59,34 @@ export default function NotesStep({ control, setValue }: Props) {
       />
       <label className="block text-sm font-medium">Attachment (optional)</label>
       <input type="file" onChange={handleFileChange} />
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -2,13 +2,58 @@
 // Final review step showing a summary of all selections.
 import SummarySidebar from '../SummarySidebar';
 
-export default function ReviewStep() {
+interface Props {
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+}
+
+export default function ReviewStep({
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onSubmit,
+  submitting,
+}: Props) {
   return (
     <div className="space-y-4">
       <SummarySidebar />
       <p className="text-gray-600 text-sm">
         Please confirm the information above before sending your request.
       </p>
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={submitting}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {submitting ? 'Submitting...' : step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -3,9 +3,21 @@ import { Control, Controller, FieldValues } from 'react-hook-form';
 
 interface Props {
   control: Control<FieldValues>;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
-export default function SoundStep({ control }: Props) {
+export default function SoundStep({
+  control,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
+}: Props) {
   return (
     <div className="space-y-4">
       <Controller
@@ -37,6 +49,34 @@ export default function SoundStep({ control }: Props) {
           </fieldset>
         )}
       />
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -3,9 +3,21 @@ import { Controller, Control, FieldValues } from 'react-hook-form';
 
 interface Props {
   control: Control<FieldValues>;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
-export default function VenueStep({ control }: Props) {
+export default function VenueStep({
+  control,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
+}: Props) {
   return (
     <div className="space-y-4">
       <Controller
@@ -47,6 +59,34 @@ export default function VenueStep({ control }: Props) {
           </fieldset>
         )}
       />
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
@@ -12,6 +12,11 @@ function Wrapper() {
     <DateTimeStep
       control={control as unknown as Control<FieldValues>}
       unavailable={[]}
+      step={0}
+      steps={['one']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
     />
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -7,7 +7,16 @@ import LocationStep from '../LocationStep';
 function Wrapper() {
   const { control } = useForm();
   return (
-    <LocationStep control={control as unknown as Control<FieldValues>} setWarning={() => {}} />
+    <LocationStep
+      control={control as unknown as Control<FieldValues>}
+      setWarning={() => {}}
+      step={1}
+      steps={['one', 'two']}
+      artistLocation={null}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
+    />
   );
 }
 

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -6,7 +6,16 @@ import VenueStep from '../VenueStep';
 
 function Wrapper() {
   const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
-  return <VenueStep control={control as unknown as Control<FieldValues>} />;
+  return (
+    <VenueStep
+      control={control as unknown as Control<FieldValues>}
+      step={2}
+      steps={['one', 'two', 'three']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
+    />
+  );
 }
 
 describe('VenueStep radio buttons', () => {


### PR DESCRIPTION
## Summary
- move step navigation into each booking step component
- implement consistent responsive button group layout
- update BookingWizard to pass handlers to steps
- adjust unit tests for new props and layout

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848aa5bbe2c832e8cf2fcc316945973