### PR TITLE
Limit artist card tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `<ArtistCard />` now accepts `rating`, `ratingCount`, `priceVisible`, `verified`, and `isAvailable` props so listings can show review data. Review counts are no longer displayed, but the `rating` value still renders beside a star icon. You may also pass `specialities` as an alias for `specialties`. Availability information remains in the data layer but is hidden from the UI.
 * Fixed a console warning by omitting the `isAvailable` prop from the underlying DOM element.
 * The card layout was revamped: the photo stacks above the details on mobile and sits left on larger screens. Taglines clamp to two lines using the new Tailwind `line-clamp` plugin. Pricing appears beneath the artist name when `priceVisible` is true or shows **Contact for pricing** otherwise.
-* Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row and use pill badges with `text-xs px-2 py-1` styling. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
-* Specialty badges now use `flex-nowrap` and `overflow-hidden` so tags remain on a single line even on small screens. If the pills would overflow, extra badges beyond the first two are removed so the row stays visible without truncation.
+* Final polish aligns `<ArtistCard />` with the global design system. The image now stretches edge to edge with only the top corners rounded. Specialty tags truncate to a single row and use pill badges with `text-[10px] px-1.5 py-0.5` styling. Ratings show a yellow star or "No ratings yet". Prices display as `from R{price}` with no decimals. A divider separates meta info from the location and **View Profile** button.
+* Specialty badges now always show at most two tags using `flex-nowrap` and `overflow-hidden` so the row stays visible on small screens without truncation.
 
 ### Service Management (Artist Dashboard)
 

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -2,7 +2,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { HTMLAttributes } from 'react';
-import { useLayoutEffect, useRef, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import clsx from 'clsx';
 import {
   StarIcon,
@@ -59,33 +59,9 @@ export default function ArtistCard({
     () => specialties || specialities || [],
     [specialties, specialities],
   );
-  // Limit displayed tags so badges fit a single row. Up to four are shown when
-  // space allows. If the container overflows, the list is reduced to two so the
-  // row remains intact instead of disappearing entirely.
-  const maxTagsFirstRow = 4;
-  const maxTagsOverflow = 2;
-  const [visibleCount, setVisibleCount] = useState(
-    Math.min(tags.length, maxTagsFirstRow),
-  );
-
-  const tagRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    const el = tagRef.current;
-    if (!el) return;
-    const update = () => {
-      const fits = el.scrollWidth <= el.clientWidth;
-      const next = fits
-        ? Math.min(tags.length, maxTagsFirstRow)
-        : Math.min(tags.length, maxTagsOverflow);
-      setVisibleCount(next);
-    };
-    update();
-    window.addEventListener('resize', update);
-    return () => window.removeEventListener('resize', update);
-  }, [tags]);
-
-  const limitedTags = tags.slice(0, visibleCount);
+  // Display at most two tags so pills remain compact.
+  const maxTags = 2;
+  const limitedTags = tags.slice(0, maxTags);
 
   return (
     <div
@@ -125,13 +101,12 @@ export default function ArtistCard({
         {subtitle && <p className="text-sm text-gray-500 leading-tight mt-0.5 line-clamp-2">{subtitle}</p>}
         {limitedTags.length > 0 && (
           <div
-            ref={tagRef}
             className="flex flex-nowrap overflow-hidden gap-1 mt-2 whitespace-nowrap"
           >
             {limitedTags.map((s) => (
               <span
                 key={`${id}-${s}`}
-                className="text-xs px-2 py-1 bg-blue-50 text-gray-700 rounded-full"
+                className="text-[10px] px-1.5 py-0.5 bg-blue-50 text-gray-700 rounded-full"
               >
                 {s}
               </span>

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -106,35 +106,23 @@ describe('ArtistCard optional fields', () => {
     container.remove();
   });
 
-  it('shows only the first row of specialty tags', () => {
+  it('shows at most two specialty tags', () => {
     const { container, root } = setup({
       specialties: ['a', 'b', 'c', 'd', 'e', 'f'],
     });
     const tagContainer = container.querySelector('div.flex.flex-nowrap');
     const tags = tagContainer?.querySelectorAll('span');
-    expect(tags?.length).toBeLessThanOrEqual(4);
+    expect(tags?.length).toBeLessThanOrEqual(2);
     tags?.forEach((tag) => {
-      expect(tag.className).toContain('text-xs');
-      expect(tag.className).toContain('px-2');
-      expect(tag.className).toContain('py-1');
+      expect(tag.className).toContain('text-[10px]');
+      expect(tag.className).toContain('px-1.5');
+      expect(tag.className).toContain('py-0.5');
     });
     act(() => root.unmount());
     container.remove();
   });
 
-  it('limits specialty tags to two when they overflow', () => {
-    const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
-    const originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
-
-    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
-      configurable: true,
-      value: 100,
-    });
-    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
-      configurable: true,
-      value: 150,
-    });
-
+  it('always limits specialty tags to two', () => {
     const { container, root } = setup({ specialties: ['x', 'y', 'z'] });
     const tagDiv = container.querySelector('div.flex.flex-nowrap');
     expect(tagDiv).not.toBeNull();
@@ -143,12 +131,5 @@ describe('ArtistCard optional fields', () => {
 
     act(() => root.unmount());
     container.remove();
-
-    if (originalClientWidth) {
-      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
-    }
-    if (originalScrollWidth) {
-      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
-    }
   });
 });


### PR DESCRIPTION
## Summary
- keep only two specialties on artist cards
- shrink badge padding and font size on cards
- update README
- update tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b45a46944832e81fd9d497f0aef34