### PR TITLE
Add framer-motion step transitions and clickable progress dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `Escape` or tap outside.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
 * Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
+* Steps now animate with **framer-motion** and the progress dots let you jump back to previous steps.
 
 ### Open Tasks
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import * as yup from 'yup';
 import { format } from 'date-fns';
 import Stepper from '../ui/Stepper'; // progress indicator
+import { AnimatePresence, motion } from 'framer-motion';
 import toast from '../ui/Toast';
 import {
   getArtistAvailability,
@@ -126,6 +127,9 @@ export default function BookingWizard({
     if (valid) setStep(step + 1);
   };
   const prev = () => setStep(step - 1);
+  const handleStepClick = (i: number) => {
+    if (i < step) setStep(i);
+  };
 
   const saveDraft = handleSubmit(async (vals) => {
     const payload: BookingRequestCreate = {
@@ -266,13 +270,23 @@ export default function BookingWizard({
 
   return (
     <div className="px-4">
-      <Stepper steps={steps} currentStep={step} />
+      <Stepper steps={steps} currentStep={step} onStepClick={handleStepClick} />
       <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md space-y-6">
         <h2 className="text-2xl font-bold" data-testid="step-heading">
           {steps[step]}
         </h2>
 
-        {renderStep()}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.3 }}
+          >
+            {renderStep()}
+          </motion.div>
+        </AnimatePresence>
         {warning && <p className="text-orange-600 text-sm">{warning}</p>}
         {Object.values(errors).length > 0 && (
           <p className="text-red-600 text-sm">Please fix the errors above.</p>

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -83,8 +83,25 @@ describe('BookingWizard flow', () => {
     expect(container.textContent).not.toContain('Summary');
     const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
     await act(async () => { setStep(5); });
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 400));
     expect(container.querySelector('h2')?.textContent).toContain('Review');
     expect(container.textContent).toContain('Summary');
+  });
+
+  it('allows navigating back via the progress bar', async () => {
+    const next = getButton('Next');
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+    expect(progressButtons).toHaveLength(1);
+    await act(async () => {
+      progressButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 400));
+    expect(
+      container.querySelector('[data-testid="step-heading"]')?.textContent,
+    ).toContain('Date & Time');
   });
 });

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -7,27 +7,48 @@ import React from 'react';
 interface StepperProps {
   steps: string[];
   currentStep: number;
+  onStepClick?: (index: number) => void;
 }
 
-export default function Stepper({ steps, currentStep }: StepperProps) {
+export default function Stepper({ steps, currentStep, onStepClick }: StepperProps) {
   return (
     <div className="flex justify-center space-x-4 my-6" aria-label="Progress">
-      {steps.map((label, i) => (
-        <div key={label} className="flex flex-col items-center text-sm">
-          <div
-            className={`w-3 h-3 rounded-full ${
-              i === currentStep ? 'bg-black' : 'bg-gray-300'
-            }`}
-          />
-          <span
-            className={`mt-1 ${
-              i === currentStep ? 'font-medium text-black' : 'text-gray-400'
-            }`}
-          >
-            {label}
-          </span>
-        </div>
-      ))}
+      {steps.map((label, i) => {
+        const content = (
+          <>
+            <div
+              className={`w-3 h-3 rounded-full ${
+                i === currentStep ? 'bg-black' : 'bg-gray-300'
+              }`}
+            />
+            <span
+              className={`mt-1 ${
+                i === currentStep ? 'font-medium text-black' : 'text-gray-400'
+              }`}
+            >
+              {label}
+            </span>
+          </>
+        );
+
+        if (onStepClick && i < currentStep) {
+          return (
+            <button
+              type="button"
+              key={label}
+              onClick={() => onStepClick(i)}
+              className="flex flex-col items-center text-sm cursor-pointer focus:outline-none"
+            >
+              {content}
+            </button>
+          );
+        }
+        return (
+          <div key={label} className="flex flex-col items-center text-sm">
+            {content}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -28,4 +28,23 @@ describe('Stepper progress bar', () => {
     expect(spans[1].className).toContain('font-medium');
     expect(container.textContent).toContain('Three');
   });
+
+  it('calls onStepClick for previous steps', () => {
+    const clickSpy = jest.fn();
+    act(() => {
+      root.render(
+        <Stepper
+          steps={["One", "Two", "Three"]}
+          currentStep={2}
+          onStepClick={clickSpy}
+        />,
+      );
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(2);
+    act(() => {
+      buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(clickSpy).toHaveBeenCalledWith(0);
+  });
 });


### PR DESCRIPTION
## Summary
- animate BookingWizard steps with AnimatePresence and motion.div
- allow going back via progress bar stepper dots
- update progress bar Stepper component to support click events
- document wizard step animations in README
- test clickable progress bar and updated Stepper

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848ae9b24c0832ea316da5be55b8530