### PR TITLE
Add response interceptor and simplify error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ rendering and tests that lack a `window` object no longer fail.
 `useIsMobile` also initializes to `false` and updates on mount so mobile devices
 avoid hydration errors when rendering responsive components.
 
+API responses are now handled by a global interceptor which maps common HTTP
+status codes to human-friendly error messages and logs server errors to the
+console. Hooks and components no longer need to parse Axios errors manually.
+
 ---
 
 ## Development

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef } from 'react';
 import NextImage from 'next/image';
-import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MobileSaveBar from '@/components/dashboard/MobileSaveBar';
@@ -15,7 +14,7 @@ import {
   uploadMyArtistProfilePicture,
   uploadMyArtistCoverPhoto,
 } from '@/lib/api';
-import { getFullImageUrl, extractErrorMessage } from '@/lib/utils';
+import { getFullImageUrl } from '@/lib/utils';
 
 import dynamic from 'next/dynamic';
 import {
@@ -334,13 +333,9 @@ export default function EditArtistProfilePage(): JSX.Element {
       setCompletedCrop(undefined);
     } catch (err: unknown) {
       console.error('Failed to crop or upload image:', err);
-      if (axios.isAxiosError(err) && err.response?.data?.detail) {
-        setError(extractErrorMessage(err.response.data.detail));
-      } else {
-        const msg =
-          err instanceof Error ? err.message : 'Failed to upload image.';
-        setError(msg);
-      }
+      const msg =
+        err instanceof Error ? err.message : 'Failed to upload image.';
+      setError(msg);
     } finally {
       setUploadingImage(false);
     }
@@ -361,13 +356,9 @@ export default function EditArtistProfilePage(): JSX.Element {
       setCoverPhotoSuccessMessage('Cover photo uploaded successfully!');
     } catch (err: unknown) {
       console.error('Failed to upload cover photo:', err);
-      if (axios.isAxiosError(err) && err.response?.data?.detail) {
-        setCoverPhotoError(extractErrorMessage(err.response.data.detail));
-      } else {
-        const msg =
-          err instanceof Error ? err.message : 'Failed to upload cover photo.';
-        setCoverPhotoError(msg);
-      }
+      const msg =
+        err instanceof Error ? err.message : 'Failed to upload cover photo.';
+      setCoverPhotoError(msg);
     } finally {
       setUploadingCoverPhoto(false);
       e.target.value = '';

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -11,8 +11,6 @@ import MainLayout from '@/components/layout/MainLayout';
 import Button from '@/components/ui/Button';
 import AuthInput from '@/components/auth/AuthInput';
 import { User } from '@/types';
-import axios from 'axios';
-import { extractErrorMessage } from '@/lib/utils';
 
 interface RegisterForm extends Omit<User, 'id' | 'is_active' | 'is_verified'> {
   password: string;
@@ -43,14 +41,13 @@ export default function RegisterPage() {
       await registerUser(userData);
       toast.success('Registration successful! Please log in.');
       router.push('/login');
-    } catch (err) {
-      if (axios.isAxiosError(err)) {
-        const message = extractErrorMessage(err.response?.data?.detail);
-        setError(message);
-      } else {
-        setError('Registration failed. Please try again.');
-      }
+    } catch (err: unknown) {
       console.error('Registration error:', err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Registration failed. Please try again.';
+      setError(message);
     }
   };
 

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -4,8 +4,6 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { Service } from '@/types';
 import { createService as apiCreateService } from '@/lib/api'; // Assuming this function exists
 import { useState } from 'react';
-import axios from 'axios';
-import { extractErrorMessage } from '@/lib/utils';
 
 interface AddServiceModalProps {
   isOpen: boolean;
@@ -42,14 +40,13 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
       onServiceAdded(response.data);
       reset();
       onClose();
-    } catch (err) {
-      if (axios.isAxiosError(err)) {
-        const message = extractErrorMessage(err.response?.data?.detail);
-        setServerError(message);
-      } else {
-        setServerError('An unexpected error occurred. Failed to create service.');
-      }
-      console.error("Service creation error:", err);
+    } catch (err: unknown) {
+      console.error('Service creation error:', err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'An unexpected error occurred. Failed to create service.';
+      setServerError(message);
     }
   };
 

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -4,8 +4,6 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { Service } from "@/types";
 import { updateService as apiUpdateService } from "@/lib/api";
 import { useState } from "react";
-import axios from "axios";
-import { extractErrorMessage } from "@/lib/utils";
 
 interface EditServiceModalProps {
   isOpen: boolean;
@@ -53,16 +51,13 @@ export default function EditServiceModal({
       onServiceUpdated(response.data);
       reset(serviceData);
       onClose();
-    } catch (err) {
-      if (axios.isAxiosError(err)) {
-        const message = extractErrorMessage(err.response?.data?.detail);
-        setServerError(message);
-      } else {
-        setServerError(
-          "An unexpected error occurred. Failed to update service.",
-        );
-      }
-      console.error("Service update error:", err);
+    } catch (err: unknown) {
+      console.error('Service update error:', err);
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'An unexpected error occurred. Failed to update service.';
+      setServerError(message);
     }
   };
 


### PR DESCRIPTION
## Summary
- add axios response interceptor to emit clear error messages
- log backend errors via the interceptor
- simplify dashboard service modals and register page error handling
- simplify profile edit error logic
- document new interceptor behaviour in README
- test response interceptor

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f03b8bac832eb90eeb4079717ea8