### PR TITLE
Improve booking request notification cards

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -111,8 +111,8 @@ export default function FullScreenNotificationModal({
                       onClick={() => handleItemClick(n.id || n.booking_request_id as number)}
                       onKeyPress={() => handleItemClick(n.id || n.booking_request_id as number)}
                       className={classNames(
-                        'flex items-start gap-3 p-4 rounded-lg shadow transition hover:bg-gray-50 cursor-pointer',
-                        n.is_read ? 'bg-white text-gray-500' : 'bg-gray-50 font-medium',
+                        'flex items-start gap-2 sm:gap-3 p-3 sm:p-4 rounded-lg shadow transition hover:bg-gray-50 cursor-pointer',
+                        n.is_read ? 'bg-white border-l border-transparent text-gray-500' : 'bg-indigo-50 border-l-4 border-indigo-500 font-medium',
                       )}
                     >
                       {parsed.avatarUrl || parsed.initials ? (
@@ -136,12 +136,15 @@ export default function FullScreenNotificationModal({
                       )}
                       <div className="flex-1 text-left">
                         <div className="flex items-start justify-between">
-                          <span className="font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
-                          <span className="text-xs text-gray-400">
+                          <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
+                          <span className="text-xs text-gray-400 text-right">
                             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
                           </span>
                         </div>
-                        <span className="block text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</span>
+                        <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
+                        {parsed.metadata && (
+                          <p className="text-xs text-gray-500 truncate whitespace-nowrap overflow-hidden">{parsed.metadata}</p>
+                        )}
                       </div>
                     </div>
                   );

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -14,7 +14,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a booking for Performance');
+    expect(parsed.subtitle).toBe('sent a new booking request for Perfo...');
     expect(parsed.bookingType).toBe('Performance');
   });
 
@@ -29,7 +29,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a booking for Personalize...');
+    expect(parsed.subtitle).toBe('sent a new booking request for Perso...');
     expect(parsed.bookingType).toBe('Personalized Video');
   });
 
@@ -44,7 +44,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a booking for Personalize...');
+    expect(parsed.subtitle).toBe('sent a new booking request for Perso...');
     expect(parsed.bookingType).toBe('Personalized Video');
   });
 
@@ -61,7 +61,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Bob');
-    expect(parsed.subtitle).toBe('sent a booking for Virtual App...');
+    expect(parsed.subtitle).toBe('sent a new booking request for Virtu...');
     expect(parsed.bookingType).toBe('Virtual Appearance');
   });
 
@@ -76,8 +76,23 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('New booking request');
-    expect(parsed.subtitle).toBe('Booking Request');
+    expect(parsed.subtitle).toBe('sent a new booking request');
     expect(parsed.bookingType).toBe('');
+  });
+
+  it('extracts metadata from details text', () => {
+    const n: UnifiedNotification = {
+      type: 'new_booking_request',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content:
+        'New booking request from Alice: Performance\nDate: 2025-01-01\nLocation: Test',
+      id: 4,
+      link: '/booking-requests/4',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.metadata).toContain('📍 Test');
+    expect(parsed.metadata).toContain('📅');
   });
 
   it('parses message notification with unread count', () => {


### PR DESCRIPTION
## Summary
- clarify booking request subtitles in NotificationDrawer
- show optional metadata like location and date
- tweak read/unread styles
- adjust layout sizing and truncation rules
- update tests for new subtitle logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849d21f741c832eab866708184fb2ee