### PR TITLE
Fix duplicate automated video prompts

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -127,7 +127,12 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     socket.onmessage = (event) => {
       const msg: Message = JSON.parse(event.data);
       // keep only the latest 200 messages to avoid excessive memory usage
-      setMessages((prev) => [...prev.slice(-199), msg]);
+      setMessages((prev) => {
+        if (prev.some((m) => m.id === msg.id)) {
+          return prev;
+        }
+        return [...prev.slice(-199), msg];
+      });
       if (msg.message_type === 'quote') {
         fetchQuotes();
       }


### PR DESCRIPTION
## Summary
- avoid duplicate message objects when a new message arrives via websocket
- track websocket stub instances in tests and ensure deduplication logic works

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684948a5ebe8832e9cdb107a1e7e0ae7