### PR TITLE
Add helpful MFA dependency guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+If you encounter `ModuleNotFoundError: No module named 'pyotp'`, the Python
+dependencies were not installed correctly. Run the `pip install` command above
+or execute `./setup.sh` from the project root to install both backend and
+frontend packages.
+
 The SQLite database path is automatically resolved to the project root, so you can start the backend from either the repo root or the `backend/` folder without creating duplicate database files.
 
 ### Database migrations

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -15,7 +15,14 @@ from ..models.user import User, UserType
 from ..models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
 from ..schemas.user import UserCreate, UserResponse, TokenData, MFAVerify
 from ..utils.auth import get_password_hash, verify_password
-import pyotp
+
+try:
+    import pyotp
+except ModuleNotFoundError as exc:
+    raise RuntimeError(
+        "pyotp is required for multi-factor authentication. "
+        "Run 'pip install -r backend/requirements.txt' to install dependencies."
+    ) from exc
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- gracefully explain missing `pyotp` dependency
- mention fix for `ModuleNotFoundError: No module named pyotp`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68512b10e7ac832e947c4b665d7bed2e