### PR TITLE
Improve chat day dividers

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
+* Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
 
 ### Artist Profile Enhancements

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -358,7 +358,20 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               className={`relative flex flex-col gap-0.5 ${isSelf ? 'items-end ml-auto' : 'items-start'} ${groupClass}`}
             >
               {group.divider && (
-                <hr className="border-t border-gray-300 w-full my-2" />
+                <div className="flex items-center my-2" role="separator">
+                  <hr className="flex-grow border-t border-gray-300" />
+                  <span
+                    className="px-2 text-xs text-gray-500 whitespace-nowrap"
+                    data-testid="day-divider"
+                  >
+                    {new Date(firstMsg.timestamp).toLocaleDateString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                  <hr className="flex-grow border-t border-gray-300" />
+                </div>
               )}
               <time
                 dateTime={firstMsg.timestamp}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -180,6 +180,44 @@ describe('MessageThread component', () => {
     expect(groups.length).toBe(2);
   });
 
+  it('shows full date divider between days', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Previous day',
+          message_type: 'text',
+          timestamp: '2024-06-09T23:59:00Z',
+        },
+        {
+          id: 2,
+          booking_request_id: 1,
+          sender_id: 1,
+          sender_type: 'client',
+          content: 'Next day',
+          message_type: 'text',
+          timestamp: '2024-06-10T00:01:00Z',
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} />);
+    });
+
+    const divider = container.querySelector('[data-testid="day-divider"]');
+    expect(divider?.textContent).toBe(
+      new Date('2024-06-10T00:01:00Z').toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    );
+  });
+
   it('deduplicates websocket messages already fetched', async () => {
     const msg = {
       id: 99,


### PR DESCRIPTION
## Summary
- show the date text when inserting a day divider in MessageThread
- document day divider change in README
- test day divider displays full date

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a87d9c5f8832ea64058ba9617f455