### PR TITLE
Improve notification drawer truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,8 +434,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * "Unread Only" toggle filters message threads and alerts in the drawer and full-screen modal.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
-* Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews.
-* Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Long service names are truncated for readability.
+* Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
+* Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability.
 
 ### Artist Profile Enhancements
 

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -135,12 +135,12 @@ export default function FullScreenNotificationModal({
                       )}
                       <div className="flex-1 text-left">
                         <div className="flex items-start justify-between">
-                          <span className="font-medium text-gray-900 truncate">{parsed.title}</span>
+                          <span className="font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
                           <span className="text-xs text-gray-400">
                             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
                           </span>
                         </div>
-                        <span className="block text-sm text-gray-700 truncate">{parsed.subtitle}</span>
+                        <span className="block text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</span>
                       </div>
                     </div>
                   );

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -28,7 +28,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a booking for Personalized Video');
+    expect(parsed.subtitle).toBe('sent a booking for Personalize...');
   });
 
   it('parses booking request with alternate separator', () => {
@@ -42,7 +42,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a booking for Personalized Video');
+    expect(parsed.subtitle).toBe('sent a booking for Personalize...');
   });
 
   it('falls back to provided fields when missing from message', () => {
@@ -58,7 +58,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Bob');
-    expect(parsed.subtitle).toBe('sent a booking for Virtual Appearance');
+    expect(parsed.subtitle).toBe('sent a booking for Virtual App...');
   });
 
   it('handles missing details with defaults', () => {
@@ -85,10 +85,25 @@ describe('parseItem', () => {
       name: 'Charlie Brown',
       unread_count: 3,
     } as UnifiedNotification;
+  const parsed = parseItem(n);
+  expect(parsed.title).toBe('Charlie Brown (3)');
+  expect(parsed.subtitle).toBe(
+      'Last message: "Hello there, this is a long me..."',
+  );
+  });
+
+  it('omits unread count when zero', () => {
+    const n: UnifiedNotification = {
+      type: 'message',
+      timestamp: new Date().toISOString(),
+      is_read: true,
+      content: 'New message: Hi',
+      booking_request_id: 6,
+      name: 'Dana',
+      unread_count: 0,
+    } as UnifiedNotification;
     const parsed = parseItem(n);
-    expect(parsed.title).toBe('Charlie Brown (3)');
-    expect(parsed.subtitle).toBe(
-      'Last message: "Hello there, this is a long message that..."',
-    );
+    expect(parsed.title).toBe('Dana');
+    expect(parsed.subtitle).toBe('Last message: "Hi"');
   });
 });


### PR DESCRIPTION
## Summary
- refine NotificationDrawer parsing logic
- clean and truncate message snippets to 30 chars
- truncate booking request titles and subtitles
- apply nowrap/overflow styles in notification components
- document drawer truncation limits

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684987c83728832e82fb399868624f2d