### PR TITLE
Fix View All Requests link placement

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -435,17 +435,14 @@ export default function DashboardPage() {
                     )}
                   </div>
                 )}
+                footer={
+                  bookingRequests.length > visibleRequests.length ? (
+                    <Link href="/booking-requests" className="text-indigo-600 hover:underline text-sm">
+                      View All Requests
+                    </Link>
+                  ) : null
+                }
               />
-              {bookingRequests.length > visibleRequests.length && (
-                <div className="mt-2">
-                  <Link
-                    href="/booking-requests"
-                    className="text-indigo-600 hover:underline text-sm"
-                  >
-                    View All Requests
-                  </Link>
-                </div>
-              )}
             </>
           )}
 

--- a/frontend/src/components/dashboard/SectionList.tsx
+++ b/frontend/src/components/dashboard/SectionList.tsx
@@ -8,6 +8,7 @@ interface SectionListProps<T> {
   renderItem: (item: T) => React.ReactNode;
   emptyState: React.ReactNode;
   defaultOpen?: boolean;
+  footer?: React.ReactNode;
 }
 
 export default function SectionList<T>({
@@ -16,6 +17,7 @@ export default function SectionList<T>({
   renderItem,
   emptyState,
   defaultOpen = false,
+  footer,
 }: SectionListProps<T>) {
   const isOpen = defaultOpen && data.length > 0;
   return (
@@ -33,6 +35,7 @@ export default function SectionList<T>({
             ))}
           </ul>
         )}
+        {footer && <div className="mt-2">{footer}</div>}
       </div>
     </details>
   );

--- a/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/SectionList.test.tsx
@@ -33,4 +33,19 @@ describe('SectionList', () => {
     });
     expect(container.textContent).toContain('Empty');
   });
+
+  it('renders footer when provided', () => {
+    act(() => {
+      root.render(
+        React.createElement(SectionList, {
+          title: 'Test',
+          data: [1],
+          emptyState: React.createElement('span', null, 'Empty'),
+          renderItem: () => React.createElement('div', null, 'item'),
+          footer: React.createElement('span', null, 'Footer'),
+        })
+      );
+    });
+    expect(container.textContent).toContain('Footer');
+  });
 });


### PR DESCRIPTION
## Summary
- add optional footer slot to `SectionList`
- show View All Requests link as SectionList footer
- test the new footer rendering

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c17b6f82c832e92649831c16e7e8e