### PR TITLE
Fix dashboard booking requests list

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
 * "Your Services" now appears in a collapsible section just like booking requests, keeping the dashboard tidy.
 * Removed the unused "Recent Activity" block.
-* Booking request and booking lists collapse after five items with a **Show All** toggle.
+* Booking request and booking lists show the five most recent items with a **View All** link to see the full history.
 * New `/dashboard/bookings` page lists all bookings with links to their quotes.
 * The dashboard Bookings tab now includes a **View All Bookings** link.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -420,6 +420,51 @@ describe('DashboardPage bookings link', () => {
   });
 });
 
+describe('DashboardPage booking requests link', () => {
+  it('shows link to all requests when more than five exist', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist', email: 'a@example.com' } });
+    const requests = Array.from({ length: 6 }).map((_, i) => ({
+      id: i,
+      client_id: 3,
+      artist_id: 2,
+      status: 'pending_artist_confirmation',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      quotes: [],
+      client: { first_name: 'C', last_name: String(i) },
+      artist: { first_name: 'A', last_name: 'B' },
+    }));
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: requests });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    const requestsTab = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Requests'
+    ) as HTMLButtonElement;
+    if (requestsTab) {
+      await act(async () => {
+        requestsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      await act(async () => { await Promise.resolve(); });
+    }
+    const link = container.querySelector('a[href="/booking-requests"]');
+    expect(link).toBeTruthy();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
 describe('DashboardPage accepted quote label', () => {
   it('shows quote accepted link when a request has an accepted quote', async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -397,44 +397,56 @@ export default function DashboardPage() {
           </div>
 
           {activeTab === 'requests' && (
-            <SectionList
-              title="Booking Requests"
-              data={visibleRequests}
-              defaultOpen={false}
-              emptyState={<span>No bookings yet</span>}
-              renderItem={(req) => (
-                <div key={req.id} className="bg-white p-4 shadow rounded-lg">
-                  <div className="font-medium text-gray-900">
-                    {user.user_type === 'artist'
-                      ? `${req.client?.first_name} ${req.client?.last_name}`
-                      :
-                          req.artist?.business_name ||
-                          `${req.artist?.first_name} ${req.artist?.last_name}`}
-                  </div>
-                  <div className="text-sm text-gray-500">
-                    {req.service?.title || '—'}
-                  </div>
-                  <div className="mt-2 flex justify-between text-sm text-gray-500">
-                    <span>{req.status}</span>
-                    <span>{new Date(req.created_at).toLocaleDateString()}</span>
-                  </div>
-                  <Link
-                    href={`/booking-requests/${req.id}`}
-                    className="mt-2 inline-block text-indigo-600 hover:underline text-sm"
-                  >
-                    View Chat
-                  </Link>
-                  {req.accepted_quote_id && (
+            <>
+              <SectionList
+                title="Booking Requests"
+                data={visibleRequests}
+                defaultOpen={false}
+                emptyState={<span>No bookings yet</span>}
+                renderItem={(req) => (
+                  <div key={req.id} className="bg-white p-4 shadow rounded-lg">
+                    <div className="font-medium text-gray-900">
+                      {user.user_type === 'artist'
+                        ? `${req.client?.first_name} ${req.client?.last_name}`
+                        :
+                            req.artist?.business_name ||
+                            `${req.artist?.first_name} ${req.artist?.last_name}`}
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      {req.service?.title || '—'}
+                    </div>
+                    <div className="mt-2 flex justify-between text-sm text-gray-500">
+                      <span>{req.status}</span>
+                      <span>{new Date(req.created_at).toLocaleDateString()}</span>
+                    </div>
                     <Link
-                      href={`/quotes/${req.accepted_quote_id}`}
-                      className="ml-4 mt-2 inline-block text-green-600 hover:underline text-sm"
+                      href={`/booking-requests/${req.id}`}
+                      className="mt-2 inline-block text-indigo-600 hover:underline text-sm"
                     >
-                      Quote accepted
+                      View Chat
                     </Link>
-                  )}
+                    {req.accepted_quote_id && (
+                      <Link
+                        href={`/quotes/${req.accepted_quote_id}`}
+                        className="ml-4 mt-2 inline-block text-green-600 hover:underline text-sm"
+                      >
+                        Quote accepted
+                      </Link>
+                    )}
+                  </div>
+                )}
+              />
+              {bookingRequests.length > visibleRequests.length && (
+                <div className="mt-2">
+                  <Link
+                    href="/booking-requests"
+                    className="text-indigo-600 hover:underline text-sm"
+                  >
+                    View All Requests
+                  </Link>
                 </div>
               )}
-            />
+            </>
           )}
 
           {activeTab === 'bookings' && (


### PR DESCRIPTION
## Summary
- show a link to view all booking requests when more than five exist
- test the requests link
- update docs to describe new dashboard links

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c15cbdfc8832e8966b522f5bd067f