### PR TITLE
Improve booking wizard guest step

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New **Review** step showing cost breakdown and selections.
 * Success toasts when saving a draft or submitting a request.
 * Simplified buttons sit below each step in a responsive button group.
+* Guests step now matches the others with Back, Save Draft, and Next buttons.
 * Attachment uploads in the notes step display a progress bar and disable the Next button until finished.
 * Collapsible sections for date/time and notes keep steps short on phones.
 * Mobile devices use native date and time pickers for faster input.

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -5,12 +5,24 @@ import useIsMobile from '@/hooks/useIsMobile';
 
 interface Props {
   control: Control<FieldValues>;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
 }
 
-export default function GuestsStep({ control }: Props) {
+export default function GuestsStep({
+  control,
+  step,
+  steps,
+  onBack,
+  onSaveDraft,
+  onNext,
+}: Props) {
   const isMobile = useIsMobile();
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       <label className="block text-sm font-medium">Number of guests</label>
       <p className="text-sm text-gray-600">How many people?</p>
       <Controller
@@ -27,6 +39,34 @@ export default function GuestsStep({ control }: Props) {
         )}
       />
       <p className="text-xs text-gray-600">Max capacity is 200 guests.</p>
+      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
+        {step > 0 && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Back
+          </button>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+          >
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+          >
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
@@ -4,10 +4,17 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import GuestsStep from '../GuestsStep';
 
-function Wrapper() {
+function Wrapper({ onNext = () => {} }: { onNext?: () => void }) {
   const { control } = useForm({ defaultValues: { guests: '' } });
   return (
-    <GuestsStep control={control as unknown as Control<FieldValues>} />
+    <GuestsStep
+      control={control as unknown as Control<FieldValues>}
+      step={2}
+      steps={['one', 'two', 'three']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={onNext}
+    />
   );
 }
 
@@ -34,5 +41,19 @@ describe('GuestsStep input', () => {
     });
     const input = container.querySelector('input[type="number"]') as HTMLInputElement;
     expect(input).not.toBeNull();
+  });
+
+  it('calls onNext when Next clicked', () => {
+    const nextSpy = jest.fn();
+    act(() => {
+      root.render(React.createElement(Wrapper, { onNext: nextSpy }));
+    });
+    const nextButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Next') || b.textContent?.includes('Submit'),
+    ) as HTMLButtonElement;
+    act(() => {
+      nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(nextSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- enhance Guests step in BookingWizard with Back, Save Draft and Next buttons
- adjust Guests step test for new props and behaviour
- document guest step buttons in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851107c3000832ebc83e5defef22669