### PR TITLE
Remove proposed date sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Chat attachment button stays inline with the message input and send button on all screens.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page at `/inbox` separates Booking Requests and Chats into tabs.
-* `/booking-requests` lists all requests with search and filters. Click the "Proposed Date" header to sort ascending/descending.
+* `/booking-requests` lists all requests with search and filters.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.
 * Tap a booking request card to open `/booking-requests/[id]`.
 * Unread booking requests are highlighted in indigo so they stand out.

--- a/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
+++ b/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
@@ -89,7 +89,7 @@ describe('BookingRequestsPage', () => {
     container.remove();
   });
 
-  it('filters by client name and sorts by proposed date', async () => {
+  it('filters by client name', async () => {
     const { container, root } = setup();
     await act(async () => {
       root.render(<BookingRequestsPage />);
@@ -97,19 +97,17 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const list = container.querySelector('ul');
-    const rows = list ? list.querySelectorAll('li') : ([] as NodeListOf<HTMLLIElement>);
-    const headerButton = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('Proposed Date')
-    ) as HTMLButtonElement;
-    const initialDate = rows[0].querySelectorAll('div')[2]?.textContent;
-    await act(async () => {
-      headerButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    act(() => {
+      input.value = 'Bob';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
-    const updatedRows = list ? list.querySelectorAll('li') : ([] as NodeListOf<HTMLLIElement>);
-    const dateCell = updatedRows[0].querySelectorAll('div')[2];
-    expect(dateCell?.textContent).not.toBe(initialDate);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const rows = Array.from(container.querySelectorAll('li'));
+    const bobRow = rows.find((r) => r.textContent?.includes('Bob B'));
+    expect(bobRow).toBeTruthy();
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -20,7 +20,6 @@ export default function BookingRequestsPage() {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [serviceFilter, setServiceFilter] = useState('');
-  const [sortAsc, setSortAsc] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -71,17 +70,8 @@ export default function BookingRequestsPage() {
         const matchesService =
           !serviceFilter || r.service?.service_type === serviceFilter;
         return matchesSearch && matchesStatus && matchesService;
-      })
-      .sort((a, b) => {
-        const aDate = a.proposed_datetime_1
-          ? new Date(a.proposed_datetime_1).getTime()
-          : 0;
-        const bDate = b.proposed_datetime_1
-          ? new Date(b.proposed_datetime_1).getTime()
-          : 0;
-        return sortAsc ? aDate - bDate : bDate - aDate;
       });
-  }, [requests, search, statusFilter, serviceFilter, sortAsc]);
+  }, [requests, search, statusFilter, serviceFilter]);
 
   if (!user) {
     return (
@@ -135,14 +125,7 @@ export default function BookingRequestsPage() {
             <div className="hidden sm:grid grid-cols-4 gap-4 bg-gray-50 p-2 text-sm font-semibold border-t">
               <div>Client Name</div>
               <div>Service Type</div>
-              <button
-                type="button"
-                onClick={() => setSortAsc(!sortAsc)}
-                className="text-left flex items-center"
-              >
-                <span className="mr-1">Proposed Date</span>
-                {sortAsc ? '▲' : '▼'}
-              </button>
+              <div className="text-left">Proposed Date</div>
               <div>Status</div>
             </div>
             <ul className="divide-y divide-gray-200">


### PR DESCRIPTION
## Summary
- remove sorting by proposed date from booking requests page
- update related test to check filtering by client name
- tweak docs to match UI

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849dc67c00c832eac60adbb76bc2da2