### PR TITLE
Fix missing import in notification modal

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -8,6 +8,7 @@ import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import { formatDistanceToNow } from 'date-fns';
+import { getFullImageUrl } from '@/lib/utils';
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ');


### PR DESCRIPTION
## Summary
- import `getFullImageUrl` in `FullScreenNotificationModal`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849937592c4832e8de129bd9f3f789e