### PR TITLE
Fix artist card tag wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Fixed a console warning by omitting the `isAvailable` prop from the underlying DOM element.
 * The card layout was revamped: the photo stacks above the details on mobile and sits left on larger screens. Taglines clamp to two lines using the new Tailwind `line-clamp` plugin. Pricing appears beneath the artist name when `priceVisible` is true or shows **Contact for pricing** otherwise.
 * Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row and use pill badges with `text-xs px-2 py-1` styling. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
+* Specialty badges now use `flex-nowrap` and `overflow-hidden` so tags remain on a single line even on small screens.
 
 ### Service Management (Artist Dashboard)
 

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -55,8 +55,9 @@ export default function ArtistCard({
   void ratingCount;
   void isAvailable;
   const tags = specialties || specialities || [];
-  // Show only the first row of tags. Approximate using a fixed slice so
-  // overflowing badges don't wrap onto a second line.
+  // Limit displayed tags so badges fit a single row. The container uses
+  // `flex-nowrap` and `overflow-hidden` to prevent wrapping, but long lists
+  // are also sliced to avoid partially hidden badges.
   const maxTagsFirstRow = 4;
   const limitedTags = tags.slice(0, maxTagsFirstRow);
 
@@ -97,7 +98,7 @@ export default function ArtistCard({
         </div>
         {subtitle && <p className="text-sm text-gray-500 leading-tight mt-1 line-clamp-2">{subtitle}</p>}
         {limitedTags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-2">
+          <div className="flex flex-nowrap overflow-hidden gap-1 mt-2 whitespace-nowrap">
             {limitedTags.map((s) => (
               <span
                 key={`${id}-${s}`}

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -110,7 +110,7 @@ describe('ArtistCard optional fields', () => {
     const { container, root } = setup({
       specialties: ['a', 'b', 'c', 'd', 'e', 'f'],
     });
-    const tagContainer = container.querySelector('div.flex.flex-wrap');
+    const tagContainer = container.querySelector('div.flex.flex-nowrap');
     const tags = tagContainer?.querySelectorAll('span');
     expect(tags?.length).toBeLessThanOrEqual(4);
     tags?.forEach((tag) => {


### PR DESCRIPTION
## Summary
- prevent specialty tags from wrapping on artist cards
- update test for new flex-nowrap behavior
- document single-line tag rule in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b3b3cfff0832e94fdd342420cf861