### PR TITLE
Add unread badge in chat groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
+* Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
 
 ### Artist Profile Enhancements

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -355,12 +355,18 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           return (
             <div
               key={firstMsg.id}
-              className={`flex flex-col gap-0.5 ${isSelf ? 'items-end ml-auto' : 'items-start'} ${groupClass}`}
+              className={`relative flex flex-col gap-0.5 ${isSelf ? 'items-end ml-auto' : 'items-start'} ${groupClass}`}
             >
               {group.divider && (
                 <hr className="border-t border-gray-300 w-full my-2" />
               )}
               <div className="text-xs text-gray-400 mb-1">{relativeGroupTime}</div>
+              {anyUnread && (
+                <span
+                  className="absolute right-0 top-1 w-2 h-2 bg-purple-600 rounded-full"
+                  aria-label="Unread messages"
+                />
+              )}
               {group.messages.map((msg, mIdx) => {
                 const bubbleClass = isSelf
                   ? 'bg-[#4F46E5] text-white self-end'

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -99,7 +99,9 @@ describe('MessageThread component', () => {
     });
     const highlightedRow = container.querySelector('.bg-purple-50');
     const senderName = container.querySelector('span.font-semibold');
+    const badge = container.querySelector('span[aria-label="Unread messages"]');
     expect(highlightedRow).not.toBeNull();
+    expect(badge).not.toBeNull();
     expect(senderName).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- show badge for unread message groups in `MessageThread`
- test unread badge rendering
- document chat badge in README

## Testing
- `./scripts/test-all.sh`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a6cf23d64832e9b42f9074ec61cff