### PR TITLE
Refine notification list styles

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -118,7 +118,7 @@ export default function FullScreenNotificationModal({
               <List
                 height={listHeight}
                 itemCount={filtered.length + (hasMore ? 1 : 0)}
-                itemSize={96}
+                itemSize={84}
                 width="100%"
                 overscanCount={3}
               >
@@ -131,7 +131,7 @@ export default function FullScreenNotificationModal({
                         n={n}
                         onClick={() => handleItemClick(n.id || (n.booking_request_id as number))}
                         style={style}
-                        className="rounded-lg shadow"
+                        className="rounded-lg"
                       />
                     );
                   }

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -121,7 +121,7 @@ export default function NotificationDrawer({
                       <List
                         height={listHeight}
                         itemCount={filtered.length + (hasMore ? 1 : 0)}
-                        itemSize={88}
+                        itemSize={84}
                         width="100%"
                         overscanCount={3}
                       >
@@ -135,7 +135,6 @@ export default function NotificationDrawer({
                                   onClick={() =>
                                     onItemClick(n.id || (n.booking_request_id as number))
                                   }
-                                  className="border-b last:border-b-0"
                                 />
                               </div>
                             );

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -121,10 +121,10 @@ export default function NotificationListItem({ n, onClick, style, className = ''
       style={style}
       onClick={onClick}
       className={classNames(
-        'group flex w-full items-start px-3 sm:px-4 py-3 text-base gap-2 sm:gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 rounded shadow-sm transition cursor-pointer',
+        'group flex w-full items-start px-3 sm:px-4 py-2.5 text-base gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 hover:bg-gray-50 transition cursor-pointer border-b border-gray-200',
         n.is_read
-          ? 'bg-white border-l border-transparent text-gray-500'
-          : 'bg-indigo-50 border-l-4 border-indigo-500 font-medium text-gray-900',
+          ? 'bg-white border-l border-transparent text-gray-600'
+          : 'bg-indigo-50 border-l-4 border-indigo-500 text-gray-900 font-medium',
         className,
       )}
     >
@@ -164,7 +164,7 @@ export default function NotificationListItem({ n, onClick, style, className = ''
         </div>
         <p className="text-sm text-gray-700 truncate whitespace-nowrap overflow-hidden">{parsed.subtitle}</p>
         {parsed.metadata && (
-          <p className="text-xs text-gray-500 truncate whitespace-nowrap overflow-hidden">{parsed.metadata}</p>
+          <p className="text-sm text-gray-500 truncate whitespace-nowrap overflow-hidden">{parsed.metadata}</p>
         )}
       </div>
     </button>


### PR DESCRIPTION
## Summary
- tweak NotificationListItem padding, font sizes, and border for consistency
- match NotificationDrawer and full-screen modal item sizes
- drop shadows from modal cards

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684aa354d818832eb500460f6c794612