### PR TITLE
Add quote detail page and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   accepts.
 * Quote V2 routes are now registered before the legacy ones so `GET /api/v1/quotes/{id}`
   correctly returns the new format and avoids 404 errors.
+* Quote notifications now link to `/quotes/{id}` so users can view accepted
+  quotes directly from the notification list.
 
 ### Booking Wizard
 

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -12,6 +12,7 @@ jest.mock('next/navigation', () => {
       pathname: '/',
     }),
     usePathname: () => '/',
+    useParams: jest.fn(() => ({})),
   };
 });
 

--- a/frontend/src/app/quotes/[quoteId]/page.tsx
+++ b/frontend/src/app/quotes/[quoteId]/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import QuoteCard from '@/components/booking/QuoteCard';
+import { getQuoteV2 } from '@/lib/api';
+import { QuoteV2 } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function QuoteDetailPage() {
+  const params = useParams();
+  const id = Number(params.quoteId);
+  const { user } = useAuth();
+  const [quote, setQuote] = useState<QuoteV2 | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchQuote = async () => {
+      try {
+        const res = await getQuoteV2(id);
+        setQuote(res.data);
+      } catch (err) {
+        console.error('Failed to load quote', err);
+        setError('Failed to load quote');
+      }
+    };
+    fetchQuote();
+  }, [id]);
+
+  if (!user) {
+    return (
+      <MainLayout>
+        <div className="p-8">Please log in to view this quote.</div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error}</div>
+      </MainLayout>
+    );
+  }
+
+  if (!quote) {
+    return (
+      <MainLayout>
+        <div className="flex justify-center items-center min-h-[60vh]">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  const isParticipant =
+    user.id === quote.client_id || user.id === quote.artist_id;
+  if (!isParticipant) {
+    return (
+      <MainLayout>
+        <div className="p-8">You are not authorized to view this quote.</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-md mx-auto p-4">
+        <h1 className="text-xl font-semibold mb-2">Quote #{quote.id}</h1>
+        <QuoteCard
+          quote={quote}
+          isClient={user.user_type === 'client'}
+          onAccept={() => {}}
+          onDecline={() => {}}
+          bookingConfirmed={false}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
+++ b/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import QuoteDetailPage from '../[quoteId]/page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useParams } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+
+function setup() {
+  (useParams as jest.Mock).mockReturnValue({ quoteId: '5' });
+  (useAuth as jest.Mock).mockReturnValue({
+    user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+  });
+  (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+    data: {
+      id: 5,
+      booking_request_id: 9,
+      artist_id: 2,
+      client_id: 1,
+      services: [{ description: 'Perf', price: 100 }],
+      sound_fee: 10,
+      travel_fee: 20,
+      accommodation: null,
+      subtotal: 130,
+      discount: null,
+      total: 130,
+      status: 'pending',
+      created_at: '',
+      updated_at: '',
+    },
+  });
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  const root = createRoot(div);
+  return { div, root };
+}
+
+describe('QuoteDetailPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays quote details', async () => {
+    const { div, root } = setup();
+    await act(async () => {
+      root.render(<QuoteDetailPage />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(div.textContent).toContain('Quote #5');
+    expect(div.textContent).toContain('Perf');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add `/quotes/[id]` page to display quote details
- document new link behavior for notifications
- include unit test for quote detail page
- extend jest setup to mock `useParams`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c00dc8a60832eb6ab35cd486296e0