### PR TITLE
Enable navigation to completed booking steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `Escape` or tap outside.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
 * Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
-* Steps now animate with **framer-motion** and the progress dots let you jump back to previous steps.
+* Steps now animate with **framer-motion** and the progress dots stay clickable for all completed steps.
 
 ### Open Tasks
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -71,6 +71,12 @@ export default function BookingWizard({
   const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [maxStepCompleted, setMaxStepCompleted] = useState(0);
+
+  // Ensure maxStepCompleted always reflects the furthest step reached.
+  useEffect(() => {
+    setMaxStepCompleted((prev) => Math.max(prev, step));
+  }, [step]);
 
   const {
     control,
@@ -124,11 +130,15 @@ export default function BookingWizard({
         fields = [];
     }
     const valid = await trigger(fields);
-    if (valid) setStep(step + 1);
+    if (valid) {
+      const newStep = step + 1;
+      setStep(newStep);
+      setMaxStepCompleted(Math.max(maxStepCompleted, newStep));
+    }
   };
   const prev = () => setStep(step - 1);
   const handleStepClick = (i: number) => {
-    if (i < step) setStep(i);
+    if (i <= maxStepCompleted && i !== step) setStep(i);
   };
 
   const saveDraft = handleSubmit(async (vals) => {
@@ -270,7 +280,12 @@ export default function BookingWizard({
 
   return (
     <div className="px-4">
-      <Stepper steps={steps} currentStep={step} onStepClick={handleStepClick} />
+      <Stepper
+        steps={steps}
+        currentStep={step}
+        maxStepCompleted={maxStepCompleted}
+        onStepClick={handleStepClick}
+      />
       <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md space-y-6">
         <h2 className="text-2xl font-bold" data-testid="step-heading">
           {steps[step]}

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -104,4 +104,18 @@ describe('BookingWizard flow', () => {
       container.querySelector('[data-testid="step-heading"]')?.textContent,
     ).toContain('Date & Time');
   });
+
+  it('keeps future completed steps clickable when rewinding', async () => {
+    const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
+    await act(async () => { setStep(2); });
+    await new Promise((r) => setTimeout(r, 0));
+    let progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+    await act(async () => {
+      progressButtons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 400));
+    // query again after DOM update
+    progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+    expect((progressButtons[2] as HTMLButtonElement).disabled).toBe(false);
+  });
 });

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -7,10 +7,11 @@ import React from 'react';
 interface StepperProps {
   steps: string[];
   currentStep: number;
+  maxStepCompleted?: number;
   onStepClick?: (index: number) => void;
 }
 
-export default function Stepper({ steps, currentStep, onStepClick }: StepperProps) {
+export default function Stepper({ steps, currentStep, maxStepCompleted, onStepClick }: StepperProps) {
   return (
     <div className="flex justify-center space-x-4 my-6" aria-label="Progress">
       {steps.map((label, i) => {
@@ -31,15 +32,19 @@ export default function Stepper({ steps, currentStep, onStepClick }: StepperProp
           </>
         );
 
+        const maxStep =
+          typeof maxStepCompleted === 'number' ? maxStepCompleted : currentStep;
         if (onStepClick) {
           return (
             <button
               type="button"
               key={label}
-              onClick={() => i <= currentStep && onStepClick(i)}
-              disabled={i > currentStep}
+              onClick={() => i <= maxStep && i !== currentStep && onStepClick(i)}
+              disabled={i > maxStep || i === currentStep}
               className={`flex flex-col items-center text-sm focus:outline-none ${
-                i > currentStep ? 'cursor-not-allowed' : 'cursor-pointer'
+                i > maxStep || i === currentStep
+                  ? 'cursor-not-allowed'
+                  : 'cursor-pointer'
               }`}
             >
               {content}

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -29,7 +29,7 @@ describe('Stepper progress bar', () => {
     expect(container.textContent).toContain('Three');
   });
 
-  it('calls onStepClick when clicking completed or current steps', () => {
+  it('calls onStepClick when clicking completed steps', () => {
     const clickSpy = jest.fn();
     act(() => {
       root.render(
@@ -47,6 +47,26 @@ describe('Stepper progress bar', () => {
     });
     expect(clickSpy).toHaveBeenCalledWith(0);
 
+    act(() => {
+      buttons[2].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(clickSpy).not.toHaveBeenCalledWith(2);
+  });
+
+  it('allows clicking a future step once completed previously', () => {
+    const clickSpy = jest.fn();
+    act(() => {
+      root.render(
+        <Stepper
+          steps={["One", "Two", "Three"]}
+          currentStep={1}
+          maxStepCompleted={2}
+          onStepClick={clickSpy}
+        />,
+      );
+    });
+    const buttons = container.querySelectorAll('button');
+    expect((buttons[2] as HTMLButtonElement).disabled).toBe(false);
     act(() => {
       buttons[2].dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });


### PR DESCRIPTION
## Summary
- keep booking progress clickable for all completed steps
- track max completed step in booking wizard
- disable stepper button for current step only
- update docs about clickable progress dots
- adjust tests for stepper and booking wizard

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68492c52a0a4832e8bb12cef0e104956