### PR TITLE
Add artist bookings page with quote info

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * "Your Services" now appears in a collapsible section just like booking requests, keeping the dashboard tidy.
 * Removed the unused "Recent Activity" block.
 * Booking request and booking lists collapse after five items with a **Show All** toggle.
+* New `/dashboard/bookings` page lists all bookings with links to their quotes.
 * Improved dashboard stats layout with monthly earnings card.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.

--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -89,6 +89,7 @@ def create_booking(
         .options(
             selectinload(Booking.client),
             selectinload(Booking.service),
+            selectinload(Booking.source_quote),
         )
         .filter(Booking.id == db_booking.id)
         .first()
@@ -110,6 +111,7 @@ def read_my_bookings(
         .options(
             selectinload(Booking.client),
             selectinload(Booking.service),
+            selectinload(Booking.source_quote),
         )
         .filter(Booking.client_id == current_client.id)
         .order_by(Booking.start_time.desc())
@@ -132,6 +134,7 @@ def read_artist_bookings(
         .options(
             selectinload(Booking.client),
             selectinload(Booking.service),
+            selectinload(Booking.source_quote),
         )
         .filter(Booking.artist_id == current_artist.id)
         .order_by(Booking.start_time.desc())
@@ -176,6 +179,7 @@ def update_booking_status(
         .options(
             selectinload(Booking.client),
             selectinload(Booking.service),
+            selectinload(Booking.source_quote),
         )
         .filter(Booking.id == booking.id)
         .first()
@@ -199,6 +203,7 @@ def read_booking_details(
         .options(
             selectinload(Booking.client),
             selectinload(Booking.service),
+            selectinload(Booking.source_quote),
         )
         .filter(Booking.id == booking_id)
         .first()

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -6,6 +6,7 @@ from ..models.booking import BookingStatus # Enum for booking status
 from .user import UserResponse # For nesting client details
 from .artist import ArtistProfileNested # For nesting artist details (partial)
 from .service import ServiceResponse # For nesting service details
+from .request_quote import QuoteResponse
 
 # Shared properties for Booking
 class BookingBase(BaseModel):
@@ -38,8 +39,9 @@ class BookingResponse(BookingBase):
     updated_at: datetime
 
     # Include nested details for frontend dashboard
-    client: Optional[UserResponse] = None 
+    client: Optional[UserResponse] = None
     service: Optional[ServiceResponse] = None
+    source_quote: Optional[QuoteResponse] = None
     # artist: Optional[ArtistProfileNested] = None # Artist details might be useful too
     # The artist_id field (user_id of artist) is already present.
     # If full ArtistProfileResponse is needed for the artist of the booking, it can be added.
@@ -48,3 +50,4 @@ class BookingResponse(BookingBase):
     model_config = {
         "from_attributes": True
     } 
+

--- a/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import ArtistBookingsPage from '../page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard/bookings'),
+}));
+
+describe('ArtistBookingsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders bookings list with quote links', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist', email: 'a@example.com' } });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          artist_id: 2,
+          client_id: 3,
+          service_id: 4,
+          start_time: new Date().toISOString(),
+          end_time: new Date().toISOString(),
+          status: 'confirmed',
+          total_price: 200,
+          notes: '',
+          client: { first_name: 'Client', last_name: 'User' },
+          service: { title: 'Show' },
+          source_quote: { id: 5 },
+        },
+      ],
+    });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ArtistBookingsPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('View Quote');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { format } from 'date-fns';
+import MainLayout from '@/components/layout/MainLayout';
+import { useAuth } from '@/contexts/AuthContext';
+import { getMyArtistBookings } from '@/lib/api';
+import { Booking } from '@/types';
+import { formatCurrency } from '@/lib/utils';
+
+export default function ArtistBookingsPage() {
+  const { user } = useAuth();
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchBookings = async () => {
+      try {
+        const res = await getMyArtistBookings();
+        setBookings(res.data);
+      } catch (err) {
+        console.error('Failed to load bookings', err);
+        setError('Failed to load bookings');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (user.user_type === 'artist') {
+      fetchBookings();
+    } else {
+      setLoading(false);
+      setError('Access denied');
+    }
+  }, [user]);
+
+  if (!user) {
+    return (
+      <MainLayout>
+        <div className="p-8">Please log in to view your bookings.</div>
+      </MainLayout>
+    );
+  }
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <div className="flex justify-center items-center min-h-[60vh]">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error}</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-3xl mx-auto p-4 space-y-4">
+        <h1 className="text-xl font-semibold">All Bookings</h1>
+        {bookings.length === 0 ? (
+          <p>No bookings yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {bookings.map((b) => (
+              <li key={b.id} className="bg-white p-4 shadow rounded-lg">
+                <div className="font-medium text-gray-900">
+                  {b.client.first_name} {b.client.last_name}
+                </div>
+                <div className="text-sm text-gray-500">{b.service.title}</div>
+                <div className="text-sm text-gray-500">
+                  {format(new Date(b.start_time), 'MMM d, yyyy h:mm a')}
+                </div>
+                <div className="mt-2 flex justify-between items-center">
+                  <span
+                    className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                      b.status === 'completed'
+                        ? 'bg-green-100 text-green-800'
+                        : b.status === 'cancelled'
+                        ? 'bg-red-100 text-red-800'
+                        : b.status === 'confirmed'
+                        ? 'bg-blue-100 text-blue-800'
+                        : 'bg-yellow-100 text-yellow-800'
+                    }`}
+                  >
+                    {b.status}
+                  </span>
+                  <span className="text-sm text-gray-500">
+                    {formatCurrency(Number(b.total_price))}
+                  </span>
+                </div>
+                {b.source_quote && (
+                  <Link
+                    href={`/quotes/${b.source_quote.id}`}
+                    className="text-indigo-600 hover:underline text-sm mt-1 inline-block"
+                  >
+                    View Quote
+                  </Link>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -66,6 +66,7 @@ export interface Booking {
   artist: ArtistProfile;
   client: User;
   service: Service;
+  source_quote?: Quote;
 }
 
 export interface Review {


### PR DESCRIPTION
## Summary
- include source quote in BookingResponse schema and API queries
- extend Booking TypeScript interface with `source_quote`
- add `/dashboard/bookings` page listing all artist bookings with link to quotes
- document new page in README
- test new bookings page

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c04dac034832ead7ff838f0715c7f