### PR TITLE
Add currency helper constant and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,8 @@ Payment processing now emits structured logs instead of printing to stdout so tr
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 
+`DEFAULT_CURRENCY` in `frontend/src/lib/constants.ts` exports this value for use across the app. Call `formatCurrency(value, currency?, locale?)` from `frontend/src/lib/utils.ts` to format amounts consistently.
+
 ---
 
 ## Troubleshooting & Common Errors

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -12,7 +12,7 @@ import React, {
 import { motion } from 'framer-motion';
 import Image from 'next/image';
 import TimeAgo from '../ui/TimeAgo';
-import { getFullImageUrl } from '@/lib/utils';
+import { getFullImageUrl, formatCurrency } from '@/lib/utils';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Message, MessageCreate, Quote } from '@/types';
@@ -418,10 +418,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                             <div className="text-gray-800">
                               <p className="font-medium">{quotes[msg.quote_id].quote_details}</p>
                               <p className="text-sm mt-1">
-                                {new Intl.NumberFormat('en-ZA', {
-                                  style: 'currency',
-                                  currency: quotes[msg.quote_id].currency,
-                                }).format(Number(quotes[msg.quote_id].price))}
+                                {formatCurrency(
+                                  Number(quotes[msg.quote_id].price),
+                                  quotes[msg.quote_id].currency,
+                                )}
                               </p>
                             </div>
                           ) : msg.message_type === 'system' && msg.content.startsWith(BOOKING_DETAILS_PREFIX) ? (

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getFullImageUrl,
   formatCurrency,
 } from '../utils';
+import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
 import { format } from 'date-fns';
 import type { Service, ArtistProfile } from '@/types';
@@ -79,11 +80,15 @@ describe('getFullImageUrl', () => {
 });
 
 describe('formatCurrency', () => {
-  it('formats numbers as ZAR currency by default', () => {
+  it('formats numbers using DEFAULT_CURRENCY and locale', () => {
     expect(formatCurrency(1000.5)).toBe('R\u00A01\u00A0000,50');
   });
 
   it('uses the provided currency code', () => {
     expect(formatCurrency(100, 'USD')).toBe('US$100,00');
+  });
+
+  it('accepts a custom locale', () => {
+    expect(formatCurrency(100, DEFAULT_CURRENCY, 'en-US')).toBe('ZAR\u00A0100.00');
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,1 +1,4 @@
 export const BOOKING_DETAILS_PREFIX = 'Booking details:';
+
+/** Default currency for all price displays */
+export const DEFAULT_CURRENCY = 'ZAR';

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import api from './api';
+import { DEFAULT_CURRENCY } from './constants';
 import { Service } from '@/types';
 import { addDays } from 'date-fns';
 
@@ -43,11 +44,13 @@ export const extractErrorMessage = (detail: unknown): string => {
   return String(detail);
 };
 
-export const formatCurrency = (
+export function formatCurrency(
   value: number,
-  currency = 'ZAR',
-): string =>
-  new Intl.NumberFormat('en-ZA', { style: 'currency', currency }).format(value);
+  currency = DEFAULT_CURRENCY,
+  locale = 'en-ZA',
+): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
+}
 
 export const normalizeService = (service: Service): Service => ({
   ...service,


### PR DESCRIPTION
## Summary
- add `DEFAULT_CURRENCY` constant
- extend `formatCurrency` utility with locale support
- use `formatCurrency` in `MessageThread`
- document currency utilities
- update tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684acde2d094832e858e150758aec040