### PR TITLE
Fix Next.js image host config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ NEXT_PUBLIC_WS_URL=ws://192.168.3.203:8000
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyDm-BKmMtzMSMd-XUdfapjEUU6O5mYy2bk
 ```
 
+The host portion of `NEXT_PUBLIC_API_URL` is also used by
+`next.config.js` to allow optimized image requests from the backend.
+Set this URL to match your API server so artist profile pictures and
+cover photos load without 400 errors from the `/_next/image` endpoint.
+
 The location input relies on the built-in Google Maps Places Autocomplete
 service instead of the experimental `@googlemaps/places` package. The previous
 dependency caused a build failure because it depended on Node-only modules like

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,25 +1,30 @@
 /** @type {import('next').NextConfig} */
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const { protocol, hostname, port } = new URL(API_URL);
+
+const remotePatterns = [
+  {
+    protocol: protocol.replace(':', ''),
+    hostname,
+    port: port || '',
+    pathname: '/static/**',
+  },
+];
+
+if (hostname !== 'localhost') {
+  remotePatterns.push({
+    protocol: 'http',
+    hostname: 'localhost',
+    port: '8000',
+    pathname: '/static/**',
+  });
+}
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    // Allow localhost (for local development) and the LAN IP
-    remotePatterns: [
-      {
-        protocol: 'http',
-        hostname: 'localhost',
-        port: '8000',
-        pathname: '/static/**',
-      },
-      {
-        protocol: 'http',
-        hostname: '192.168.3.203',
-        port: '8000',
-        pathname: '/static/**',
-      },
-    ],
-    // If you prefer using domains instead of remotePatterns, you can uncomment:
-    // domains: ['localhost', '192.168.3.203'],
+    remotePatterns,
   },
 };
 


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` for Next.js remote image host
- document configuring the image host in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ab83e2068832ea1a3a3b3516b8aaa