### PR TITLE
Fix React prop warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Dashboard stats now animate on load using **framer-motion**.
 * Artist cards display star ratings and verified badges. Prices only appear when `price_visible` is true.
 * `<ArtistCard />` now accepts `rating`, `ratingCount`, `priceVisible`, `verified`, and `isAvailable` props so listings can show review data. Review counts are no longer displayed, but the `rating` value still renders beside a star icon. You may also pass `specialities` as an alias for `specialties`. Availability information remains in the data layer but is hidden from the UI.
+* Fixed a console warning by omitting the `isAvailable` prop from the underlying DOM element.
 * The card layout was revamped: the photo stacks above the details on mobile and sits left on larger screens. Taglines clamp to two lines using the new Tailwind `line-clamp` plugin. Pricing appears beneath the artist name when `priceVisible` is true or shows **Contact for pricing** otherwise.
 * Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
 

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -26,10 +26,13 @@ export interface ArtistCardProps extends HTMLAttributes<HTMLDivElement> {
   /** explicitly controls if price is shown */
   priceVisible?: boolean;
   verified?: boolean;
-  // isAvailable?: boolean; // reserved for future availability indicator
+  /** availability flag reserved for future indicator */
+  isAvailable?: boolean;
   href: string;
 }
 
+// ratingCount and isAvailable are currently unused but may be utilized in the future.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function ArtistCard({
   id,
   imageUrl,
@@ -40,13 +43,17 @@ export default function ArtistCard({
   specialties,
   specialities,
   rating,
-  ratingCount: _ratingCount,
+  ratingCount,
   priceVisible = true,
   verified = false,
   href,
+  isAvailable,
   className,
   ...props
 }: ArtistCardProps) {
+  // Ensure unused props don't trigger lint errors until availability features land
+  void ratingCount;
+  void isAvailable;
   const tags = specialties || specialities || [];
   const maxTagsToShow = 4;
   const limitedTags = tags.slice(0, maxTagsToShow);


### PR DESCRIPTION
## Summary
- include `isAvailable` prop in `ArtistCard` without forwarding it to the DOM
- update docs on prop usage

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b34561800832eb87ac71d3c0050eb