### PR TITLE
Improve timestamp accessibility

### DIFF
--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -180,9 +180,16 @@ export default function InboxPage() {
               </div>
               <div className="text-xs text-gray-500 truncate">{t.content}</div>
             </div>
-            <div className="text-xs text-gray-400">
+            <time
+              dateTime={t.timestamp}
+              title={new Date(t.timestamp).toLocaleString()}
+              className="text-xs text-gray-400"
+            >
+              <span className="sr-only">
+                {new Date(t.timestamp).toLocaleString()}
+              </span>
               {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
-            </div>
+            </time>
           </div>
         );
       })}

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -360,7 +360,16 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               {group.divider && (
                 <hr className="border-t border-gray-300 w-full my-2" />
               )}
-              <div className="text-xs text-gray-400 mb-1">{relativeGroupTime}</div>
+              <time
+                dateTime={firstMsg.timestamp}
+                title={new Date(firstMsg.timestamp).toLocaleString()}
+                className="text-xs text-gray-400 mb-1"
+              >
+                <span className="sr-only">
+                  {new Date(firstMsg.timestamp).toLocaleString()}
+                </span>
+                {relativeGroupTime}
+              </time>
               {anyUnread && (
                 <span
                   className="absolute right-0 top-1 w-2 h-2 bg-purple-600 rounded-full"
@@ -420,7 +429,16 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                             </a>
                           )}
                         </div>
-                        <span className={timeClass}>{timeString}</span>
+                        <time
+                          dateTime={msg.timestamp}
+                          title={new Date(msg.timestamp).toLocaleString()}
+                          className={timeClass}
+                        >
+                          <span className="sr-only">
+                            {new Date(msg.timestamp).toLocaleString()}
+                          </span>
+                          {timeString}
+                        </time>
                       </div>
                     </div>
                   </motion.div>

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -163,9 +163,16 @@ export default function FullScreenNotificationModal({
                         <div className="flex-1 text-left">
                           <div className="flex items-start justify-between">
                             <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
-                            <span className="text-xs text-gray-400 text-right">
+                            <time
+                              dateTime={n.timestamp}
+                              title={new Date(n.timestamp).toLocaleString()}
+                              className="text-xs text-gray-400 text-right"
+                            >
+                              <span className="sr-only">
+                                {new Date(n.timestamp).toLocaleString()}
+                              </span>
                               {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-                            </span>
+                            </time>
                           </div>
                           <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
                           {parsed.metadata && (

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -161,9 +161,16 @@ function DrawerItem({ n, onClick }: { n: UnifiedNotification; onClick: () => voi
               </span>
             )}
           </div>
-          <span className="text-xs text-gray-400 text-right">
+          <time
+            dateTime={n.timestamp}
+            title={new Date(n.timestamp).toLocaleString()}
+            className="text-xs text-gray-400 text-right"
+          >
+            <span className="sr-only">
+              {new Date(n.timestamp).toLocaleString()}
+            </span>
             {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-          </span>
+          </time>
         </div>
         <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
         {parsed.metadata && (


### PR DESCRIPTION
## Summary
- show full timestamp for screen readers in notification drawer
- apply accessible timestamps in fullscreen notification modal
- use `<time>` elements in message thread
- improve inbox list timestamp semantics

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a84e54690832e9cbc2b65af687f90