### PR TITLE
Improve npm network guidance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y curl gnupg ca-certificates \
     libxshmfence1 libdbus-1-3 libxss1 libxtst6 \
     && curl -fsSL https://deb.nodesource.com/setup_21.x | bash - \
     && apt-get update \
+    # Use `docker build --network bridge` if npm fails to reach registry.npmjs.org
     && apt-get install -y nodejs \
     && npm config set fetch-retry-mintimeout 20000 \
     && npm config set registry https://registry.npmjs.org \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ rebuild whenever dependencies change. If you hit network errors during
 or running `docker build`/`docker run` with `--network bridge` so npm can
 reach the registry.
 
+Even with Docker network access, corporate proxies or partial restrictions may
+still block requests to `registry.npmjs.org`. If `npm ci` fails with
+`ECONNRESET` or `ENETUNREACH`, configure your proxy and rerun with network
+bridge enabled:
+
+```bash
+npm config set proxy http://proxy:8080
+npm config set https-proxy http://proxy:8080
+DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh
+```
+
 ### docker-test.sh quickstart
 
 1. **Populate caches with network access**
@@ -698,11 +709,12 @@ formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
 * **next: not found / ENOTEMPTY**: Reinstall in `frontend/` with `npm install` or `./setup.sh`.
 * **Module not found: Can't resolve 'framer-motion'**: Run `npm install` in `frontend/` to pull the latest dependencies.
 * **Packages missing after setup**: If you see errors like `next: command not found` or `cannot find module`, `npm ci` likely did not finish. Rerun `./setup.sh` or run `npm ci` inside `frontend/`. When offline, use `scripts/docker-test.sh` to restore dependencies.
-* **npm ci fails with `ECONNRESET`**: Check your proxy configuration. Run
-  `npm config set proxy http://proxy:8080` and
-  `npm config set https-proxy http://proxy:8080` if your environment requires a
-  proxy. Without these settings you may see `ENETUNREACH` or other network
-  errors when running `setup.sh` or `npm ci`.
+* **npm ci fails with `ECONNRESET` or `ENETUNREACH`**: Your environment may
+  block access to `registry.npmjs.org`. Configure a proxy and rerun with
+  network bridging:
+  `npm config set proxy http://proxy:8080`
+  `npm config set https-proxy http://proxy:8080`
+  `DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh`
 * **npm install failed**: `scripts/test-all.sh` shows the last npm debug log on
   failure. Verify your proxy settings or run
   `scripts/docker-test.sh` with `DOCKER_TEST_NETWORK=bridge` to install

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -9,6 +9,12 @@ NETWORK=${DOCKER_TEST_NETWORK:-none}
 WORKDIR=/workspace
 HOST_REPO=$(pwd)
 
+# Warn when DOCKER_TEST_NETWORK isn't specified so users know npm may fail
+if [ -z "${DOCKER_TEST_NETWORK+x}" ]; then
+  echo "⚠️  DOCKER_TEST_NETWORK is unset. Tests will run with --network none." >&2
+  echo "   Set DOCKER_TEST_NETWORK=bridge for the initial run so npm can reach registry.npmjs.org." >&2
+fi
+
 # Restore dependency caches from a previous Docker run. When running
 # offline, `docker-test.sh` saves `backend/venv.tar.zst` and
 # `frontend/node_modules.tar.zst`. If the unpacked directories are

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -18,6 +18,8 @@ echo "npm $(npm --version)"
 
 # Always run both backend and frontend tests
 echo "⚙️  Installing dependencies…"
+# When running this script inside Docker, use --network bridge or set
+# DOCKER_TEST_NETWORK=bridge if npm fails to contact registry.npmjs.org.
 ./setup.sh
 
 echo "🧪 Running backend tests…"


### PR DESCRIPTION
## Summary
- warn when DOCKER_TEST_NETWORK isn't set in `docker-test.sh`
- mention bridge network usage in Dockerfile and test-all.sh
- document proxy setup and offline test commands in README

## Testing
- `DOCKER_TEST_NETWORK=bridge ./scripts/docker-test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68511455d128832e90d2804f43ead8e9