### PR TITLE
Improve booking details toggle styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
-* Booking details messages are shown in chat threads inside a collapsible section with a "Show details" toggle.
+* Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image';
 import { formatDistanceToNow } from 'date-fns';
 import { getFullImageUrl } from '@/lib/utils';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
+import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Message, MessageCreate, Quote } from '@/types';
 import {
   getMessagesForBookingRequest,
@@ -74,6 +75,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [announceNewMessage, setAnnounceNewMessage] = useState('');
+  const [openDetails, setOpenDetails] = useState<Record<number, boolean>>({});
   const prevLengthRef = useRef(0);
 
   const fetchMessages = useCallback(async () => {
@@ -429,12 +431,33 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                               </p>
                             </div>
                           ) : msg.message_type === 'system' && msg.content.startsWith(BOOKING_DETAILS_PREFIX) ? (
-                            <details data-testid="booking-details">
-                              <summary className="cursor-pointer text-blue-600">Show details</summary>
-                              <pre className="whitespace-pre-wrap">
-                                {msg.content.slice(BOOKING_DETAILS_PREFIX.length).trim()}
-                              </pre>
-                            </details>
+                            <div data-testid="booking-details">
+                              <button
+                                type="button"
+                                data-testid="booking-details-button"
+                                onClick={() =>
+                                  setOpenDetails((prev) => ({
+                                    ...prev,
+                                    [msg.id]: !prev[msg.id],
+                                  }))
+                                }
+                                className="flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
+                              >
+                                {openDetails[msg.id] ? (
+                                  <ChevronDownIcon className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                  <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
+                                )}
+                                {openDetails[msg.id] ? 'Hide details' : 'Show details'}
+                              </button>
+                              {openDetails[msg.id] && (
+                                <div className="mt-2 rounded-lg bg-gray-50 border border-gray-200 px-4 py-3 text-sm text-gray-800 font-mono whitespace-pre-wrap" data-testid="booking-details-content">
+                                  {msg.content
+                                    .slice(BOOKING_DETAILS_PREFIX.length)
+                                    .trim()}
+                                </div>
+                              )}
+                            </div>
                           ) : (
                             msg.content
                           )}{' '}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -333,10 +333,20 @@ describe('MessageThread component', () => {
     });
 
     const details = container.querySelector('[data-testid="booking-details"]');
-    const summary = container.querySelector('summary');
+    const button = container.querySelector(
+      '[data-testid="booking-details-button"]',
+    ) as HTMLButtonElement;
     expect(details).not.toBeNull();
-    expect(summary?.textContent).toBe('Show details');
-    expect(details?.textContent).toContain('Location: Test City');
+    expect(button?.textContent).toBe('Show details');
+    expect(
+      container.querySelector('[data-testid="booking-details-content"]'),
+    ).toBeNull();
+    act(() => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const content = container.querySelector('[data-testid="booking-details-content"]');
+    expect(button?.textContent).toBe('Hide details');
+    expect(content?.textContent).toContain('Location: Test City');
   });
 
   it('announces new messages when scrolled away from bottom', async () => {


### PR DESCRIPTION
## Summary
- update documentation to mention the new show/hide details button
- enhance booking details toggle UI with chevron icons
- adjust MessageThread tests for new button behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a938c15a8832ea8fda7d5821b700f