### PR TITLE
Fix Stepper cursor on current step

### DIFF
--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -42,9 +42,11 @@ export default function Stepper({ steps, currentStep, maxStepCompleted, onStepCl
               onClick={() => i <= maxStep && i !== currentStep && onStepClick(i)}
               disabled={i > maxStep || i === currentStep}
               className={`flex flex-col items-center text-sm focus:outline-none ${
-                i > maxStep || i === currentStep
+                i > maxStep
                   ? 'cursor-not-allowed'
-                  : 'cursor-pointer'
+                  : i === currentStep
+                    ? 'cursor-default'
+                    : 'cursor-pointer'
               }`}
             >
               {content}

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -88,4 +88,15 @@ describe('Stepper progress bar', () => {
     expect((buttons[1] as HTMLButtonElement).disabled).toBe(true);
     expect((buttons[2] as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it('shows default cursor on the current step', () => {
+    act(() => {
+      root.render(
+        <Stepper steps={["One", "Two", "Three"]} currentStep={1} onStepClick={() => {}} />,
+      );
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[1].className).toContain('cursor-default');
+    expect(buttons[1].className).not.toContain('cursor-not-allowed');
+  });
 });


### PR DESCRIPTION
## Summary
- prevent `cursor-not-allowed` on the active step in Stepper
- test that current step shows default cursor

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68492f5839f0832e8dcdb476d93807f1