### PR TITLE
Format earnings using locale currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Removed the unused "Recent Activity" block.
 * Booking request and booking lists collapse after five items with a **Show All** toggle.
 * Improved dashboard stats layout with monthly earnings card.
+* Currency values now use consistent locale formatting with `formatCurrency()`.
 * Streamlined mobile dashboard with collapsible overview and sticky tabs.
   ![Mobile dashboard states](docs/mobile_dashboard_states.svg)
 

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
+import { formatCurrency } from '@/lib/utils';
 import { waitFor } from '@testing-library/react';
 import DashboardPage from '../page';
 import * as api from '@/lib/api';
@@ -147,7 +148,7 @@ describe('DashboardPage artist stats', () => {
 
   it('renders monthly earnings card', () => {
     expect(container.textContent).toContain('Earnings This Month');
-    expect(container.textContent).toContain('120');
+    expect(container.textContent).toContain(formatCurrency(120));
   });
 });
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ import {
   deleteService,
 } from "@/lib/api";
 import { format } from "date-fns";
-import { normalizeService } from "@/lib/utils";
+import { formatCurrency, normalizeService } from "@/lib/utils";
 import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
 import OverviewAccordion from "@/components/dashboard/OverviewAccordion";
@@ -109,7 +109,7 @@ function ServiceCard({
           <p className="text-xs text-gray-500">{service.service_type}</p>
           <div className="mt-2 flex items-center justify-between">
             <span className="text-sm font-medium text-gray-900">
-              ${service.price.toFixed(2)}
+              {formatCurrency(Number(service.price))}
             </span>
             <span className="text-sm text-gray-500">{service.duration_minutes} min</span>
           </div>
@@ -365,11 +365,11 @@ export default function DashboardPage() {
             <OverviewAccordion
               primaryStats={[
                 { label: 'Total Bookings', value: bookings.length },
-                { label: 'Total Earnings', value: `$${totalEarnings.toFixed(2)}` },
+                { label: 'Total Earnings', value: formatCurrency(totalEarnings) },
               ]}
               secondaryStats={[
                 { label: 'Total Services', value: servicesCount },
-                { label: 'Earnings This Month', value: `$${earningsThisMonth.toFixed(2)}` },
+                { label: 'Earnings This Month', value: formatCurrency(earningsThisMonth) },
               ]}
             />
           </div>
@@ -461,7 +461,7 @@ export default function DashboardPage() {
                       {booking.status}
                     </span>
                     <span className="text-sm text-gray-500">
-                      ${booking.total_price.toFixed(2)}
+                      {formatCurrency(Number(booking.total_price))}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- update artist dashboard to use `formatCurrency()` for service prices
- show formatted totals for earnings widgets
- format booking total price in booking list
- document new currency formatting
- update tests for dashboard earnings card

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ac9c15d58832ea30c19a1581ca2fb