### PR TITLE
Add empty state and clear filters to artists page

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,10 @@ returned. Newly created profiles default to `true`.
 The redesigned listing page features a rounded filter bar wrapped in a white
 card with a subtle shadow. Chips use `rounded-full bg-gray-100 text-gray-700
 px-3 py-1.5 text-sm` styling and highlight in indigo when selected. The entire
-page now rests on a soft gradient background from indigo to white.
+page now rests on a soft gradient background from indigo to white. A new
+"Clear filters" button appears when any filter is active and resets all filter
+inputs. When no results match the current filters the page shows "No artists
+found" beneath the filter bar.
 
 ### Mobile Navigation & Inbox
 

--- a/frontend/src/app/artists/__tests__/page.test.tsx
+++ b/frontend/src/app/artists/__tests__/page.test.tsx
@@ -117,4 +117,45 @@ describe('Artists page filters', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('shows message when no artists found', async () => {
+    jest.spyOn(api, 'getArtists').mockResolvedValue({ data: [] });
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(ArtistsPage));
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('No artists found');
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('clears all filters', async () => {
+    const spy = jest.spyOn(api, 'getArtists').mockResolvedValue({ data: [] });
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(ArtistsPage));
+      await Promise.resolve();
+    });
+    const locationInput = container.querySelector('input[placeholder="Location"]') as HTMLInputElement;
+    const sortSelect = container.querySelector('select') as HTMLSelectElement;
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await act(async () => {
+      locationInput.value = 'NY';
+      locationInput.dispatchEvent(new Event('input', { bubbles: true }));
+      sortSelect.value = 'newest';
+      sortSelect.dispatchEvent(new Event('change', { bubbles: true }));
+      checkbox.click();
+      await Promise.resolve();
+    });
+    const button = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Clear filters') as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+    expect(spy).toHaveBeenLastCalledWith({ category: undefined, location: undefined, sort: undefined });
+    act(() => root.unmount());
+    container.remove();
+  });
 });

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -23,6 +23,16 @@ export default function ArtistsPage() {
   const [sort, setSort] = useState<string | undefined>();
   const [verifiedOnly, setVerifiedOnly] = useState(false);
 
+  const clearFilters = () => {
+    setCategory(undefined);
+    setLocation('');
+    setSort(undefined);
+    setVerifiedOnly(false);
+  };
+
+  const filtersActive =
+    Boolean(category) || Boolean(location) || Boolean(sort) || verifiedOnly;
+
   const fetchArtists = async (params?: { category?: string; location?: string; sort?: string }) => {
     try {
       const res = await getArtists(params);
@@ -97,10 +107,22 @@ export default function ArtistsPage() {
             />
             Verified Only
           </label>
+          {filtersActive && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="text-sm text-blue-600 hover:underline ml-auto"
+            >
+              Clear filters
+            </button>
+          )}
         </div>
         <div>
           {loading && <p>Loading...</p>}
           {error && <p className="text-red-600">{error}</p>}
+          {!loading && artists.length === 0 && !error && (
+            <p>No artists found</p>
+          )}
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             {artists.map((a) => {
               const user = (a as Partial<typeof a>).user as ArtistProfile['user'] | null | undefined;


### PR DESCRIPTION
## Summary
- show a "No artists found" message when artist search returns empty results
- add a clear filters button to reset all listing filters
- document new listing behavior
- test the empty state and clear filters functionality

## Testing
- `./scripts/test-all.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68504f4e3c08832ea034acfbea412175