### PR TITLE
Enable wildcard CORS via env

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 SQLALCHEMY_DATABASE_URL=sqlite:///./booking.db
 CORS_ORIGINS=["http://localhost:3000", "http://localhost:3002", "http://192.168.3.203:3000"]
+CORS_ALLOW_ALL=false

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
 When the server starts it logs the resolved origins, e.g. `CORS origins set to: ['http://localhost:3000']`, so you can verify your configuration.
 
+For quick local testing you can bypass specific origins entirely by setting `CORS_ALLOW_ALL=true` in `.env`. When enabled the API responds with `Access-Control-Allow-Origin: *`.
+
 Unhandled exceptions are returned as JSON 500 responses, so your configured CORS headers are always included.
 
 ---

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,5 @@
 from pydantic_settings import BaseSettings
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from typing import Any, ClassVar
 import json
 from pathlib import Path
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
 
     # CORS origins
     CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:3002"]
+    CORS_ALLOW_ALL: bool = False
 
     @field_validator("CORS_ORIGINS", mode="before")
     def split_origins(cls, v: Any) -> list[str]:
@@ -37,6 +38,13 @@ class Settings(BaseSettings):
                 pass
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
+
+
+    @model_validator(mode="after")
+    def allow_all_if_requested(cls, values: "Settings") -> "Settings":
+        if values.CORS_ALLOW_ALL:
+            values.CORS_ORIGINS = ["*"]
+        return values
 
     class Config:
         env_file = ".env"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,15 +90,16 @@ app.mount("/cover_photos", StaticFiles(directory=COVER_PHOTOS_DIR), name="cover_
 
 
 # ─── CORS middleware (adjust allow_origins if your frontend is hosted elsewhere) ─────────
-# Allow configurable origins (defaults to * for development)
+# Allow configurable origins or "*" when CORS_ALLOW_ALL is enabled
+allow_origins = ["*"] if settings.CORS_ALLOW_ALL else (settings.CORS_ORIGINS or ["*"])
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.CORS_ORIGINS or ["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
-logger.info("CORS origins set to: %s", settings.CORS_ORIGINS or "*")
+logger.info("CORS origins set to: %s", allow_origins)
 
 
 @app.middleware("http")

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,23 @@
+import os
+from importlib import reload
+
+os.environ['CORS_ALLOW_ALL'] = 'true'
+
+import app.core.config as config
+reload(config)
+from app import main as main_module
+reload(main_module)
+app = main_module.app
+
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+def test_cors_allow_all():
+    response = client.options('/', headers={
+        'Origin': 'http://foo.com',
+        'Access-Control-Request-Method': 'GET'
+    })
+    assert response.status_code == 200
+    assert response.headers.get('access-control-allow-origin') == 'http://foo.com'
+


### PR DESCRIPTION
## Summary
- add `CORS_ALLOW_ALL` setting and parser
- configure middleware to honor `CORS_ALLOW_ALL`
- document `CORS_ALLOW_ALL` usage
- add regression test for wildcard CORS

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684be6aa9e74832ea91593e682478b9e