### PR TITLE
Add guests requirement to booking flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` in `bookings_simple`.
+- Booking wizard includes a required **Guests** step.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -22,6 +22,7 @@ import { useBooking, EventDetails } from '@/contexts/BookingContext';
 import useBookingForm from '@/hooks/useBookingForm';
 import DateTimeStep from './steps/DateTimeStep';
 import LocationStep from './steps/LocationStep';
+import GuestsStep from './steps/GuestsStep';
 import SoundStep from './steps/SoundStep';
 import VenueStep from './steps/VenueStep';
 import NotesStep from './steps/NotesStep';
@@ -30,6 +31,7 @@ import ReviewStep from './steps/ReviewStep';
 const steps = [
   'Date & Time',
   'Location',
+  'Guests',
   'Venue Type',
   'Sound',
   'Notes',
@@ -39,6 +41,10 @@ const steps = [
 const schema = yup.object({
   date: yup.date().required().min(new Date(), 'Pick a future date'),
   location: yup.string().required('Location is required'),
+  guests: yup
+    .string()
+    .required('Number of guests is required')
+    .matches(/^\d+$/, 'Guests must be a number'),
   venueType: yup
     .mixed<'indoor' | 'outdoor' | 'hybrid'>()
     .oneOf(['indoor', 'outdoor', 'hybrid'])
@@ -121,9 +127,12 @@ export default function BookingWizard({
         fields = ['location'];
         break;
       case 2:
-        fields = ['venueType'];
+        fields = ['guests'];
         break;
       case 3:
+        fields = ['venueType'];
+        break;
+      case 4:
         fields = ['sound'];
         break;
       default:
@@ -186,6 +195,7 @@ export default function BookingWizard({
       const detailLines = [
         `Date: ${format(vals.date, 'yyyy-MM-dd')}`,
         `Location: ${vals.location}`,
+        `Guests: ${vals.guests}`,
         `Sound: ${vals.sound}`,
         `Venue Type: ${vals.venueType}`,
         vals.notes ? `Notes: ${vals.notes}` : null,
@@ -232,7 +242,7 @@ export default function BookingWizard({
         );
       case 2:
         return (
-          <VenueStep
+          <GuestsStep
             control={control as unknown as Control<FieldValues>}
             step={step}
             steps={steps}
@@ -243,7 +253,7 @@ export default function BookingWizard({
         );
       case 3:
         return (
-          <SoundStep
+          <VenueStep
             control={control as unknown as Control<FieldValues>}
             step={step}
             steps={steps}
@@ -253,6 +263,17 @@ export default function BookingWizard({
           />
         );
       case 4:
+        return (
+          <SoundStep
+            control={control as unknown as Control<FieldValues>}
+            step={step}
+            steps={steps}
+            onBack={prev}
+            onSaveDraft={saveDraft}
+            onNext={next}
+          />
+        );
+      case 5:
         return (
           <NotesStep
             control={control as unknown as Control<FieldValues>}

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -82,7 +82,7 @@ describe('BookingWizard flow', () => {
     expect(container.querySelector('h2')?.textContent).toContain('Date & Time');
     expect(container.textContent).not.toContain('Summary');
     const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
-    await act(async () => { setStep(5); });
+    await act(async () => { setStep(6); });
     await new Promise((r) => setTimeout(r, 400));
     expect(container.querySelector('h2')?.textContent).toContain('Review');
     expect(container.textContent).toContain('Summary');

--- a/frontend/src/components/booking/__tests__/SummarySidebar.test.tsx
+++ b/frontend/src/components/booking/__tests__/SummarySidebar.test.tsx
@@ -30,6 +30,7 @@ describe('SummarySidebar', () => {
         date: new Date('2024-01-02T00:00:00Z'),
         time: '10am',
         location: '',
+        guests: '20',
         venueType: 'indoor',
         sound: 'yes',
       },
@@ -46,6 +47,7 @@ describe('SummarySidebar', () => {
         date: '2024-05-03',
         time: '9pm',
         location: '',
+        guests: '50',
         venueType: 'indoor',
         sound: 'yes',
       },
@@ -54,5 +56,6 @@ describe('SummarySidebar', () => {
       root.render(<SummarySidebar />);
     });
     expect(container.textContent).toContain('May 3, 2024');
+    expect(container.textContent).toContain('50');
   });
 });

--- a/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
@@ -1,0 +1,38 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import { useForm, Control, FieldValues } from 'react-hook-form';
+import GuestsStep from '../GuestsStep';
+
+function Wrapper() {
+  const { control } = useForm({ defaultValues: { guests: '' } });
+  return (
+    <GuestsStep control={control as unknown as Control<FieldValues>} />
+  );
+}
+
+describe('GuestsStep input', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('renders number input', () => {
+    act(() => {
+      root.render(React.createElement(Wrapper));
+    });
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
+  });
+});

--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useState, ReactNode } from 'react';
 export interface EventDetails {
   date: Date;
   location: string;
+  guests: string;
   venueType: 'indoor' | 'outdoor' | 'hybrid';
   sound: 'yes' | 'no';
   notes?: string;
@@ -27,6 +28,7 @@ export const BookingProvider = ({ children }: { children: ReactNode }) => {
   const [details, setDetails] = useState<EventDetails>({
     date: new Date(),
     location: '',
+    guests: '',
     venueType: 'indoor',
     sound: 'yes',
     attachment_url: '',


### PR DESCRIPTION
## Summary
- add guest field to booking context
- validate guest count and insert Guests step in BookingWizard
- include guests in booking summary message
- document new Guests step
- update unit tests and add GuestsStep tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685051589ee4832e8872573a9bcaf7e0