### PR TITLE
Fix chat order in wizard

### DIFF
--- a/frontend/src/components/booking/ChatThreadView.tsx
+++ b/frontend/src/components/booking/ChatThreadView.tsx
@@ -32,7 +32,7 @@ export default function ChatThreadView({
           </div>
         </header>
         <div
-          className="flex-1 overflow-y-auto flex flex-col-reverse gap-2 p-4 max-w-[90vw] mx-auto"
+          className="flex-1 overflow-y-auto flex flex-col gap-2 p-4 max-w-[90vw] mx-auto"
           data-testid="message-container"
         >
           {children}

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -244,7 +244,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
         <div
           ref={containerRef}
           onScroll={handleScroll}
-          className="flex-1 overflow-y-auto flex flex-col-reverse gap-2 px-4 py-2"
+          className="flex-1 overflow-y-auto flex flex-col gap-2 px-4 py-2"
         >
         {loading ? (
           <div className="flex justify-center py-4" aria-label="Loading messages">


### PR DESCRIPTION
## Summary
- show messages top-to-bottom in ChatThreadView
- show messages top-to-bottom in MessageThread

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684932284b38832e8f2ab2b28f954a6f