### PR TITLE
Add quote modal and chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Desktop bubbles expand wider to avoid unnecessary line breaks.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
+* Artists can now send itemized quotes directly in the thread via a **Send Quote** modal. Clients can accept or decline, and accepted quotes show a confirmation banner.
 * Upload progress and new message alerts are announced to screen readers.
 * Personalized Video flow: multi-step prompts, typing indicators, progress bar.
 * Sticky input demo at `/demo/sticky-input` shows local message appending.

--- a/frontend/src/components/booking/QuoteCard.tsx
+++ b/frontend/src/components/booking/QuoteCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Button from '../ui/Button';
+import { QuoteV2 } from '@/types';
+
+interface Props {
+  quote: QuoteV2;
+  isClient: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+  bookingConfirmed: boolean;
+}
+
+const QuoteCard: React.FC<Props> = ({ quote, isClient, onAccept, onDecline, bookingConfirmed }) => {
+  const statusMap: Record<string, string> = {
+    pending: 'Pending',
+    accepted: 'Accepted',
+    rejected: 'Rejected',
+    expired: 'Expired',
+  };
+  return (
+    <div className="border rounded-lg p-3 bg-gray-50 mt-2" data-testid="quote-card">
+      <h3 className="font-medium mb-1">Quote</h3>
+      <ul className="list-disc list-inside text-sm mb-1">
+        {quote.services.map((s, i) => (
+          <li key={i}>{s.description} – {Number(s.price).toFixed(2)}</li>
+        ))}
+      </ul>
+      <p className="text-sm">Sound fee: {Number(quote.sound_fee).toFixed(2)}</p>
+      <p className="text-sm">Travel fee: {Number(quote.travel_fee).toFixed(2)}</p>
+      {quote.accommodation && (
+        <p className="text-sm">Accommodation: {quote.accommodation}</p>
+      )}
+      <p className="text-sm font-medium">Subtotal: {Number(quote.subtotal).toFixed(2)}</p>
+      {quote.discount && (
+        <p className="text-sm">Discount: {Number(quote.discount).toFixed(2)}</p>
+      )}
+      <p className="font-semibold">Total: {Number(quote.total).toFixed(2)}</p>
+      {quote.expires_at && (
+        <span className="text-xs text-gray-500">Expires {new Date(quote.expires_at).toLocaleString()}</span>
+      )}
+      <div className="mt-2">
+        <span className="text-xs mr-2">Status: {statusMap[quote.status]}</span>
+        {quote.status === 'pending' && isClient && !bookingConfirmed && (
+          <>
+            <Button type="button" onClick={onAccept} className="mr-2" size="sm">Accept</Button>
+            <Button type="button" onClick={onDecline} variant="secondary" size="sm">Decline</Button>
+          </>
+        )}
+        {bookingConfirmed && <span className="ml-2 text-green-600">🎉 Booking Confirmed</span>}
+      </div>
+    </div>
+  );
+};
+
+export default QuoteCard;

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import Button from '../ui/Button';
+import { ServiceItem, QuoteV2Create } from '@/types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: QuoteV2Create) => Promise<void> | void;
+  artistId: number;
+  clientId: number;
+  bookingRequestId: number;
+}
+
+const expiryOptions = [
+  { label: '24h', value: 24 },
+  { label: '3 days', value: 72 },
+];
+
+const SendQuoteModal: React.FC<Props> = ({
+  open,
+  onClose,
+  onSubmit,
+  artistId,
+  clientId,
+  bookingRequestId,
+}) => {
+  const [services, setServices] = useState<ServiceItem[]>([
+    { description: '', price: 0 },
+  ]);
+  const [soundFee, setSoundFee] = useState(0);
+  const [travelFee, setTravelFee] = useState(0);
+  const [accommodation, setAccommodation] = useState('');
+  const [discount, setDiscount] = useState(0);
+  const [expiresHours, setExpiresHours] = useState<number | null>(null);
+
+  const subtotal = services.reduce((acc, s) => acc + Number(s.price), 0) + soundFee + travelFee;
+  const total = subtotal - (discount || 0);
+
+  const addService = () => setServices([...services, { description: '', price: 0 }]);
+  const removeService = (idx: number) =>
+    setServices(services.filter((_, i) => i !== idx));
+  const updateService = (idx: number, field: keyof ServiceItem, value: string) => {
+    const updated = services.map((s, i) => (i === idx ? { ...s, [field]: field === 'price' ? Number(value) : value } : s));
+    setServices(updated);
+  };
+
+  const handleSubmit = async () => {
+    const expires_at = expiresHours ? new Date(Date.now() + expiresHours * 3600000).toISOString() : null;
+    await onSubmit({
+      booking_request_id: bookingRequestId,
+      artist_id: artistId,
+      client_id: clientId,
+      services,
+      sound_fee: soundFee,
+      travel_fee: travelFee,
+      accommodation: accommodation || null,
+      discount: discount || null,
+      expires_at,
+    });
+  };
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-4">
+        <h2 className="text-lg font-medium mb-2">Send Quote</h2>
+        <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+          {services.map((s, i) => (
+            <div key={i} className="flex gap-2 items-center">
+              <input
+                type="text"
+                className="flex-1 border rounded p-1"
+                placeholder="Description"
+                value={s.description}
+                onChange={(e) => updateService(i, 'description', e.target.value)}
+              />
+              <input
+                type="number"
+                className="w-24 border rounded p-1"
+                placeholder="Price"
+                value={s.price}
+                onChange={(e) => updateService(i, 'price', e.target.value)}
+              />
+              {services.length > 1 && (
+                <button type="button" onClick={() => removeService(i)} aria-label="Remove item" className="text-red-600">
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+          <Button type="button" onClick={addService} className="text-sm" variant="secondary">
+            Add Item
+          </Button>
+          <input
+            type="number"
+            className="w-full border rounded p-1"
+            placeholder="Sound fee"
+            value={soundFee}
+            onChange={(e) => setSoundFee(Number(e.target.value))}
+          />
+          <input
+            type="number"
+            className="w-full border rounded p-1"
+            placeholder="Travel fee"
+            value={travelFee}
+            onChange={(e) => setTravelFee(Number(e.target.value))}
+          />
+          <textarea
+            className="w-full border rounded p-1"
+            placeholder="Accommodation (optional)"
+            value={accommodation}
+            onChange={(e) => setAccommodation(e.target.value)}
+          />
+          <input
+            type="number"
+            className="w-full border rounded p-1"
+            placeholder="Discount (optional)"
+            value={discount}
+            onChange={(e) => setDiscount(Number(e.target.value))}
+          />
+          <select
+            className="w-full border rounded p-1"
+            value={expiresHours ?? ''}
+            onChange={(e) => setExpiresHours(e.target.value ? Number(e.target.value) : null)}
+          >
+            <option value="">No expiry</option>
+            {expiryOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <div className="text-sm mt-2">
+            Subtotal: {subtotal.toFixed(2)}
+            <br />
+            Total: {total.toFixed(2)}
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit}>
+            Send
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SendQuoteModal;

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -28,7 +28,8 @@ describe('MessageThread component', () => {
 
   beforeEach(() => {
     (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
-    (api.getQuotesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+    (api.acceptQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -381,5 +382,18 @@ describe('MessageThread component', () => {
     });
     const live = container.querySelector('div.sr-only[aria-live="polite"]');
     expect(live).not.toBeNull();
+  });
+
+  it('shows send quote button for artist', async () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist' } });
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} clientId={1} artistId={2} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const buttons = container.querySelectorAll('button');
+    const found = Array.from(buttons).find((b) => b.textContent === 'Send Quote');
+    expect(found).not.toBeUndefined();
   });
 });

--- a/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
+++ b/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import QuoteCard from '../QuoteCard';
+import { act } from 'react';
+
+const quote = {
+  id: 1,
+  booking_request_id: 1,
+  artist_id: 2,
+  client_id: 1,
+  services: [{ description: 'Perf', price: 100 }],
+  sound_fee: 10,
+  travel_fee: 20,
+  accommodation: null,
+  subtotal: 130,
+  discount: null,
+  total: 130,
+  status: 'pending',
+  created_at: '',
+  updated_at: '',
+};
+
+describe('QuoteCard', () => {
+  it('renders service items and buttons', () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    act(() => {
+      root.render(
+        <QuoteCard quote={quote} isClient onAccept={() => {}} onDecline={() => {}} bookingConfirmed={false} />,
+      );
+    });
+    expect(div.textContent).toContain('Perf');
+    expect(div.textContent).toContain('130');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,6 +12,9 @@ import {
   BookingRequest,
   QuoteCreate,
   Quote,
+  QuoteV2Create,
+  QuoteV2,
+  BookingSimple,
   Message,
   MessageCreate,
   SoundProvider,
@@ -255,6 +258,15 @@ export const getQuotesForBookingRequest = (bookingRequestId: number) =>
   api.get<Quote[]>(
     `${API_V1}/booking-requests/${bookingRequestId}/quotes`
   );
+
+export const createQuoteV2 = (data: QuoteV2Create) =>
+  api.post<QuoteV2>(`${API_V1}/quotes`, data);
+
+export const getQuoteV2 = (quoteId: number) =>
+  api.get<QuoteV2>(`${API_V1}/quotes/${quoteId}`);
+
+export const acceptQuoteV2 = (quoteId: number) =>
+  api.post<BookingSimple>(`${API_V1}/quotes/${quoteId}/accept`, {});
 
 // ─── MESSAGES ───────────────────────────────────────────────────────────
 export const getMessagesForBookingRequest = (bookingRequestId: number) =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -134,6 +134,42 @@ export interface Quote {
   // artist?: User;
 }
 
+export interface ServiceItem {
+  description: string;
+  price: number;
+}
+
+export interface QuoteV2Create {
+  booking_request_id: number;
+  artist_id: number;
+  client_id: number;
+  services: ServiceItem[];
+  sound_fee: number;
+  travel_fee: number;
+  accommodation?: string | null;
+  discount?: number | null;
+  expires_at?: string | null;
+}
+
+export interface QuoteV2 extends QuoteV2Create {
+  id: number;
+  subtotal: number;
+  total: number;
+  status: 'pending' | 'accepted' | 'rejected' | 'expired';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BookingSimple {
+  id: number;
+  quote_id: number;
+  artist_id: number;
+  client_id: number;
+  confirmed: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface Message {
   id: number;
   booking_request_id: number;


### PR DESCRIPTION
## Summary
- implement SendQuoteModal and QuoteCard components
- integrate quoting flow into MessageThread
- expose new quote API helpers
- extend types for QuoteV2
- document quoting in README
- test MessageThread and QuoteCard

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b51488910832e8ba6f94939251d35