### PR TITLE
Add currency field to service responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking request and booking lists collapse after five items with a **Show All** toggle.
 * Improved dashboard stats layout with monthly earnings card.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
+* Service API responses now include a `currency` field.
 * Streamlined mobile dashboard with collapsible overview and sticky tabs.
   ![Mobile dashboard states](docs/mobile_dashboard_states.svg)
 

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -35,6 +35,7 @@ class Service(BaseModel):
     title = Column(String, index=True, nullable=False)
     description = Column(Text, nullable=True)
     price = Column(Numeric(10, 2), nullable=False)
+    currency = Column(String(3), nullable=False, default="ZAR")
     duration_minutes = Column(Integer, nullable=False)
     display_order = Column(Integer, nullable=False, default=0)
     service_type = Column(

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -12,6 +12,7 @@ class ServiceBase(BaseModel):
     description: Optional[str] = None
     duration_minutes: Optional[int] = None
     price: Optional[Decimal] = None
+    currency: Optional[str] = "ZAR"
     display_order: Optional[int] = None
     service_type: Optional[ServiceType] = None
 

--- a/backend/tests/test_currency_fields.py
+++ b/backend/tests/test_currency_fields.py
@@ -1,0 +1,56 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.models import User, UserType, BookingRequest, BookingRequestStatus
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.models.base import BaseModel
+from app.models.service import ServiceType
+from app.schemas import ServiceCreate, ServiceResponse, QuoteCreate, QuoteResponse
+from app.api import api_service
+from app.crud import crud_quote
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_service_response_includes_currency():
+    db = setup_db()
+    artist = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    db.add(artist)
+    db.commit()
+    db.refresh(artist)
+    profile = ArtistProfileV2(user_id=artist.id)
+    db.add(profile)
+    db.commit()
+
+    svc_in = ServiceCreate(title='Gig', duration_minutes=60, price=100, service_type=ServiceType.OTHER)
+    svc = api_service.create_service(db=db, service_in=svc_in, current_artist=artist)
+    schema = ServiceResponse.model_validate(svc)
+    assert schema.currency == 'ZAR'
+
+
+def test_quote_response_includes_currency():
+    db = setup_db()
+    client = User(email='c@test.com', password='x', first_name='C', last_name='Client', user_type=UserType.CLIENT)
+    artist = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+    profile = ArtistProfileV2(user_id=artist.id)
+    db.add(profile)
+    db.commit()
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id, status=BookingRequestStatus.PENDING_QUOTE)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote_in = QuoteCreate(booking_request_id=br.id, quote_details='Hi', price=50)
+    quote = crud_quote.create_quote(db=db, quote=quote_in, artist_id=artist.id)
+    schema = QuoteResponse.model_validate(quote)
+    assert schema.currency == 'ZAR'
+

--- a/backend/tests/test_service_schema.py
+++ b/backend/tests/test_service_schema.py
@@ -13,11 +13,13 @@ def test_service_create_requires_type():
     )
     assert s.service_type == ServiceType.OTHER
     assert s.display_order is None
+    assert s.currency == "ZAR"
 
 
 def test_service_update_type_optional():
     upd = ServiceUpdate()
     assert upd.service_type is None
+    assert upd.currency == "ZAR"
 
 
 def test_service_update_accepts_display_order():


### PR DESCRIPTION
## Summary
- include `currency` field in Service model and schema
- document the new field in README
- test that quote and service responses return currency

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ad0507640832eafaad87b1a609837