### PR TITLE
Add TimeAgo component

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -11,7 +11,7 @@ import React, {
 } from 'react';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
-import { formatDistanceToNow } from 'date-fns';
+import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl } from '@/lib/utils';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
@@ -350,9 +350,6 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           const isSelf = !isSystem && firstMsg.sender_id === user?.id;
           const anyUnread = group.messages.some((m) => m.unread);
           const groupClass = `${idx > 0 ? 'mt-1' : ''} ${anyUnread ? 'bg-purple-50' : ''}`;
-          const relativeGroupTime = formatDistanceToNow(new Date(firstMsg.timestamp), {
-            addSuffix: true,
-          });
 
           return (
             <div
@@ -375,16 +372,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                   <hr className="flex-grow border-t border-gray-300" />
                 </div>
               )}
-              <time
-                dateTime={firstMsg.timestamp}
-                title={new Date(firstMsg.timestamp).toLocaleString()}
+              <TimeAgo
+                timestamp={firstMsg.timestamp}
                 className="text-xs text-gray-400 mb-1"
-              >
-                <span className="sr-only">
-                  {new Date(firstMsg.timestamp).toLocaleString()}
-                </span>
-                {relativeGroupTime}
-              </time>
+              />
               {anyUnread && (
                 <span
                   className="absolute right-0 top-1 w-2 h-2 bg-purple-600 rounded-full"

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { formatDistanceToNow, format } from 'date-fns';
+import { format } from 'date-fns';
+import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl } from '@/lib/utils';
 import type { UnifiedNotification } from '@/types';
 
@@ -156,14 +157,10 @@ export default function NotificationListItem({ n, onClick, style, className = ''
               </span>
             )}
           </div>
-          <time
-            dateTime={n.timestamp}
-            title={new Date(n.timestamp).toLocaleString()}
+          <TimeAgo
+            timestamp={n.timestamp}
             className="text-xs text-gray-400 text-right"
-          >
-            <span className="sr-only">{new Date(n.timestamp).toLocaleString()}</span>
-            {formatDistanceToNow(new Date(n.timestamp), { addSuffix: true })}
-          </time>
+          />
         </div>
         <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
         {parsed.metadata && (

--- a/frontend/src/components/ui/TimeAgo.tsx
+++ b/frontend/src/components/ui/TimeAgo.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+interface TimeAgoProps {
+  timestamp: string | number | Date;
+  addSuffix?: boolean;
+  intervalMs?: number;
+  className?: string;
+}
+
+export default function TimeAgo({
+  timestamp,
+  addSuffix = true,
+  intervalMs = 60000,
+  className,
+}: TimeAgoProps) {
+  const [relative, setRelative] = useState(() =>
+    formatDistanceToNow(new Date(timestamp), { addSuffix }),
+  );
+
+  useEffect(() => {
+    function update() {
+      setRelative(formatDistanceToNow(new Date(timestamp), { addSuffix }));
+    }
+    const id = setInterval(update, intervalMs);
+    update();
+    return () => clearInterval(id);
+  }, [timestamp, addSuffix, intervalMs]);
+
+  const iso = new Date(timestamp).toISOString();
+  const full = new Date(timestamp).toLocaleString();
+
+  return (
+    <time dateTime={iso} title={full} className={className}>
+      <span className="sr-only">{full}</span>
+      {relative}
+    </time>
+  );
+}

--- a/frontend/src/components/ui/__tests__/TimeAgo.test.tsx
+++ b/frontend/src/components/ui/__tests__/TimeAgo.test.tsx
@@ -1,0 +1,42 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import TimeAgo from '../TimeAgo';
+
+describe('TimeAgo component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('updates relative time periodically', () => {
+    act(() => {
+      root.render(
+        <TimeAgo timestamp="2025-01-01T11:59:00Z" intervalMs={60000} />,
+      );
+    });
+    const timeEl = container.querySelector('time') as HTMLElement;
+    const firstText = timeEl.textContent;
+
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+
+    const secondText = timeEl.textContent;
+    expect(secondText).not.toBe(firstText);
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -4,3 +4,4 @@ export { default as Tag } from './Tag';
 export { default as Stepper } from './Stepper';
 export { default as TextInput } from './TextInput';
 export { default as Toast } from './Toast';
+export { default as TimeAgo } from './TimeAgo';


### PR DESCRIPTION
## Summary
- add `TimeAgo` wrapper around `formatDistanceToNow`
- use `TimeAgo` in message thread and notification list items
- export `TimeAgo` from UI index
- test periodic updates in `TimeAgo`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a9cc530a4832e9018a81064c84999