### PR TITLE
Fix quote route precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New quote endpoints: `POST /api/v1/quotes`, `GET /api/v1/quotes/{id}`, and
   `POST /api/v1/quotes/{id}/accept` create simplified bookings when a client
   accepts.
+* Quote V2 routes are now registered before the legacy ones so `GET /api/v1/quotes/{id}`
+  correctly returns the new format and avoids 404 errors.
 
 ### Booking Wizard
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -162,8 +162,9 @@ app.include_router(
 
 
 # ─── QUOTE ROUTES (under /api/v1) ─────────────────────────────────────────────
-app.include_router(api_quote.router, prefix=f"{api_prefix}", tags=["quotes"])
+# Register the newer v2 routes first so they take precedence when paths overlap
 app.include_router(api_quote_v2.router, prefix=f"{api_prefix}", tags=["quotes-v2"])
+app.include_router(api_quote.router, prefix=f"{api_prefix}", tags=["quotes"])
 
 # ─── MESSAGE ROUTES (under /api/v1) ─────────────────────────────────────────
 app.include_router(


### PR DESCRIPTION
## Summary
- ensure `/api/v1/quotes` v2 endpoints take priority over legacy routes
- clarify README about quote route precedence

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bd72d54b0832eadbba193c2bca7df