### PR TITLE
Fix quote accepted notification link

### DIFF
--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -91,7 +91,9 @@ def accept_quote(db: Session, quote_id: int) -> models.BookingSimple:
     # Send notifications to both artist and client
     artist = db_quote.artist
     client = db_quote.client
-    notify_quote_accepted(db, artist, db_quote.id)
+    notify_quote_accepted(
+        db, artist, db_quote.id, db_quote.booking_request_id
+    )
     notify_new_booking(db, client, booking.id)
 
     return booking

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -146,7 +146,9 @@ def notify_booking_status_update(
     _send_sms(user.phone_number, message)
 
 
-def notify_quote_accepted(db: Session, user: User, quote_id: int) -> None:
+def notify_quote_accepted(
+    db: Session, user: User, quote_id: int, booking_request_id: int
+) -> None:
     """Notify a user that a quote was accepted."""
     message = format_notification_message(
         NotificationType.QUOTE_ACCEPTED,
@@ -157,7 +159,7 @@ def notify_quote_accepted(db: Session, user: User, quote_id: int) -> None:
         user_id=user.id,
         type=NotificationType.QUOTE_ACCEPTED,
         message=message,
-        link=f"/quotes/{quote_id}",
+        link=f"/booking-requests/{booking_request_id}",
     )
     logger.info("Notify %s: %s", user.email, message)
     _send_sms(user.phone_number, message)


### PR DESCRIPTION
## Summary
- route quote accepted notification to booking request instead of missing `/quotes/:id`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684bf283f02c832e9282692b4a788d31