### PR TITLE
Add unread badges to notifications and inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Tap a booking request card to open `/booking-requests/[id]`.
 * Unread booking requests are highlighted in indigo so they stand out.
 * Requests from the same client are grouped under a collapsible heading for a cleaner overview.
-* Cards no longer display a "1 new message" label to keep the list concise.
+* Unread counts appear as a red badge next to the sender name.
 
 ### Auth & Registration
 

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -77,7 +77,8 @@ describe('InboxPage unread badge', () => {
     });
     const card = container.querySelector('li div');
     expect(card?.className).toContain('bg-indigo-50');
-    expect(container.textContent).not.toContain('new message');
+    const badge = container.querySelector('span.bg-red-600');
+    expect(badge?.textContent).toBe('2');
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -128,7 +128,14 @@ export default function InboxPage() {
             )}
           >
             <div className="flex justify-between items-center">
-              <span className="font-semibold text-sm">{b.senderName}</span>
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-sm">{b.senderName}</span>
+                {b.unread > 0 && (
+                  <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
+                    {b.unread > 99 ? '99+' : b.unread}
+                  </span>
+                )}
+              </div>
               <span className="text-xs text-gray-500">{b.formattedDate}</span>
             </div>
             <div className="text-sm text-gray-600">
@@ -163,7 +170,14 @@ export default function InboxPage() {
               {initials}
             </div>
             <div className="flex-1 overflow-hidden">
-              <div className="font-medium text-sm">{t.name}</div>
+              <div className="flex items-center gap-2">
+                <div className="font-medium text-sm">{t.name}</div>
+                {(t.unread_count ?? 0) > 0 && (
+                  <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
+                    {t.unread_count && t.unread_count > 99 ? '99+' : t.unread_count}
+                  </span>
+                )}
+              </div>
               <div className="text-xs text-gray-500 truncate">{t.content}</div>
             </div>
             <div className="text-xs text-gray-400">

--- a/frontend/src/components/layout/BookingRequestIcon.tsx
+++ b/frontend/src/components/layout/BookingRequestIcon.tsx
@@ -28,7 +28,7 @@ export default function BookingRequestIcon() {
         <span className="sr-only">View booking requests</span>
         <ClipboardIcon className="h-6 w-6" aria-hidden="true" />
         {unreadCount > 0 && (
-          <span className="absolute -top-1 -right-1 inline-flex items-center justify-center px-1 py-0.5 text-xs font-bold leading-none text-white bg-red-600 rounded-full">
+          <span className="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
             {badge}
           </span>
         )}

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -31,18 +31,16 @@ export interface ParsedNotification {
   initials?: string;
   bookingType?: string;
   metadata?: string;
+  unreadCount?: number;
 }
 
 export function parseItem(n: UnifiedNotification): ParsedNotification {
   if (n.type === 'message') {
     const cleaned = n.content.replace(/^New message:\s*/i, '').trim();
     const snippet = cleaned.length > 30 ? `${cleaned.slice(0, 30)}...` : cleaned;
-    const titleRaw =
-      n.unread_count && n.unread_count > 0
-        ? `${n.name} (${n.unread_count})`
-        : n.name || '';
-    const title =
-      titleRaw.length > 36 ? `${titleRaw.slice(0, 36)}...` : titleRaw;
+    const titleRaw = n.name || '';
+    const title = titleRaw.length > 36 ? `${titleRaw.slice(0, 36)}...` : titleRaw;
+    const unreadCount = n.unread_count ?? 0;
     return {
       title,
       subtitle: `Last message: "${snippet}"`,
@@ -54,6 +52,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
             .map((w) => w[0])
             .join('')
         : undefined,
+      unreadCount,
     };
   }
   if (n.type === 'new_booking_request') {
@@ -154,7 +153,14 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
       )}
       <div className="flex-1 text-left">
         <div className="flex items-start justify-between">
-          <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
+            {parsed.unreadCount && parsed.unreadCount > 0 && (
+              <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
+                {parsed.unreadCount > 99 ? '99+' : parsed.unreadCount}
+              </span>
+            )}
+          </div>
           <span className="text-xs text-gray-400 text-right">
             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
           </span>

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -63,7 +63,8 @@ describe('parseItem', () => {
       unread_count: 3,
     } as UnifiedNotification;
   const parsed = parseItem(n);
-  expect(parsed.title).toBe('Charlie Brown (3)');
+  expect(parsed.title).toBe('Charlie Brown');
+  expect(parsed.unreadCount).toBe(3);
   expect(parsed.subtitle).toBe(
       'Last message: "Hello there, this is a long me..."',
   );
@@ -81,6 +82,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Dana');
+    expect(parsed.unreadCount).toBe(0);
     expect(parsed.subtitle).toBe('Last message: "Hi"');
   });
 });


### PR DESCRIPTION
## Summary
- show unread count badge inside NotificationDrawer items
- unify badge style on BookingRequestIcon and add badges to Inbox listings
- update unit tests for parseItem and Inbox page
- document inbox badge behavior in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849feac87f0832e88f75425cb683677