### PR TITLE
Improve proxy guidance for npm failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,9 +671,10 @@ formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
   `npm config set https-proxy http://proxy:8080` if your environment requires a
   proxy. Without these settings you may see `ENETUNREACH` or other network
   errors when running `setup.sh` or `npm ci`.
-* **npm install failed**: `scripts/test-all.sh` prints the last npm debug log on
-  failure. Verify network access or run `scripts/docker-test.sh` to install
-  dependencies offline.
+* **npm install failed**: `scripts/test-all.sh` shows the last npm debug log on
+  failure. Verify your proxy settings or run
+  `scripts/docker-test.sh` with `DOCKER_TEST_NETWORK=bridge` to install
+  dependencies or refresh caches.
 * **Outdated Docker cache**: If `docker-test.sh` fails due to missing packages,
   update the Docker image and allow network access:
   `BOOKING_APP_BUILD=1 DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh`.

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -66,7 +66,11 @@ fi
 
 if [ -z "${BOOKING_APP_SKIP_PULL:-}" ]; then
   echo "Pulling $IMAGE"
-  docker pull "$IMAGE"
+  if ! docker pull "$IMAGE"; then
+    echo "❌ Failed to contact Docker daemon. Is it running?" >&2
+    echo "   Install or start Docker, or run ./scripts/test-all.sh directly." >&2
+    exit 1
+  fi
 else
   echo "Skipping docker pull because BOOKING_APP_SKIP_PULL is set"
 fi

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -70,7 +70,8 @@ if [ -n "$FRONTEND_CHANGES" ]; then
   if [ ! -f node_modules/.install_complete ]; then
     npm config set install-links true
     if ! npm ci --prefer-offline --no-audit --progress=false 2>npm-ci.log; then
-      echo "\n❌ npm install failed. Check network access or run ./scripts/docker-test.sh" >&2
+      echo "\n❌ npm install failed." >&2
+      echo "   Verify your proxy settings or run ./scripts/docker-test.sh with DOCKER_TEST_NETWORK=bridge" >&2
       if [ -s npm-ci.log ]; then
         echo "--- npm ci output ---" >&2
         cat npm-ci.log >&2


### PR DESCRIPTION
## Summary
- clarify proxy troubleshooting in `scripts/test-all.sh`
- document proxy check in README

## Testing
- `FORCE_TESTS=1 ./scripts/test-all.sh` *(fails: npm ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684b2be5b0a8832eb9d557e2b87d2642