### PR TITLE
Group booking requests by client

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.
 * Tap a booking request card to open `/booking-requests/[id]`.
 * Unread booking requests are highlighted in indigo so they stand out.
+* Requests from the same client are grouped under a collapsible heading for a cleaner overview.
 * Cards no longer display a "1 new message" label to keep the list concise.
 
 ### Auth & Registration

--- a/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
+++ b/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
@@ -80,8 +80,18 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const rows = Array.from(container.querySelectorAll('li'));
-    const aliceRow = rows.find((li) => li.textContent?.includes('Alice A'));
+    const aliceHeader = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Alice A'),
+    ) as HTMLButtonElement;
+    if (aliceHeader) {
+      act(() => {
+        aliceHeader.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const aliceRow = container.querySelector('li[data-request-id="1"]');
     expect(aliceRow?.className).toContain('bg-indigo-50');
     act(() => {
       root.unmount();
@@ -105,9 +115,10 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const rows = Array.from(container.querySelectorAll('li'));
-    const bobRow = rows.find((r) => r.textContent?.includes('Bob B'));
-    expect(bobRow).toBeTruthy();
+    const bobHeader = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Bob B'),
+    );
+    expect(bobHeader).toBeTruthy();
     act(() => {
       root.unmount();
     });


### PR DESCRIPTION
## Summary
- group booking requests by client name
- show grouped requests in collapsible UI
- humanize booking request status labels
- update tests for new grouping behaviour
- document grouped booking request rows

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849e3c3c7c0832e9220688a8c11b396