### PR TITLE
Expose accepted quotes on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking request and booking lists collapse after five items with a **Show All** toggle.
 * New `/dashboard/bookings` page lists all bookings with links to their quotes.
 * The dashboard Bookings tab now includes a **View All Bookings** link.
+* Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
 * Improved dashboard stats layout with monthly earnings card.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.

--- a/backend/app/crud/crud_booking_request.py
+++ b/backend/app/crud/crud_booking_request.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from typing import List, Optional
 
 from .. import models
@@ -23,11 +23,17 @@ def create_booking_request(
     return db_booking_request
 
 def get_booking_request(db: Session, request_id: int) -> Optional[models.BookingRequest]:
-    return db.query(models.BookingRequest).filter(models.BookingRequest.id == request_id).first()
+    return (
+        db.query(models.BookingRequest)
+        .options(joinedload(models.BookingRequest.quotes))
+        .filter(models.BookingRequest.id == request_id)
+        .first()
+    )
 
 def get_booking_requests_by_client(db: Session, client_id: int, skip: int = 0, limit: int = 100) -> List[models.BookingRequest]:
     return (
         db.query(models.BookingRequest)
+        .options(joinedload(models.BookingRequest.quotes))
         .filter(models.BookingRequest.client_id == client_id)
         .order_by(models.BookingRequest.created_at.desc())
         .offset(skip)
@@ -38,6 +44,7 @@ def get_booking_requests_by_client(db: Session, client_id: int, skip: int = 0, l
 def get_booking_requests_by_artist(db: Session, artist_id: int, skip: int = 0, limit: int = 100) -> List[models.BookingRequest]:
     return (
         db.query(models.BookingRequest)
+        .options(joinedload(models.BookingRequest.quotes))
         .filter(models.BookingRequest.artist_id == artist_id)
         .order_by(models.BookingRequest.created_at.desc())
         .offset(skip)

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -43,7 +43,8 @@ class BookingRequestResponse(BookingRequestBase):
     client: Optional[UserResponse] = None
     artist: Optional[UserResponse] = None # Artist's UserResponse
     service: Optional[ServiceResponse] = None
-    # quotes: List['QuoteResponse'] = [] # Forward reference for QuoteResponse
+    quotes: List['QuoteResponse'] = []
+    accepted_quote_id: Optional[int] = None
 
     model_config = {
         "from_attributes": True

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -419,3 +419,42 @@ describe('DashboardPage bookings link', () => {
     container.remove();
   });
 });
+
+describe('DashboardPage accepted quote label', () => {
+  it('shows quote accepted link when a request has an accepted quote', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
+    (api.getMyClientBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getMyBookingRequests as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          client_id: 1,
+          artist_id: 2,
+          status: 'pending_artist_confirmation',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          accepted_quote_id: 42,
+          quotes: [],
+          artist: { first_name: 'A', last_name: 'B' },
+        },
+      ],
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const link = container.querySelector('a[href="/quotes/42"]');
+    expect(link).toBeTruthy();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -424,6 +424,14 @@ export default function DashboardPage() {
                   >
                     View Chat
                   </Link>
+                  {req.accepted_quote_id && (
+                    <Link
+                      href={`/quotes/${req.accepted_quote_id}`}
+                      className="ml-4 mt-2 inline-block text-green-600 hover:underline text-sm"
+                    >
+                      Quote accepted
+                    </Link>
+                  )}
                 </div>
               )}
             />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -108,7 +108,8 @@ export interface BookingRequest {
   client?: User;
   artist?: User;
   service?: Service;
-  // quotes?: Quote[];
+  quotes?: Quote[];
+  accepted_quote_id?: number | null;
 }
 
 // If you need to handle Quotes (e.g. when the artist replies):


### PR DESCRIPTION
## Summary
- load quotes when fetching booking requests
- include `quotes` and `accepted_quote_id` in booking request schema
- expose accepted quote info via booking request API
- show "Quote accepted" link in dashboard when applicable
- test dashboard rendering of accepted quote label
- document new dashboard behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c0f73cdf0832eb53e5f3d8c5b17ef