### PR TITLE
Show booking details in collapsible section

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
+* Booking details messages are shown in chat threads inside a collapsible section with a "Show details" toggle.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -13,6 +13,7 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import { formatDistanceToNow } from 'date-fns';
 import { getFullImageUrl } from '@/lib/utils';
+import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { Message, MessageCreate, Quote } from '@/types';
 import {
   getMessagesForBookingRequest,
@@ -81,8 +82,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       const filtered = res.data.filter(
         (m) =>
           !(
-            (m.message_type === 'text' && m.content.startsWith('Requesting ')) ||
-            (m.message_type === 'system' && m.content === 'Booking request sent')
+            m.message_type === 'text' && m.content.startsWith('Requesting ')
           ),
       );
       setMessages(filtered);
@@ -428,6 +428,13 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                                 }).format(Number(quotes[msg.quote_id].price))}
                               </p>
                             </div>
+                          ) : msg.message_type === 'system' && msg.content.startsWith(BOOKING_DETAILS_PREFIX) ? (
+                            <details data-testid="booking-details">
+                              <summary className="cursor-pointer text-blue-600">Show details</summary>
+                              <pre className="whitespace-pre-wrap">
+                                {msg.content.slice(BOOKING_DETAILS_PREFIX.length).trim()}
+                              </pre>
+                            </details>
                           ) : (
                             msg.content
                           )}{' '}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -310,6 +310,35 @@ describe('MessageThread component', () => {
     expect(sendButton?.getAttribute('aria-label')).toBe('Send message');
   });
 
+  it('renders booking details in a collapsible section', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Booking details:\nLocation: Test City',
+          message_type: 'system',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const details = container.querySelector('[data-testid="booking-details"]');
+    const summary = container.querySelector('summary');
+    expect(details).not.toBeNull();
+    expect(summary?.textContent).toBe('Show details');
+    expect(details?.textContent).toContain('Location: Test City');
+  });
+
   it('announces new messages when scrolled away from bottom', async () => {
     await act(async () => {
       root.render(<MessageThread bookingRequestId={1} />);

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const BOOKING_DETAILS_PREFIX = 'Booking details:';


### PR DESCRIPTION
## Summary
- stop filtering system messages in MessageThread
- render booking details messages in a collapsible "Show details" section
- document the new behavior in the README
- add unit tests for the collapsible rendering

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a8cc37268832ea91fd1d0764029a4