### PR TITLE
Restore unread notification indicator

### DIFF
--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -117,8 +117,10 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
       type="button"
       onClick={onClick}
       className={classNames(
-        'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 rounded shadow-sm border-b last:border-b-0',
-        n.is_read ? 'bg-white text-gray-500' : 'bg-gray-100 text-gray-900 font-medium',
+        'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 rounded shadow-sm border-b last:border-b-0 transition',
+        n.is_read
+          ? 'border-l-4 border-transparent bg-gray-50 text-gray-500'
+          : 'border-l-4 border-indigo-500 bg-white text-gray-900 font-medium',
       )}
     >
       {parsed.avatarUrl || parsed.initials ? (


### PR DESCRIPTION
## Summary
- tweak NotificationDrawer item styles to restore blue left bar for unread notifications

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684989946988832e93086a4de7709e32