### PR TITLE
Improve booking request accordion accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Tap a booking request card to open `/booking-requests/[id]`.
 * Unread booking requests are highlighted in indigo so they stand out.
 * Requests from the same client are grouped under a collapsible heading for a cleaner overview.
+* Toggle buttons now include `aria-expanded` and `aria-controls` attributes and display a focus ring for keyboard users.
 * Each request row now shows a red badge with its unread count next to the status.
 * Threads with unread messages also show a small dot next to the timestamp until opened.
 

--- a/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
+++ b/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
@@ -126,4 +126,34 @@ describe('BookingRequestsPage', () => {
     });
     container.remove();
   });
+
+  it('sets aria attributes on toggle buttons', async () => {
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(<BookingRequestsPage />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const aliceHeader = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Alice A'),
+    ) as HTMLButtonElement;
+    expect(aliceHeader?.getAttribute('aria-controls')).toBe('requests-1');
+    expect(aliceHeader?.getAttribute('aria-expanded')).toBe('false');
+    if (aliceHeader) {
+      act(() => {
+        aliceHeader.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(aliceHeader?.getAttribute('aria-expanded')).toBe('true');
+    const list = container.querySelector('#requests-1');
+    expect(list).toBeTruthy();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });

--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -172,20 +172,22 @@ export default function BookingRequestsPage() {
             </div>
             <ul className="divide-y divide-gray-200">
               {grouped.map((g) => (
-                <li key={`client-${g.clientId}`}> 
+                <li key={`client-${g.clientId}`}>
                   <button
                     type="button"
                     onClick={() =>
                       setOpenClients((o) => ({ ...o, [g.clientId]: !o[g.clientId] }))
                     }
-                    className="w-full text-left p-4 bg-gray-50 font-medium flex items-center justify-between"
+                    aria-expanded={openClients[g.clientId] || false}
+                    aria-controls={`requests-${g.clientId}`}
+                    className="w-full text-left p-4 bg-gray-50 font-medium flex items-center justify-between focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300"
                   >
                     <span>
                       {openClients[g.clientId] ? '▼' : '▶'} {g.clientName} ({g.requests.length} requests)
                     </span>
                   </button>
                   {openClients[g.clientId] && (
-                    <ul className="divide-y divide-gray-200">
+                    <ul id={`requests-${g.clientId}`} className="divide-y divide-gray-200">
                       {g.requests.map((r) => {
                         const count = unreadCounts[r.id] ?? 0;
                         const unread = count > 0;


### PR DESCRIPTION
## Summary
- highlight toggle buttons when focused
- mark each collapsible section with `aria-expanded` and `aria-controls`
- verify the attributes via unit test
- document accessible toggle behaviour in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a99b74104832eacd52b01bcb4d44e