### PR TITLE
Fix notification title overflow

### DIFF
--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -149,8 +149,13 @@ export default function NotificationListItem({ n, onClick, style, className = ''
       )}
       <div className="flex-1 text-left">
         <div className="flex items-start justify-between">
-          <div className="flex items-center gap-2">
-            <span className="text-base font-medium text-gray-900 truncate whitespace-nowrap overflow-hidden">{parsed.title}</span>
+          <div className="flex items-center gap-2 truncate overflow-hidden">
+            <span
+              className="text-base font-medium text-gray-900 whitespace-nowrap"
+              title={parsed.title}
+            >
+              {parsed.title}
+            </span>
             {parsed.unreadCount > 0 && (
               <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">
                 {parsed.unreadCount > 99 ? '99+' : parsed.unreadCount}

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -1,0 +1,45 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import NotificationListItem from '../NotificationListItem';
+import type { UnifiedNotification } from '@/types';
+
+const baseNotification: UnifiedNotification = {
+  type: 'message',
+  timestamp: new Date().toISOString(),
+  is_read: false,
+  content: 'New message: Hi',
+  booking_request_id: 1,
+  name: 'Alice',
+} as UnifiedNotification;
+
+describe('NotificationListItem', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('sets title attribute to parsed title', () => {
+    act(() => {
+      root.render(
+        React.createElement(NotificationListItem, {
+          n: baseNotification,
+          onClick: () => {},
+        }),
+      );
+    });
+    const span = container.querySelector('span[title]');
+    expect(span?.getAttribute('title')).toBe('Alice');
+  });
+});


### PR DESCRIPTION
## Summary
- apply `truncate` and `overflow-hidden` to title container in `NotificationListItem`
- add `title` attribute to show full text on hover
- test that `title` attribute is rendered

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684aa58e7b2c832e9e7469ae04feb647