### PR TITLE
Update artist card tags display

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `<ArtistCard />` now accepts `rating`, `ratingCount`, `priceVisible`, `verified`, and `isAvailable` props so listings can show review data. Review counts are no longer displayed, but the `rating` value still renders beside a star icon. You may also pass `specialities` as an alias for `specialties`. Availability information remains in the data layer but is hidden from the UI.
 * Fixed a console warning by omitting the `isAvailable` prop from the underlying DOM element.
 * The card layout was revamped: the photo stacks above the details on mobile and sits left on larger screens. Taglines clamp to two lines using the new Tailwind `line-clamp` plugin. Pricing appears beneath the artist name when `priceVisible` is true or shows **Contact for pricing** otherwise.
-* Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
+* Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row and use pill badges with `text-xs px-2 py-1` styling. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
 
 ### Service Management (Artist Dashboard)
 

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -55,8 +55,10 @@ export default function ArtistCard({
   void ratingCount;
   void isAvailable;
   const tags = specialties || specialities || [];
-  const maxTagsToShow = 4;
-  const limitedTags = tags.slice(0, maxTagsToShow);
+  // Show only the first row of tags. Approximate using a fixed slice so
+  // overflowing badges don't wrap onto a second line.
+  const maxTagsFirstRow = 4;
+  const limitedTags = tags.slice(0, maxTagsFirstRow);
 
   return (
     <div
@@ -95,11 +97,11 @@ export default function ArtistCard({
         </div>
         {subtitle && <p className="text-sm text-gray-500 leading-tight mt-1 line-clamp-2">{subtitle}</p>}
         {limitedTags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2 text-xs">
+          <div className="flex flex-wrap gap-1 mt-2">
             {limitedTags.map((s) => (
               <span
                 key={`${id}-${s}`}
-                className="bg-gray-100 text-gray-700 px-2 py-1 rounded-full"
+                className="text-xs px-2 py-1 bg-gray-100 text-gray-700 rounded-full"
               >
                 {s}
               </span>

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -105,4 +105,20 @@ describe('ArtistCard optional fields', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('shows only the first row of specialty tags', () => {
+    const { container, root } = setup({
+      specialties: ['a', 'b', 'c', 'd', 'e', 'f'],
+    });
+    const tagContainer = container.querySelector('div.flex.flex-wrap');
+    const tags = tagContainer?.querySelectorAll('span');
+    expect(tags?.length).toBeLessThanOrEqual(4);
+    tags?.forEach((tag) => {
+      expect(tag.className).toContain('text-xs');
+      expect(tag.className).toContain('px-2');
+      expect(tag.className).toContain('py-1');
+    });
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- limit tags in `ArtistCard` to a single row
- test that badges slice to the first row
- document consistent pill styling for badges

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b39cce838832ea05c64945dea4266