### PR TITLE
Handle return path in auth redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ fail.
 `useIsMobile` also initializes to `false` and updates on mount so mobile devices
 avoid hydration errors when rendering responsive components.
 
+Protected pages redirect unauthenticated visitors to `/login?next=<path>`. After
+sign in or sign up, the app automatically returns to the original URL.
+
 API responses are now handled by a global interceptor which maps common HTTP
 status codes to human-friendly error messages and logs server errors to the
 console. Hooks and components no longer need to parse Axios errors manually.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import MainLayout from "@/components/layout/MainLayout";
 import { useAuth } from "@/contexts/AuthContext";
 import { Booking, Service, ArtistProfile, BookingRequest } from "@/types";
@@ -146,6 +146,7 @@ function ServiceCard({
 export default function DashboardPage() {
   const { user } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [services, setServices] = useState<Service[]>([]);
   const [artistProfile, setArtistProfile] = useState<ArtistProfile | null>(
@@ -180,7 +181,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (!user) {
-      router.push("/login");
+      router.push(`/login?next=${encodeURIComponent(pathname)}`);
       return;
     }
 
@@ -223,7 +224,7 @@ export default function DashboardPage() {
     };
 
     fetchDashboardData();
-  }, [user, router]);
+  }, [user, router, pathname]);
 
   const handleServiceAdded = (newService: Service) => {
     const processedService = normalizeService(newService);

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import NextImage from 'next/image';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MobileSaveBar from '@/components/dashboard/MobileSaveBar';
 import { useAuth } from '@/contexts/AuthContext';
@@ -109,6 +109,7 @@ async function getCroppedImg(
 export default function EditArtistProfilePage(): JSX.Element {
   const { user, loading: authLoading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
 
   // Fetched profile
   const [profile, setProfile] = useState<Partial<ArtistProfile>>({});
@@ -149,7 +150,7 @@ export default function EditArtistProfilePage(): JSX.Element {
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
-      router.push('/login');
+      router.push(`/login?next=${encodeURIComponent(pathname)}`);
       return;
     }
     if (user.user_type !== 'artist') {
@@ -193,7 +194,7 @@ export default function EditArtistProfilePage(): JSX.Element {
     };
 
     fetchProfile();
-  }, [user, authLoading, router]);
+  }, [user, authLoading, router, pathname]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/app/login/__tests__/LoginPage.test.tsx
+++ b/frontend/src/app/login/__tests__/LoginPage.test.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { act } from 'react';
 import LoginPage from '../page';
 import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
   usePathname: jest.fn(() => '/login'),
 }));
 
@@ -19,6 +20,7 @@ describe('LoginPage remember me option', () => {
   it('renders a remember me checkbox with label', async () => {
     (useAuth as jest.Mock).mockReturnValue({ login: jest.fn() });
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useSearchParams as jest.Mock).mockReturnValue({ get: () => null });
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -7,7 +7,7 @@
 
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
@@ -24,6 +24,8 @@ interface LoginForm {
 export default function LoginPage() {
   const { login } = useAuth();
   const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next');
   const [error, setError] = useState('');
   const {
     register,
@@ -34,7 +36,7 @@ export default function LoginPage() {
   const onSubmit = async (data: LoginForm) => {
     try {
       await login(data.email, data.password, data.remember);
-      router.push('/dashboard');
+      router.push(next || '/dashboard');
     } catch (err) {
       setError('Invalid email or password');
     }
@@ -125,7 +127,10 @@ export default function LoginPage() {
 
           <p className="mt-10 text-center text-sm text-gray-500">
             Not a member?{' '}
-            <Link href="/register" className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">
+            <Link
+              href={`/register${next ? `?next=${encodeURIComponent(next)}` : ''}`}
+              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
+            >
               Sign up now
             </Link>
           </p>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
@@ -20,6 +20,8 @@ interface RegisterForm extends Omit<User, 'id' | 'is_active' | 'is_verified'> {
 export default function RegisterPage() {
   const { register: registerUser } = useAuth();
   const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next');
   const [error, setError] = useState('');
   const { register, handleSubmit, watch, formState: { errors, isSubmitting } } = useForm<RegisterForm>();
 
@@ -40,7 +42,7 @@ export default function RegisterPage() {
       void confirmPassword;
       await registerUser(userData);
       toast.success('Registration successful! Please log in.');
-      router.push('/login');
+      router.push(`/login${next ? `?next=${encodeURIComponent(next)}` : ''}`);
     } catch (err: unknown) {
       console.error('Registration error:', err);
       const message =
@@ -194,7 +196,10 @@ export default function RegisterPage() {
 
           <p className="mt-10 text-center text-sm text-gray-500">
             Already have an account?{' '}
-            <Link href="/login" className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">
+            <Link
+              href={`/login${next ? `?next=${encodeURIComponent(next)}` : ''}`}
+              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
+            >
               Sign in
             </Link>
           </p>


### PR DESCRIPTION
## Summary
- preserve path when redirecting unauthenticated users to `/login`
- respect `next` parameter on login and registration pages
- test login page with mocked `useSearchParams`
- document new redirect behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850532ecb9c832e8ec3162f69185d8c