### PR TITLE
Fix image url builder

### DIFF
--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,10 @@
-import { extractErrorMessage, normalizeService, getNextAvailableDates } from '../utils';
+import {
+  extractErrorMessage,
+  normalizeService,
+  getNextAvailableDates,
+  getFullImageUrl,
+} from '../utils';
+import api from '../api';
 import { format } from 'date-fns';
 import type { Service, ArtistProfile } from '@/types';
 
@@ -53,5 +59,20 @@ describe('getNextAvailableDates', () => {
     expect(format(dates[0], 'yyyy-MM-dd')).toBe('2024-06-11');
     expect(format(dates[1], 'yyyy-MM-dd')).toBe('2024-06-13');
     expect(format(dates[2], 'yyyy-MM-dd')).toBe('2024-06-14');
+  });
+});
+
+describe('getFullImageUrl', () => {
+  it('joins base url and path removing /api suffix', () => {
+    const orig = api.defaults.baseURL;
+    api.defaults.baseURL = 'http://example.com/api';
+    const result = getFullImageUrl('profile_pics/foo.jpg');
+    expect(result).toBe('http://example.com/static/profile_pics/foo.jpg');
+    api.defaults.baseURL = orig;
+  });
+
+  it('returns absolute path unchanged', () => {
+    const url = 'https://cdn.example.com/img.png';
+    expect(getFullImageUrl(url)).toBe(url);
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -2,13 +2,23 @@ import api from './api';
 import { Service } from '@/types';
 import { addDays } from 'date-fns';
 
-export const getFullImageUrl = (relativePath: string | undefined | null): string | null => {
+export const getFullImageUrl = (
+  relativePath: string | undefined | null,
+): string | null => {
   if (!relativePath) return null;
   if (relativePath.startsWith('http://') || relativePath.startsWith('https://')) {
     return relativePath;
   }
-  const cleanPath = relativePath.startsWith('/static/') ? relativePath : `/static/${relativePath.replace(/^\/+/, '')}`;
-  return `${api.defaults.baseURL}${cleanPath}`;
+
+  const cleanPath = relativePath.startsWith('/static/')
+    ? relativePath
+    : `/static/${relativePath.replace(/^\/+/, '')}`;
+
+  let base = api.defaults.baseURL || '';
+  base = base.replace(/\/+$/, '');
+  base = base.replace(/\/api(?:\/v\d+)?$/, '');
+
+  return `${base}${cleanPath}`;
 };
 
 export const extractErrorMessage = (detail: unknown): string => {


### PR DESCRIPTION
## Summary
- handle `/api` suffix when building image URLs
- test `getFullImageUrl` helper

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ab9c235c0832e9b7012c0eab6af19