### PR TITLE
Implement structured notifications and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Grouped by type, mark-as-read endpoints, and “Mark All as Read”.
 * "Unread Only" toggle filters message threads and alerts in the drawer and full-screen modal.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
+* Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
+* Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews.
 
 ### Artist Profile Enhancements
 

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -78,7 +78,15 @@ def create_booking_request(
     # The chat thread used to include a generic "Booking request sent" system
     # message immediately after creation. This extra message cluttered the
     # conversation view, so it has been removed.
-    notify_user_new_booking_request(db, artist_user, new_request.id)
+    service = None
+    if new_request.service_id:
+        service = db.query(models.Service).filter(models.Service.id == new_request.service_id).first()
+    booking_type = service.service_type if service else "General"
+    sender_name = f"{current_user.first_name} {current_user.last_name}"
+    if booking_type != "Personalized Video":
+        notify_user_new_booking_request(
+            db, artist_user, new_request.id, sender_name, booking_type
+        )
     return new_request
 
 @router.get("/me/client", response_model=List[schemas.BookingRequestResponse])

--- a/frontend/src/hooks/notificationUtils.ts
+++ b/frontend/src/hooks/notificationUtils.ts
@@ -10,7 +10,23 @@ export function mergeNotifications(
 ): Notification[] {
   const map = new Map<number, Notification>();
   [...existing, ...incoming].forEach((n) => map.set(n.id, n));
-  return Array.from(map.values()).sort(
+  const sorted = Array.from(map.values()).sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
   );
+  const deduped: Notification[] = [];
+  for (const n of sorted) {
+    const last = deduped[deduped.length - 1];
+    if (
+      last &&
+      last.type === n.type &&
+      last.link === n.link &&
+      last.message === n.message &&
+      Math.abs(new Date(last.timestamp).getTime() - new Date(n.timestamp).getTime()) <
+        10 * 60 * 1000
+    ) {
+      continue;
+    }
+    deduped.push(n);
+  }
+  return deduped;
 }


### PR DESCRIPTION
## Summary
- suppress notifications during personalized video flows and send single booking request alert after final prompt
- include sender name and booking type in booking request notifications
- deduplicate notifications on merge and format drawer items with icons
- add expandable two-line cards in notification drawer
- document updated notification behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684964ec7a60832e9db2de76ea13ac6a