### PR TITLE
Add upload progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New **Review** step showing cost breakdown and selections.
 * Success toasts when saving a draft or submitting a request.
 * Simplified buttons sit below each step in a responsive button group.
+* Attachment uploads in the notes step display a progress bar and disable the Next button until finished.
 * Collapsible sections for date/time and notes keep steps short on phones.
 * Mobile devices use native date and time pickers for faster input.
 * Each step appears in a white card with rounded corners and a subtle shadow.
@@ -422,6 +423,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Fixed input bar & auto-scroll on mobile.
 * Desktop bubbles expand wider to avoid unnecessary line breaks.
 * Floating “scroll to latest” button on small screens.
+* File uploads show an inline progress bar and the send button is disabled until complete.
 * Personalized Video flow: multi-step prompts, typing indicators, progress bar.
 * Sticky input demo at `/demo/sticky-input` shows local message appending.
 

--- a/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
@@ -1,0 +1,87 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import { useForm, Control, FieldValues } from 'react-hook-form';
+import NotesStep from '../NotesStep';
+import * as api from '@/lib/api';
+
+jest.mock('@/lib/api');
+jest.mock('../../../ui/Toast', () => ({ __esModule: true, default: { success: jest.fn(), error: jest.fn() } }));
+
+function Wrapper() {
+  const { control, setValue } = useForm();
+  return (
+    <NotesStep
+      control={control as unknown as Control<FieldValues>}
+      setValue={setValue}
+      step={0}
+      steps={['one', 'two']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
+    />
+  );
+}
+
+describe('NotesStep attachment upload', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows upload progress and disables Next button', async () => {
+    let resolveUpload: () => void;
+    (api.uploadBookingAttachment as jest.Mock).mockImplementation(
+      (_form: FormData, cb?: (e: { loaded: number; total: number }) => void) => {
+        cb?.({ loaded: 25, total: 100 });
+        return new Promise((res) => {
+          resolveUpload = () => {
+            cb?.({ loaded: 100, total: 100 });
+            res({ data: { url: '/file' } });
+          };
+        });
+      },
+    );
+
+    await act(async () => {
+      root.render(React.createElement(Wrapper));
+    });
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', { value: [file] });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const nextButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Next'),
+    ) as HTMLButtonElement;
+
+    expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
+    expect(nextButton.disabled).toBe(true);
+
+    await act(async () => {
+      resolveUpload();
+    });
+
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
+    expect(nextButton.disabled).toBe(false);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 // frontend/src/lib/api.ts
 
-import axios from 'axios';
+import axios, { AxiosProgressEvent } from 'axios';
 import {
   User,
   ArtistProfile,
@@ -235,22 +235,26 @@ export const postMessageToBookingRequest = (
 
 export const uploadMessageAttachment = (
   bookingRequestId: number,
-  file: File
+  file: File,
+  onUploadProgress?: (event: AxiosProgressEvent) => void,
 ) => {
   const formData = new FormData();
   formData.append('file', file);
   return api.post<{ url: string }>(
     `${API_V1}/booking-requests/${bookingRequestId}/attachments`,
     formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } }
+    { headers: { 'Content-Type': 'multipart/form-data' }, onUploadProgress }
   );
 };
 
-export const uploadBookingAttachment = (formData: FormData) =>
+export const uploadBookingAttachment = (
+  formData: FormData,
+  onUploadProgress?: (event: AxiosProgressEvent) => void,
+) =>
   api.post<{ url: string }>(
     `${API_V1}/booking-requests/attachments`,
     formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } }
+    { headers: { 'Content-Type': 'multipart/form-data' }, onUploadProgress }
   );
 
 


### PR DESCRIPTION
## Summary
- support progress callbacks for message and booking attachment uploads
- show upload progress bars in NotesStep and MessageThread
- disable send and next buttons during uploads
- test progress indicators
- document file upload progress

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849ee9a483c832e973b0aff717b904a