### PR TITLE
Add default ZAR currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,8 @@ POST /api/v1/payments
 ```
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
 
+All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
+
 ---
 
 ## Troubleshooting & Common Errors

--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -57,7 +57,7 @@ class Quote(Base):
     
     quote_details = Column(Text, nullable=False)
     price = Column(Numeric(10, 2), nullable=False)
-    currency = Column(String(3), nullable=False, default="USD") # e.g., USD, EUR
+    currency = Column(String(3), nullable=False, default="ZAR") # e.g., ZAR, EUR
     valid_until = Column(DateTime, nullable=True) # Quote expiry date
 
     status = Column(SQLAlchemyEnum(QuoteStatus), nullable=False, default=QuoteStatus.PENDING_CLIENT_ACTION)

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -54,7 +54,7 @@ class BookingRequestResponse(BookingRequestBase):
 class QuoteBase(BaseModel):
     quote_details: str
     price: Decimal
-    currency: str = "USD"
+    currency: str = "ZAR"
     valid_until: Optional[datetime] = None
 
 class QuoteCreate(QuoteBase):

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -612,7 +612,7 @@ export default function EditArtistProfilePage(): JSX.Element {
               <div className="space-y-4">
                 <div>
                   <label htmlFor="hourlyRate" className={labelClasses}>
-                    Hourly Rate (USD)
+                    Hourly Rate (R)
                   </label>
                   <input
                     type="number"

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -418,7 +418,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                             <div className="text-gray-800">
                               <p className="font-medium">{quotes[msg.quote_id].quote_details}</p>
                               <p className="text-sm mt-1">
-                                {new Intl.NumberFormat('en-US', {
+                                {new Intl.NumberFormat('en-ZA', {
                                   style: 'currency',
                                   currency: quotes[msg.quote_id].currency,
                                 }).format(Number(quotes[msg.quote_id].price))}

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -99,7 +99,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
             </div>
 
             <div>
-              <label htmlFor="price" className="block text-sm font-medium text-gray-700">Price ($)</label>
+              <label htmlFor="price" className="block text-sm font-medium text-gray-700">Price (R)</label>
               <input
                 type="number"
                 id="price"

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -152,7 +152,7 @@ export default function EditServiceModal({
                 htmlFor="price"
                 className="block text-sm font-medium text-gray-700"
               >
-                Price ($)
+                Price (R)
               </label>
               <input
                 type="number"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,7 +107,7 @@ export interface QuoteCreate {
   booking_request_id: number;
   quote_details: string;
   price: number;
-  currency?: string; // defaults to "USD"
+  currency?: string; // defaults to "ZAR"
   valid_until?: string; // ISO date-time
 }
 


### PR DESCRIPTION
## Summary
- set South African Rand (ZAR) as the default currency in backend models and schemas
- update frontend forms and message formatting to use ZAR and locale `en-ZA`
- adjust labels on service forms and profile edit page
- document the new default currency

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ac158fbb0832e846457933106be8d