### PR TITLE
Fix notification for system messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * "Unread Only" toggle filters message threads and alerts in the drawer and full-screen modal.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
+* System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability.
 

--- a/backend/app/api/api_message.py
+++ b/backend/app/api/api_message.py
@@ -143,7 +143,9 @@ def create_message(
                 notify_user_new_booking_request(db, artist, request_id, sender_name, booking_type)
         # suppress message notifications during flow
     elif other_user:
-        notify_user_new_message(db, other_user, request_id, message_in.content)
+        notify_user_new_message(
+            db, other_user, request_id, message_in.content, message_in.message_type
+        )
 
     avatar_url = None
     if msg.sender.user_type == models.UserType.ARTIST:

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -117,9 +117,9 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
       type="button"
       onClick={onClick}
       className={classNames(
-        'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 rounded shadow-sm border-b last:border-b-0 transition',
+        'group flex w-full items-start px-4 py-3 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 rounded shadow-sm transition',
         n.is_read
-          ? 'border-l-4 border-transparent bg-gray-50 text-gray-500'
+          ? 'border-b last:border-b-0 border-l-4 border-transparent bg-gray-50 text-gray-500'
           : 'border-l-4 border-indigo-500 bg-white text-gray-900 font-medium',
       )}
     >


### PR DESCRIPTION
## Summary
- avoid duplicate chat alerts for system booking messages
- highlight unread notifications with left border only
- update notification tests for booking details suppression
- document new behavior for booking request alerts

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68498ba14fc8832e97c54005a2466486