### PR TITLE
Fix cyclic reference in booking request serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   correctly returns the new format and avoids 404 errors.
 * Quote notifications now link to `/quotes/{id}` so users can view accepted
   quotes directly from the notification list.
+* Quote API responses omit the nested `booking_request` field to avoid
+  circular references.
 
 ### Booking Wizard
 

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -103,6 +103,8 @@ def read_my_client_booking_requests(
         db=db, client_id=current_user.id, skip=skip, limit=limit
     )
     for req in requests:
+        for q in req.quotes:
+            q.booking_request = None
         accepted = next(
             (
                 q
@@ -132,6 +134,8 @@ def read_my_artist_booking_requests(
         db=db, artist_id=current_artist.id, skip=skip, limit=limit
     )
     for req in requests:
+        for q in req.quotes:
+            q.booking_request = None
         accepted = next(
             (
                 q
@@ -166,6 +170,8 @@ def read_booking_request(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Booking request not found")
     if not (db_request.client_id == current_user.id or db_request.artist_id == current_user.id):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this request")
+    for q in db_request.quotes:
+        q.booking_request = None
     accepted = next(
         (
             q

--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -112,6 +112,7 @@ def read_quote(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to access this quote",
         )
+    db_quote.booking_request = None
     return db_quote
 
 
@@ -150,10 +151,12 @@ def read_quotes_for_booking_request(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to access quotes for this request",
         )
-
-    return crud.crud_quote.get_quotes_by_booking_request(
+    quotes = crud.crud_quote.get_quotes_by_booking_request(
         db, booking_request_id=request_id
     )
+    for q in quotes:
+        q.booking_request = None
+    return quotes
 
 
 @router.get("/quotes/me/artist", response_model=List[schemas.QuoteResponse])
@@ -166,9 +169,12 @@ def read_my_artist_quotes(
     """
     Retrieve all quotes made by the current artist.
     """
-    return crud.crud_quote.get_quotes_by_artist(
+    quotes = crud.crud_quote.get_quotes_by_artist(
         db=db, artist_id=current_artist.id, skip=skip, limit=limit
     )
+    for q in quotes:
+        q.booking_request = None
+    return quotes
 
 
 @router.put("/quotes/{quote_id}/client", response_model=schemas.QuoteResponse)

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -79,8 +79,12 @@ class QuoteResponse(QuoteBase):
     created_at: datetime
     updated_at: Optional[datetime] = None
     
-    artist: Optional[UserResponse] = None # Artist's UserResponse
-    booking_request: Optional[BookingRequestResponse] = None # Optional: The request this quote is for
+    artist: Optional[UserResponse] = None  # Artist details
+    # Exclude booking_request to avoid recursion when nested under
+    # BookingRequestResponse -> QuoteResponse -> BookingRequestResponse
+    booking_request: Optional[BookingRequestResponse] = Field(
+        default=None, exclude=True
+    )
     # booking: Optional[BookingResponse] = None # Optional: If a booking was created from this quote
 
     model_config = {

--- a/backend/tests/test_booking_request_recursion.py
+++ b/backend/tests/test_booking_request_recursion.py
@@ -1,0 +1,57 @@
+import decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import (
+    User,
+    UserType,
+    BookingRequest,
+    BookingRequestStatus,
+    Quote,
+)
+from app.models.base import BaseModel
+from app.api import api_booking_request
+from app.schemas import BookingRequestResponse
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_artist_booking_requests_no_recursion():
+    db = setup_db()
+    artist = User(email="a@test.com", password="x", first_name="A", last_name="R", user_type=UserType.ARTIST)
+    client = User(email="c@test.com", password="x", first_name="C", last_name="L", user_type=UserType.CLIENT)
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id, status=BookingRequestStatus.PENDING_QUOTE)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = Quote(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        quote_details="details",
+        price=decimal.Decimal("10.00"),
+        currency="ZAR",
+    )
+    br.quotes.append(quote)
+    db.add(quote)
+    db.commit()
+    db.refresh(br)
+    db.refresh(quote)
+
+    result = api_booking_request.read_my_artist_booking_requests(db=db, current_artist=artist)
+    assert result
+    # Should serialize without recursion errors
+    model = BookingRequestResponse.model_validate(result[0])
+    dumped = model.model_dump()
+    if dumped["quotes"]:
+        assert "booking_request" not in dumped["quotes"][0]


### PR DESCRIPTION
## Summary
- avoid recursion errors by excluding `booking_request` from QuoteResponse
- strip circular refs when listing or retrieving booking requests and quotes
- clarify quote API change in README
- add regression test for booking request recursion

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c12910d7c832e938ca096560beec3