### PR TITLE
Fix chat attachment alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Persistent bottom nav on small screens (visible only when logged in) with compact 56px height.
 * Bottom nav auto-hides when you scroll down and reappears when scrolling up.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
+* Chat attachment button stays inline with the message input and send button on all screens.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -445,11 +445,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           )}
           <form
             onSubmit={handleSend}
-            className="sticky bottom-0 bg-white border-t flex sm:flex-row flex-col items-center gap-2 px-4 py-3"
+            className="sticky bottom-0 bg-white border-t flex flex-row items-center gap-x-2 px-4 py-3"
           >
             <label
               htmlFor="file-upload"
-              className="p-2 text-gray-600 rounded-full hover:bg-gray-100"
+              className="w-8 h-8 flex items-center justify-center text-gray-600 rounded-full hover:bg-gray-100"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- keep chat attachment button inline on all screens
- document chat input layout update

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684943aa8c50832e988f1c69484ae4a3