### PR TITLE
Fix booking request parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews.
-* Booking request notifications now display the sender name as the title and the service type in the subtitle for quicker context.
+* Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Long service names are truncated for readability.
 
 ### Artist Profile Enhancements
 

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -47,9 +47,17 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     };
   }
   if (n.type === 'new_booking_request') {
-    const match = n.content.match(/New booking request from ([^:]+):\s*(.+)/i);
-    const sender = match?.[1] || n.sender_name;
-    const btype = match?.[2] || n.booking_type;
+    let sender = n.sender_name;
+    let btype = n.booking_type;
+    if (!sender || !btype) {
+      const match = n.content.match(
+        /New booking request from (.+?)(?::| - | for )\s*(.+)/i,
+      );
+      if (match) {
+        sender = sender || match[1];
+        btype = btype || match[2];
+      }
+    }
     const iconMap: Record<string, string> = {
       video: '🎥',
       song: '🎵',

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -17,6 +17,20 @@ describe('parseItem', () => {
     expect(parsed.subtitle).toBe('sent a new booking for Performance');
   });
 
+  it('parses booking request with alternate separator', () => {
+    const n: UnifiedNotification = {
+      type: 'new_booking_request',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'New booking request from Alice for Personalized Video',
+      id: 11,
+      link: '/booking-requests/11',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.title).toBe('Alice');
+    expect(parsed.subtitle).toBe('sent a new booking for Personalized Video');
+  });
+
   it('falls back to provided fields when missing from message', () => {
     const n: UnifiedNotification = {
       type: 'new_booking_request',


### PR DESCRIPTION
## Summary
- better parse booking request notifications
- add alt separator test
- document updated notification behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68497ac0f924832ebde8671f61ca76ec