### PR TITLE
Fix missing services.currency column

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The SQLite database path is automatically resolved to the project root, so you c
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible` automatically for SQLite setups, but explicit migrations are recommended for other databases.
+Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible` and `services.currency` automatically for SQLite setups, but explicit migrations are recommended for other databases.
 
 ### Service type enum
 

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -101,3 +101,14 @@ def ensure_price_visible_column(engine: Engine) -> None:
         "price_visible",
         "price_visible BOOLEAN NOT NULL DEFAULT TRUE",
     )
+
+
+def ensure_currency_column(engine: Engine) -> None:
+    """Add the ``currency`` column to ``services`` if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "services",
+        "currency",
+        "currency VARCHAR(3) NOT NULL DEFAULT 'ZAR'",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .db_utils import (
     ensure_notification_link_column,
     ensure_custom_subtitle_column,
     ensure_price_visible_column,
+    ensure_currency_column,
     ensure_request_attachment_column,
 )
 from .models.user import User
@@ -58,6 +59,7 @@ ensure_display_order_column(engine)
 ensure_notification_link_column(engine)
 ensure_custom_subtitle_column(engine)
 ensure_price_visible_column(engine)
+ensure_currency_column(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -5,6 +5,7 @@ from sqlalchemy.engine import Engine
 from app.db_utils import (
     ensure_notification_link_column,
     ensure_price_visible_column,
+    ensure_currency_column,
 )
 
 
@@ -52,9 +53,35 @@ def setup_artist_engine() -> Engine:
     return engine
 
 
+def setup_service_engine() -> Engine:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE services (
+                    id INTEGER PRIMARY KEY,
+                    artist_id INTEGER,
+                    title VARCHAR,
+                    price NUMERIC(10, 2)
+                )
+                """
+            )
+        )
+    return engine
+
+
 def test_add_price_visible_column():
     engine = setup_artist_engine()
     ensure_price_visible_column(engine)
     inspector = inspect(engine)
     column_names = [col["name"] for col in inspector.get_columns("artist_profiles")]
     assert "price_visible" in column_names
+
+
+def test_add_currency_column():
+    engine = setup_service_engine()
+    ensure_currency_column(engine)
+    inspector = inspect(engine)
+    column_names = [col["name"] for col in inspector.get_columns("services")]
+    assert "currency" in column_names


### PR DESCRIPTION
## Summary
- add `ensure_currency_column` helper
- call helper during startup
- test new helper
- document automatic migration of `services.currency`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684aee37f2d8832e9acc4b6c9055b1e6