### PR TITLE
Remove unused filter button

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,9 +554,8 @@ returned. Newly created profiles default to `true`.
 
 The redesigned listing page features a rounded filter bar wrapped in a white
 card with a subtle shadow. Chips use `rounded-full bg-gray-100 text-gray-700
-px-3 py-1.5 text-sm` styling and highlight in indigo when selected. An optional
-**Filter** button with a funnel icon sits on the far right. The entire page now
-rests on a soft gradient background from indigo to white.
+px-3 py-1.5 text-sm` styling and highlight in indigo when selected. The entire
+page now rests on a soft gradient background from indigo to white.
 
 ### Mobile Navigation & Inbox
 

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { FunnelIcon } from '@heroicons/react/24/outline';
 import MainLayout from '@/components/layout/MainLayout';
 import { getArtists } from '@/lib/api';
 import { getFullImageUrl } from '@/lib/utils';
@@ -98,12 +97,6 @@ export default function ArtistsPage() {
             />
             Verified Only
           </label>
-          <div className="ml-auto">
-            <button type="button" className="flex items-center gap-1 text-sm font-medium text-indigo-600 hover:underline">
-              <FunnelIcon className="w-4 h-4" />
-              Filter
-            </button>
-          </div>
         </div>
         <div>
           {loading && <p>Loading...</p>}


### PR DESCRIPTION
## Summary
- remove Filter button from Artists page filter bar
- drop FunnelIcon import and update README docs

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b44ce0890832eae035b28edeb8ba6