### PR TITLE
Fix booking request notification parsing

### DIFF
--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -363,6 +363,21 @@ def test_format_notification_message_new_types():
     assert msg_review == "Please review your booking #42"
 
 
+def test_format_notification_message_booking_request():
+    msg_full = format_notification_message(
+        NotificationType.NEW_BOOKING_REQUEST,
+        sender_name="Bob",
+        booking_type="Performance",
+        request_id=5,
+    )
+    msg_simple = format_notification_message(
+        NotificationType.NEW_BOOKING_REQUEST,
+        request_id=7,
+    )
+    assert msg_full == "New booking request from Bob: Performance"
+    assert msg_simple == "New booking request #7"
+
+
 def test_personalized_video_notifications_suppressed_until_final():
     db = setup_db()
     client = User(

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -25,20 +25,33 @@ function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ');
 }
 
-interface ParsedNotification {
+export interface ParsedNotification {
   title: string;
   subtitle: string;
   icon: string;
 }
 
-function parseNotification(n: Notification): ParsedNotification {
+export function parseNotification(n: Notification): ParsedNotification {
   if (n.type === 'new_booking_request') {
     const match = n.message.match(/New booking request from (.+): (.+)/i);
     if (match) {
       const [, sender, btype] = match;
-      const icon = btype.includes('Video') ? '🎥' : btype.includes('Performance') ? '🎵' : '📅';
-      return { title: sender, subtitle: `sent a new booking request`, icon };
+      const icon = btype.includes('Video')
+        ? '🎥'
+        : btype.includes('Performance')
+          ? '🎵'
+          : '📅';
+      return {
+        title: sender,
+        subtitle: 'sent a new booking request',
+        icon,
+      };
     }
+    return {
+      title: 'New booking request',
+      subtitle: 'Tap to view details',
+      icon: '📅',
+    };
   }
   return { title: n.message, subtitle: '', icon: '🔔' };
 }

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -1,0 +1,34 @@
+import { parseNotification } from '../NotificationDrawer';
+import type { Notification } from '@/types';
+
+describe('parseNotification', () => {
+  it('parses booking request with sender and type', () => {
+    const n: Notification = {
+      id: 1,
+      user_id: 1,
+      type: 'new_booking_request',
+      message: 'New booking request from Alice: Performance',
+      link: '/booking-requests/1',
+      is_read: false,
+      timestamp: new Date().toISOString(),
+    };
+    const parsed = parseNotification(n);
+    expect(parsed.title).toBe('Alice');
+    expect(parsed.subtitle).toBe('sent a new booking request');
+  });
+
+  it('falls back when no sender or type in message', () => {
+    const n: Notification = {
+      id: 2,
+      user_id: 1,
+      type: 'new_booking_request',
+      message: 'New booking request #2',
+      link: '/booking-requests/2',
+      is_read: false,
+      timestamp: new Date().toISOString(),
+    };
+    const parsed = parseNotification(n);
+    expect(parsed.title).toBe('New booking request');
+    expect(parsed.subtitle).toBe('Tap to view details');
+  });
+});


### PR DESCRIPTION
## Summary
- format `NEW_BOOKING_REQUEST` notifications using sender and booking type
- expose `parseNotification` utility
- parse fallback message for booking requests in the notification drawer
- add unit tests for backend and frontend notification helpers

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684969d83490832ea62256c46781b325