### PR TITLE
Add notification prefetching

### DIFF
--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -7,12 +7,18 @@ import dynamic from 'next/dynamic';
 
 const NotificationDrawer = dynamic(() => import('./NotificationDrawer'), {
   loading: () => <div className="p-4">Loading...</div>,
+  ssr: false,
 });
 
 const FullScreenNotificationModal = dynamic(
   () => import('./FullScreenNotificationModal'),
   { loading: () => <div className="p-4">Loading...</div>, ssr: false },
 );
+
+function prefetchNotifications() {
+  import('./NotificationDrawer');
+  import('./FullScreenNotificationModal');
+}
 import useIsMobile from '@/hooks/useIsMobile';
 import useNotifications from '@/hooks/useNotifications';
 
@@ -68,6 +74,8 @@ export default function NotificationBell(): JSX.Element {
       <button
         type="button"
         onClick={() => setOpen(true)}
+        onMouseEnter={prefetchNotifications}
+        onFocus={prefetchNotifications}
         className="flex text-gray-400 hover:text-gray-600 focus:outline-none"
       >
         <span className="sr-only">View notifications</span>

--- a/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
@@ -1,0 +1,91 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import NotificationBell from '../NotificationBell';
+import useNotifications from '@/hooks/useNotifications';
+import useIsMobile from '@/hooks/useIsMobile';
+
+jest.mock('@/hooks/useNotifications');
+jest.mock('@/hooks/useIsMobile');
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+jest.mock('../NotificationDrawer', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('div', { 'data-testid': 'drawer' }),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+jest.mock('../FullScreenNotificationModal', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('div', { 'data-testid': 'modal' }),
+  };
+});
+
+function setup() {
+  (useNotifications as jest.Mock).mockReturnValue({
+    items: [],
+    unreadCount: 0,
+    markItem: jest.fn(),
+    markAll: jest.fn(),
+    loadMore: jest.fn(),
+    hasMore: false,
+  });
+  (useIsMobile as jest.Mock).mockReturnValue(false);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('NotificationBell prefetch', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders drawer after hover prefetch and open', async () => {
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(NotificationBell));
+      await Promise.resolve();
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="drawer"]')).not.toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('renders drawer when opened without prefetch', async () => {
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(NotificationBell));
+      await Promise.resolve();
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="drawer"]')).not.toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ssr: false` for `NotificationDrawer`
- prefetch notification modules on bell hover/focus
- test that drawer still loads with and without prefetch

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f39c1f24832eb4a8de2b5d52144a