### PR TITLE
Allow single-character chat messages

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -224,9 +224,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     ],
   );
 
-  // Filter out very short or empty messages before rendering
+  // Filter out empty messages before rendering so even 1-character
+  // messages like "ok" or "?" still show up
   const visibleMessages = useMemo(
-    () => messages.filter((m) => m.content && m.content.trim().length > 5),
+    () => messages.filter((m) => m.content && m.content.trim().length > 0),
     [messages],
   );
 

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -93,7 +93,7 @@ describe('MessageThread component', () => {
     expect(senderName?.textContent).toBe('Artist');
   });
 
-  it('filters out short messages', async () => {
+  it('displays short messages', async () => {
     (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
       data: [
         {
@@ -122,7 +122,8 @@ describe('MessageThread component', () => {
     });
 
     const messageBubbles = container.querySelectorAll('.whitespace-pre-wrap');
-    expect(messageBubbles.length).toBe(1);
-    expect(messageBubbles[0].textContent).toContain('Hello there');
+    expect(messageBubbles.length).toBe(2);
+    expect(messageBubbles[0].textContent).toContain('Hi');
+    expect(messageBubbles[1].textContent).toContain('Hello there');
   });
 });


### PR DESCRIPTION
## Summary
- allow empty message filtering to permit 1-char messages in chat
- expect short messages in MessageThread tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849457bcba4832ea6524f6dde0b7496