### PR TITLE
Document docker-test.sh fallback when Docker missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,9 @@ formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
 * **Outdated Docker cache**: If `docker-test.sh` fails due to missing packages,
   update the Docker image and allow network access:
   `BOOKING_APP_BUILD=1 DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh`.
+* **Docker command not found**: The test helper falls back to host tests when
+  `docker` is missing or the daemon isn't running. Install Docker and start the
+  service to run tests in the container.
 * Running `./scripts/test-all.sh` (or `./setup.sh` first) installs dependencies and
   prints the path to the Jest binary if it is missing.
 * Use `scripts/docker-test.sh` when you need to run the tests completely offline


### PR DESCRIPTION
## Summary
- clarify in README that `docker-test.sh` falls back to host tests when Docker isn't installed
- mention that Docker needs to be installed and running to use the container

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c0c003824832eb2198a8a51fcf6e4