### PR TITLE
Handle missing profile images

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * ARIA roles, clearer empty states, optional subtitle/tagline.
 * Shared `Card`, `Tag`, `TextInput` components.
 * Open Graph meta tags and fallback avatars.
+* Profile images across the UI now automatically fall back to `default-avatar.svg` if the requested file cannot be loaded.
 * Accessibility and animation improvements.
 * Dashboard stats now animate on load using **framer-motion**.
 

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -38,7 +38,16 @@ export default function ArtistCard({
     <Card className={clsx('overflow-hidden', className)} {...props}>
       <div className="aspect-w-16 aspect-h-9 bg-gray-200 flex items-center justify-center">
         {imageUrl ? (
-          <Image src={imageUrl} alt={name} width={512} height={270} className="object-cover w-full h-48" />
+          <Image
+            src={imageUrl}
+            alt={name}
+            width={512}
+            height={270}
+            className="object-cover w-full h-48"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+            }}
+          />
         ) : (
           <span className="text-gray-400 text-sm">No Image</span>
         )}

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -39,4 +39,18 @@ describe('ArtistCard optional fields', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('falls back to default avatar on image error', () => {
+    const { container, root } = setup({ imageUrl: '/missing.jpg' });
+    const img = container.querySelector('img') as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    if (img) {
+      act(() => {
+        img.dispatchEvent(new Event('error'));
+      });
+      expect(img.src).toContain('/default-avatar.svg');
+    }
+    act(() => root.unmount());
+    container.remove();
+  });
 });

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -327,6 +327,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               width={32}
               height={32}
               className="h-8 w-8 rounded-full object-cover"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+              }}
             />
           )}
         </header>

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -136,6 +136,9 @@ export default function NotificationListItem({ n, onClick, style, className = ''
             width={40}
             height={40}
             className="h-10 w-10 flex-shrink-0 rounded-full object-cover"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+            }}
           />
         ) : (
           <div className="h-10 w-10 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">


### PR DESCRIPTION
## Summary
- show placeholder avatar if artist profile image fails to load
- apply same fallback logic in message threads and notifications
- document fallback behavior
- test image error handler in ArtistCard

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684abba48268832e9aed326ebf0dc48d