### PR TITLE
Add collapsible booking steps and sticky progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Simplified buttons sit below each step in a responsive button group.
 * Guests step now matches the others with Back, Save Draft, and Next buttons.
 * Attachment uploads in the notes step display a progress bar and disable the Next button until finished.
-* Collapsible sections for date/time and notes keep steps short on phones.
+* Collapsible sections ensure only the active step is expanded on phones.
 * Mobile devices use native date and time pickers for faster input.
 * Each step appears in a white card with rounded corners and a subtle shadow.
 * The progress bar sticks below the header so progress is always visible while scrolling.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -27,6 +27,7 @@ import SoundStep from './steps/SoundStep';
 import VenueStep from './steps/VenueStep';
 import NotesStep from './steps/NotesStep';
 import ReviewStep from './steps/ReviewStep';
+import useIsMobile from '@/hooks/useIsMobile';
 
 const steps = [
   'Date & Time',
@@ -78,6 +79,7 @@ export default function BookingWizard({
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [maxStepCompleted, setMaxStepCompleted] = useState(0);
+  const isMobile = useIsMobile();
 
   // Ensure maxStepCompleted always reflects the furthest step reached.
   useEffect(() => {
@@ -213,14 +215,14 @@ export default function BookingWizard({
     }
   });
 
-  const renderStep = () => {
-    switch (step) {
+  const renderStep = (index: number) => {
+    switch (index) {
       case 0:
         return (
           <DateTimeStep
             control={control as unknown as Control<FieldValues>}
             unavailable={unavailable}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -233,7 +235,7 @@ export default function BookingWizard({
             control={control as unknown as Control<FieldValues>}
             artistLocation={artistLocation || undefined}
             setWarning={setWarning}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -244,7 +246,7 @@ export default function BookingWizard({
         return (
           <GuestsStep
             control={control as unknown as Control<FieldValues>}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -255,7 +257,7 @@ export default function BookingWizard({
         return (
           <VenueStep
             control={control as unknown as Control<FieldValues>}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -266,7 +268,7 @@ export default function BookingWizard({
         return (
           <SoundStep
             control={control as unknown as Control<FieldValues>}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -278,7 +280,7 @@ export default function BookingWizard({
           <NotesStep
             control={control as unknown as Control<FieldValues>}
             setValue={setValue as unknown as (name: string, value: unknown) => void}
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -288,7 +290,7 @@ export default function BookingWizard({
       default:
         return (
           <ReviewStep
-            step={step}
+            step={index}
             steps={steps}
             onBack={prev}
             onSaveDraft={saveDraft}
@@ -301,34 +303,84 @@ export default function BookingWizard({
 
   return (
     <div className="px-4">
-      <Stepper
-        steps={steps}
-        currentStep={step}
-        maxStepCompleted={maxStepCompleted}
-        onStepClick={handleStepClick}
-      />
-      <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md space-y-6">
-        <h2 className="text-2xl font-bold" data-testid="step-heading">
-          {steps[step]}
-        </h2>
-
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={step}
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -20 }}
-            transition={{ duration: 0.3 }}
-          >
-            {renderStep()}
-          </motion.div>
-        </AnimatePresence>
-        {warning && <p className="text-orange-600 text-sm">{warning}</p>}
-        {Object.values(errors).length > 0 && (
-          <p className="text-red-600 text-sm">Please fix the errors above.</p>
-        )}
-        {error && <p className="text-red-600 text-sm">{error}</p>}
+      <div className="sticky top-0 z-10 bg-white">
+        <Stepper
+          steps={steps}
+          currentStep={step}
+          maxStepCompleted={maxStepCompleted}
+          onStepClick={handleStepClick}
+        />
       </div>
+      {isMobile ? (
+        <div className="space-y-4">
+          {steps.map((label, i) => (
+            <details
+              key={label}
+              open={i === step}
+              className="max-w-md mx-auto bg-white rounded-lg shadow-md"
+            >
+              <summary
+                className="p-4 font-bold cursor-pointer border-b"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleStepClick(i);
+                }}
+              >
+                {label}
+              </summary>
+              {i === step && (
+                <div className="p-6 space-y-6">
+                  <h2 className="sr-only" data-testid="step-heading">
+                    {label}
+                  </h2>
+                  <AnimatePresence mode="wait">
+                    <motion.div
+                      key={step}
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -20 }}
+                      transition={{ duration: 0.3 }}
+                    >
+                      {renderStep(i)}
+                    </motion.div>
+                  </AnimatePresence>
+                  {warning && (
+                    <p className="text-orange-600 text-sm">{warning}</p>
+                  )}
+                  {Object.values(errors).length > 0 && (
+                    <p className="text-red-600 text-sm">
+                      Please fix the errors above.
+                    </p>
+                  )}
+                  {error && <p className="text-red-600 text-sm">{error}</p>}
+                </div>
+              )}
+            </details>
+          ))}
+        </div>
+      ) : (
+        <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md space-y-6">
+          <h2 className="text-2xl font-bold" data-testid="step-heading">
+            {steps[step]}
+          </h2>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              {renderStep(step)}
+            </motion.div>
+          </AnimatePresence>
+          {warning && <p className="text-orange-600 text-sm">{warning}</p>}
+          {Object.values(errors).length > 0 && (
+            <p className="text-red-600 text-sm">Please fix the errors above.</p>
+          )}
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -78,6 +78,20 @@ describe('BookingWizard flow', () => {
     expect(heading()).toContain('Location');
   });
 
+  it('collapses inactive steps on mobile', async () => {
+    const details = () => Array.from(container.querySelectorAll('details'));
+    expect(details()[0].open).toBe(true);
+    expect(details()[1].open).toBe(false);
+    const next = getButton('Next');
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    const updated = details();
+    expect(updated[0].open).toBe(false);
+    expect(updated[1].open).toBe(true);
+  });
+
   it('shows summary only on the review step', async () => {
     expect(container.querySelector('h2')?.textContent).toContain('Date & Time');
     expect(container.textContent).not.toContain('Summary');
@@ -117,5 +131,10 @@ describe('BookingWizard flow', () => {
     // query again after DOM update
     progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
     expect((progressButtons[2] as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('renders a sticky progress indicator', () => {
+    const wrapper = container.querySelector('[aria-label="Progress"]')?.parentElement;
+    expect(wrapper?.className).toContain('sticky');
   });
 });


### PR DESCRIPTION
## Summary
- collapse inactive booking steps on mobile
- keep progress bar sticky while scrolling
- test for collapsible steps and sticky progress
- document mobile step behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68511d414928832eb5ee1f87af50636b