### PR TITLE
Improve accessibility labels and announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Desktop bubbles expand wider to avoid unnecessary line breaks.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
+* Upload progress and new message alerts are announced to screen readers.
 * Personalized Video flow: multi-step prompts, typing indicators, progress bar.
 * Sticky input demo at `/demo/sticky-input` shows local message appending.
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -72,6 +72,8 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [announceNewMessage, setAnnounceNewMessage] = useState('');
+  const prevLengthRef = useRef(0);
 
   const fetchMessages = useCallback(async () => {
     try {
@@ -169,6 +171,13 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     const atBottom = scrollHeight - scrollTop - clientHeight < 20;
     setShowScrollButton(!atBottom);
   }, []);
+
+  useEffect(() => {
+    if (prevLengthRef.current && messages.length > prevLengthRef.current && showScrollButton) {
+      setAnnounceNewMessage('New messages available');
+    }
+    prevLengthRef.current = messages.length;
+  }, [messages, showScrollButton]);
 
   const handleSend = useCallback(
     async (e: React.FormEvent) => {
@@ -455,6 +464,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           </svg>
         </button>
       )}
+      <div aria-live="polite" className="sr-only">{announceNewMessage}</div>
       {user && (
         <>
           {previewUrl && (
@@ -481,6 +491,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           >
             <label
               htmlFor="file-upload"
+              aria-label="Upload attachment"
               className="w-8 h-8 flex items-center justify-center text-gray-600 rounded-full hover:bg-gray-100"
             >
               <svg
@@ -517,7 +528,16 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               placeholder="Type a message"
             />
             {uploading && (
-              <div className="flex items-center gap-2" role="progressbar" aria-valuenow={uploadProgress}>
+              <div
+                className="flex items-center gap-2"
+                role="progressbar"
+                aria-label="Upload progress"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={uploadProgress}
+                aria-valuetext={`${uploadProgress}%`}
+                aria-live="polite"
+              >
                 <div className="w-16 bg-gray-200 rounded h-1">
                   <div className="bg-blue-600 h-1 rounded" style={{ width: `${uploadProgress}%` }} />
                 </div>
@@ -526,6 +546,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             )}
             <Button
               type="submit"
+              aria-label="Send message"
               disabled={uploading}
               className="rounded-full bg-blue-600 text-white px-4 py-2 hover:bg-blue-700"
             >

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -73,9 +73,18 @@ export default function NotesStep({
         render={({ field }) => <input type="hidden" {...field} />}
       />
       <label className="block text-sm font-medium">Attachment (optional)</label>
-      <input type="file" onChange={handleFileChange} />
+      <input type="file" aria-label="Upload attachment" onChange={handleFileChange} />
       {uploading && (
-        <div className="flex items-center gap-2 mt-2" role="progressbar" aria-valuenow={progress}>
+        <div
+          className="flex items-center gap-2 mt-2"
+          role="progressbar"
+          aria-label="Upload progress"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progress}
+          aria-valuetext={`${progress}%`}
+          aria-live="polite"
+        >
           <div className="w-full bg-gray-200 rounded h-2">
             <div className="bg-blue-600 h-2 rounded" style={{ width: `${progress}%` }} />
           </div>

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -179,6 +179,7 @@ export default function FullScreenNotificationModal({
                     <div style={style} className="text-center pt-2">
                       <button
                         type="button"
+                        aria-label="Load more notifications"
                         onClick={loadMore}
                         className="text-sm text-indigo-600 hover:underline focus:outline-none"
                       >

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -294,6 +294,7 @@ export default function NotificationDrawer({
                             <div style={style} className="px-4 py-2 border-t border-gray-200 text-center">
                               <button
                                 type="button"
+                                aria-label="Load more notifications"
                                 onClick={loadMore}
                                 className="text-sm text-indigo-600 hover:underline focus:outline-none"
                               >

--- a/frontend/src/components/layout/__tests__/NotificationVirtualization.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationVirtualization.test.tsx
@@ -67,7 +67,7 @@ describe('Notification virtualization', () => {
         }),
       );
     });
-    const btn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Load more')) as HTMLButtonElement | undefined;
+    const btn = document.querySelector('button[aria-label="Load more notifications"]') as HTMLButtonElement | null;
     btn?.click();
     if (btn) {
       expect(loadMore).toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe('Notification virtualization', () => {
         }),
       );
     });
-    const btn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Load more')) as HTMLButtonElement | undefined;
+    const btn = document.querySelector('button[aria-label="Load more notifications"]') as HTMLButtonElement | null;
     btn?.click();
     if (btn) {
       expect(loadMore).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add aria-labels to upload, send and load-more buttons
- announce upload progress & new messages for screen readers
- update tests for accessibility features
- document accessibility improvements in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f7bb5490832eaa26f9fc41b4430d