### PR TITLE
Add currency formatter to artists page

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react';
 import MainLayout from '@/components/layout/MainLayout';
 import { getArtists } from '@/lib/api';
-import { getFullImageUrl } from '@/lib/utils';
+import { getFullImageUrl, formatCurrency } from '@/lib/utils';
 import type { ArtistProfile } from '@/types';
 import ArtistCard from '@/components/artist/ArtistCard';
 
@@ -101,7 +101,11 @@ export default function ArtistsPage() {
                   getFullImageUrl(a.profile_picture_url || a.portfolio_urls?.[0]) ||
                   undefined
                 }
-                price={a.hourly_rate && a.price_visible ? `$${a.hourly_rate}` : undefined}
+                price={
+                  a.hourly_rate && a.price_visible
+                    ? formatCurrency(Number(a.hourly_rate))
+                    : undefined
+                }
                 location={a.location}
                 specialties={a.specialties}
                 verified={user?.is_verified}

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeService,
   getNextAvailableDates,
   getFullImageUrl,
+  formatCurrency,
 } from '../utils';
 import api from '../api';
 import { format } from 'date-fns';
@@ -74,5 +75,15 @@ describe('getFullImageUrl', () => {
   it('returns absolute path unchanged', () => {
     const url = 'https://cdn.example.com/img.png';
     expect(getFullImageUrl(url)).toBe(url);
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats numbers as ZAR currency by default', () => {
+    expect(formatCurrency(1000.5)).toBe('R\u00A01\u00A0000,50');
+  });
+
+  it('uses the provided currency code', () => {
+    expect(formatCurrency(100, 'USD')).toBe('US$100,00');
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -43,6 +43,12 @@ export const extractErrorMessage = (detail: unknown): string => {
   return String(detail);
 };
 
+export const formatCurrency = (
+  value: number,
+  currency = 'ZAR',
+): string =>
+  new Intl.NumberFormat('en-ZA', { style: 'currency', currency }).format(value);
+
 export const normalizeService = (service: Service): Service => ({
   ...service,
   price:


### PR DESCRIPTION
## Summary
- add `formatCurrency` utility for consistent money display
- update artist listings to use `formatCurrency`
- test new currency formatter

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ac587f2a8832ebe68e3d9188da917