### PR TITLE
Log CORS origins at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Then start the API on all interfaces:
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+When the server starts it logs the resolved origins, e.g. `CORS origins set to: ['http://localhost:3000']`, so you can verify your configuration.
+
 Unhandled exceptions are returned as JSON 500 responses, so your configured CORS headers are always included.
 
 ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -98,6 +98,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+logger.info("CORS origins set to: %s", settings.CORS_ORIGINS or "*")
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- log configured CORS origins when the backend starts
- document how the log confirms CORS settings

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684be1b82cd4832e80a11622322e8e1b