### PR TITLE
Add unread badge dot to inbox threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Unread booking requests are highlighted in indigo so they stand out.
 * Requests from the same client are grouped under a collapsible heading for a cleaner overview.
 * Unread counts appear as a red badge next to the sender name.
+* Threads with unread messages also show a small dot next to the timestamp until opened.
 
 ### Auth & Registration
 

--- a/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
+++ b/frontend/src/app/inbox/__tests__/InboxPage.test.tsx
@@ -79,6 +79,24 @@ describe('InboxPage unread badge', () => {
     expect(card?.className).toContain('bg-indigo-50');
     const badge = container.querySelector('span.bg-red-600');
     expect(badge?.textContent).toBe('2');
+    const dot = container.querySelector('span[aria-label="Unread messages"]');
+    expect(dot).not.toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('does not show unread dot for read threads', async () => {
+    const { container, root } = setup(0);
+    await act(async () => {
+      root.render(<InboxPage />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const dot = container.querySelector('span[aria-label="Unread messages"]');
+    expect(dot).toBeNull();
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -136,7 +136,15 @@ export default function InboxPage() {
                   </span>
                 )}
               </div>
-              <span className="text-xs text-gray-500">{b.formattedDate}</span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-500">{b.formattedDate}</span>
+                {b.unread > 0 && (
+                  <span
+                    className="w-2 h-2 bg-red-600 rounded-full"
+                    aria-label="Unread messages"
+                  />
+                )}
+              </div>
             </div>
             <div className="text-sm text-gray-600">
               📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
@@ -180,16 +188,24 @@ export default function InboxPage() {
               </div>
               <div className="text-xs text-gray-500 truncate">{t.content}</div>
             </div>
-            <time
-              dateTime={t.timestamp}
-              title={new Date(t.timestamp).toLocaleString()}
-              className="text-xs text-gray-400"
-            >
-              <span className="sr-only">
-                {new Date(t.timestamp).toLocaleString()}
-              </span>
-              {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
-            </time>
+            <div className="flex items-center gap-2">
+              <time
+                dateTime={t.timestamp}
+                title={new Date(t.timestamp).toLocaleString()}
+                className="text-xs text-gray-400"
+              >
+                <span className="sr-only">
+                  {new Date(t.timestamp).toLocaleString()}
+                </span>
+                {formatDistanceToNow(new Date(t.timestamp), { addSuffix: true })}
+              </time>
+              {(t.unread_count ?? 0) > 0 && (
+                <span
+                  className="w-2 h-2 bg-red-600 rounded-full"
+                  aria-label="Unread messages"
+                />
+              )}
+            </div>
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- display a small unread dot in Inbox thread list
- update README for the new badge
- test unread dot rendering

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a85e806d8832ebf1799064fd5647d