### PR TITLE
Add progress step clickability

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `Escape` or tap outside.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
 * Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
+* Steps now animate with **framer-motion** and the progress dots let you jump back to previous steps.
 
 ### Open Tasks
 

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -83,8 +83,28 @@ describe('BookingWizard flow', () => {
     expect(container.textContent).not.toContain('Summary');
     const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
     await act(async () => { setStep(5); });
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 400));
     expect(container.querySelector('h2')?.textContent).toContain('Review');
     expect(container.textContent).toContain('Summary');
   });
+
+  it('allows navigating back via the progress bar', async () => {
+    const next = getButton('Next');
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const progressButtons = container.querySelectorAll(
+      '[aria-label="Progress"] button',
+    );
+    expect(progressButtons).toHaveLength(1);
+    await act(async () => {
+      progressButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 400));
+    expect(
+      container.querySelector('[data-testid="step-heading"]')?.textContent,
+    ).toContain('Date & Time');
+  });
+
 });

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -7,27 +7,54 @@ import React from 'react';
 interface StepperProps {
   steps: string[];
   currentStep: number;
+  maxStepCompleted?: number;
+  onStepClick?: (index: number) => void;
 }
 
-export default function Stepper({ steps, currentStep }: StepperProps) {
+export default function Stepper({
+  steps,
+  currentStep,
+  maxStepCompleted = currentStep - 1,
+  onStepClick,
+}: StepperProps) {
   return (
     <div className="flex justify-center space-x-4 my-6" aria-label="Progress">
-      {steps.map((label, i) => (
-        <div key={label} className="flex flex-col items-center text-sm">
-          <div
-            className={`w-3 h-3 rounded-full ${
-              i === currentStep ? 'bg-black' : 'bg-gray-300'
-            }`}
-          />
-          <span
-            className={`mt-1 ${
-              i === currentStep ? 'font-medium text-black' : 'text-gray-400'
-            }`}
-          >
-            {label}
-          </span>
-        </div>
-      ))}
+      {steps.map((label, i) => {
+        const content = (
+          <>
+            <div
+              className={`w-3 h-3 rounded-full ${
+                i === currentStep ? 'bg-black' : 'bg-gray-300'
+              }`}
+            />
+            <span
+              className={`mt-1 ${
+                i === currentStep ? 'font-medium text-black' : 'text-gray-400'
+              }`}
+            >
+              {label}
+            </span>
+          </>
+        );
+
+        if (onStepClick && i <= maxStepCompleted) {
+          return (
+            <button
+              type="button"
+              key={label}
+              onClick={() => onStepClick(i)}
+              className="flex flex-col items-center text-sm cursor-pointer focus:outline-none"
+            >
+              {content}
+            </button>
+          );
+        }
+        return (
+          <div key={label} className="flex flex-col items-center text-sm">
+            {content}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -22,10 +22,52 @@ describe('Stepper progress bar', () => {
 
   it('shows step names and highlights the current one', () => {
     act(() => {
-      root.render(<Stepper steps={["One", "Two", "Three"]} currentStep={1} />);
+      root.render(
+        <Stepper steps={["One", "Two", "Three"]} currentStep={1} />,
+      );
     });
     const spans = container.querySelectorAll('span');
     expect(spans[1].className).toContain('font-medium');
     expect(container.textContent).toContain('Three');
+  });
+
+  it('calls onStepClick for previous steps', () => {
+    const clickSpy = jest.fn();
+    act(() => {
+      root.render(
+        <Stepper
+          steps={["One", "Two", "Three"]}
+          currentStep={2}
+          maxStepCompleted={2}
+          onStepClick={clickSpy}
+        />,
+      );
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(3);
+    act(() => {
+      buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(clickSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('allows clicking steps up to maxStepCompleted even when behind', () => {
+    const clickSpy = jest.fn();
+    act(() => {
+      root.render(
+        <Stepper
+          steps={["One", "Two", "Three"]}
+          currentStep={0}
+          maxStepCompleted={2}
+          onStepClick={clickSpy}
+        />,
+      );
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(3);
+    act(() => {
+      buttons[2].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(clickSpy).toHaveBeenCalledWith(2);
   });
 });


### PR DESCRIPTION
## Summary
- track max completed wizard step so forward steps stay clickable when navigating backwards
- allow Stepper buttons up to that step
- update tests for clickable progress bar behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848ae9b24c0832ea316da5be55b8530