### PR TITLE
Improve timestamp accessibility

### DIFF
--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -166,9 +166,15 @@ export default function InboxPage() {
               <div className="font-medium text-sm">{t.name}</div>
               <div className="text-xs text-gray-500 truncate">{t.content}</div>
             </div>
-            <div className="text-xs text-gray-400">
+            <time
+              className="text-xs text-gray-400"
+              title={new Date(t.timestamp).toLocaleString()}
+            >
               {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
-            </div>
+              <span className="sr-only">
+                {new Date(t.timestamp).toLocaleString()}
+              </span>
+            </time>
           </div>
         );
       })}

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -348,9 +348,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           const isSelf = !isSystem && firstMsg.sender_id === user?.id;
           const anyUnread = group.messages.some((m) => m.unread);
           const groupClass = `${idx > 0 ? 'mt-1' : ''} ${anyUnread ? 'bg-purple-50' : ''}`;
-          const relativeGroupTime = formatDistanceToNow(new Date(firstMsg.timestamp), {
+          const groupDate = new Date(firstMsg.timestamp);
+          const relativeGroupTime = formatDistanceToNow(groupDate, {
             addSuffix: true,
           });
+          const fullGroupTime = groupDate.toLocaleString();
 
           return (
             <div
@@ -360,7 +362,13 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               {group.divider && (
                 <hr className="border-t border-gray-300 w-full my-2" />
               )}
-              <div className="text-xs text-gray-400 mb-1">{relativeGroupTime}</div>
+              <time
+                className="text-xs text-gray-400 mb-1"
+                title={fullGroupTime}
+              >
+                {relativeGroupTime}
+                <span className="sr-only">{fullGroupTime}</span>
+              </time>
               {group.messages.map((msg, mIdx) => {
                 const bubbleClass = isSelf
                   ? 'bg-[#4F46E5] text-white self-end'
@@ -370,11 +378,13 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 const bubbleBase =
                   'relative inline-flex min-w-[fit-content] flex-shrink-0 rounded-2xl px-4 py-2 pr-12 text-sm leading-snug max-w-[70%] sm:max-w-[60%]';
 
-                const timeString = new Date(msg.timestamp).toLocaleTimeString([], {
+                const msgDate = new Date(msg.timestamp);
+                const timeString = msgDate.toLocaleTimeString([], {
                   hour: '2-digit',
                   minute: '2-digit',
                   hour12: false,
                 });
+                const fullTimeString = msgDate.toLocaleString();
                 const timeClass =
                   'absolute bottom-1 right-2 text-xs text-right text-gray-400';
 
@@ -414,7 +424,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                             </a>
                           )}
                         </div>
-                        <span className={timeClass}>{timeString}</span>
+                        <time className={timeClass} title={fullTimeString}>
+                          {timeString}
+                          <span className="sr-only">{fullTimeString}</span>
+                        </time>
                       </div>
                     </div>
                   </motion.div>

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -163,9 +163,15 @@ export default function FullScreenNotificationModal({
                         <div className="flex-1 text-left">
                           <div className="flex items-start justify-between">
                             <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
-                            <span className="text-xs text-gray-400 text-right">
+                            <time
+                              className="text-xs text-gray-400 text-right"
+                              title={new Date(n.timestamp).toLocaleString()}
+                            >
                               {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-                            </span>
+                              <span className="sr-only">
+                                {new Date(n.timestamp).toLocaleString()}
+                              </span>
+                            </time>
                           </div>
                           <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
                           {parsed.metadata && (

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -155,9 +155,15 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
       <div className="flex-1 text-left">
         <div className="flex items-start justify-between">
           <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
-          <span className="text-xs text-gray-400 text-right">
+          <time
+            className="text-xs text-gray-400 text-right"
+            title={new Date(n.timestamp).toLocaleString()}
+          >
             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-          </span>
+            <span className="sr-only">
+              {new Date(n.timestamp).toLocaleString()}
+            </span>
+          </time>
         </div>
         <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
         {parsed.metadata && (


### PR DESCRIPTION
## Summary
- use `<time>` for timestamps in NotificationDrawer and NotificationModal
- show full timestamp for screen readers in NotificationDrawer and NotificationModal
- show accessible timestamps in MessageThread
- wrap inbox timestamps in `<time>` with screen-reader text

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a6ce54a40832e9d5f8382ba772a9f