### PR TITLE
Add websocket token test and quote refresh check

### DIFF
--- a/backend/tests/test_ws_booking_requests.py
+++ b/backend/tests/test_ws_booking_requests.py
@@ -1,0 +1,68 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models.base import BaseModel
+from app.api.auth import create_access_token
+from app.api.dependencies import get_db
+from app.models import User, UserType, BookingRequest, BookingRequestStatus
+
+
+def setup_app():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    artist = User(email='artist@test.com', password='x', first_name='A', last_name='R', user_type=UserType.ARTIST)
+    client = User(email='client@test.com', password='x', first_name='C', last_name='L', user_type=UserType.CLIENT)
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+    br = BookingRequest(client_id=client.id, artist_id=artist.id, status=BookingRequestStatus.PENDING_QUOTE)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+    db.close()
+    return br, artist, client
+
+
+def test_ws_token_validation():
+    Session = setup_app()
+    br, artist, _ = create_data(Session)
+    client = TestClient(app)
+
+    token = create_access_token({"sub": artist.email})
+    with client.websocket_connect(
+        f"/api/v1/ws/booking-requests/{br.id}?token={token}"
+    ) as ws:
+        ws.send_text("ping")
+        ws.close()
+
+    bad_ws = client.websocket_connect(
+        f"/api/v1/ws/booking-requests/{br.id}?token=bad"
+    )
+    with pytest.raises(Exception):
+        bad_ws.send_text("ping")
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- ensure WebSocket token is required and invalid tokens close the connection
- add backend test for WebSocket token validation
- mock SendQuoteModal in MessageThread tests and verify message refresh after creating a quote

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bd038fd28832e8cf0b2b11ad77ee0