### PR TITLE
Fix desktop service type subtitle

### DIFF
--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -28,6 +28,7 @@ export interface ParsedNotification {
   icon: string;
   avatarUrl?: string | null;
   initials?: string;
+  bookingType?: string;
 }
 
 export function parseItem(n: UnifiedNotification): ParsedNotification {
@@ -93,6 +94,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       title,
       subtitle,
       icon,
+      bookingType: formattedType,
     };
   }
   if (/quote accepted/i.test(n.content)) {
@@ -112,6 +114,10 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
 
 function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => void }) {
   const parsed = parseItem(n);
+  const subtitleText =
+    n.type === 'new_booking_request' && parsed.bookingType
+      ? parsed.bookingType
+      : parsed.subtitle;
   return (
     <button
       type="button"
@@ -149,7 +155,7 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
           </span>
         </div>
-        <span className="block text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</span>
+        <span className="block text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{subtitleText}</span>
       </div>
     </button>
   );

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -15,6 +15,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
     expect(parsed.subtitle).toBe('sent a booking for Performance');
+    expect(parsed.bookingType).toBe('Performance');
   });
 
   it('parses booking request with alternate separator', () => {
@@ -29,6 +30,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
     expect(parsed.subtitle).toBe('sent a booking for Personalize...');
+    expect(parsed.bookingType).toBe('Personalized Video');
   });
 
   it('parses booking request with alternate separator', () => {
@@ -43,6 +45,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
     expect(parsed.subtitle).toBe('sent a booking for Personalize...');
+    expect(parsed.bookingType).toBe('Personalized Video');
   });
 
   it('falls back to provided fields when missing from message', () => {
@@ -59,6 +62,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Bob');
     expect(parsed.subtitle).toBe('sent a booking for Virtual App...');
+    expect(parsed.bookingType).toBe('Virtual Appearance');
   });
 
   it('handles missing details with defaults', () => {
@@ -73,6 +77,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('New booking request');
     expect(parsed.subtitle).toBe('Booking Request');
+    expect(parsed.bookingType).toBe('');
   });
 
   it('parses message notification with unread count', () => {


### PR DESCRIPTION
## Summary
- display booking type directly in desktop notification drawer
- expose bookingType from parseItem
- update unit tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684990286a94832e985885623c91c770