### PR TITLE
Defer Google Map rendering on Location step

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ The location input relies on the built-in Google Maps Places Autocomplete
 service instead of the experimental `@googlemaps/places` package. The previous
 dependency caused a build failure because it depended on Node-only modules like
 `fs`. No additional npm install step is required after this change.
+The embedded map only loads after a location is selected so the page renders
+quickly.
 
 To expose the app on your local network, replace `192.168.3.203` with your
 machine's LAN IP. Set the same address in `backend/.env` under

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -4,8 +4,14 @@
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import dynamic from 'next/dynamic';
 import { useLoadScript } from '@react-google-maps/api';
-const GoogleMap = dynamic(() => import('@react-google-maps/api').then((m) => m.GoogleMap), { ssr: false });
-const Marker = dynamic(() => import('@react-google-maps/api').then((m) => m.Marker), { ssr: false });
+const GoogleMap = dynamic(
+  () => import('@react-google-maps/api').then((m) => m.GoogleMap),
+  { ssr: false },
+);
+const Marker = dynamic(
+  () => import('@react-google-maps/api').then((m) => m.Marker),
+  { ssr: false },
+);
 import { useRef, useState, useEffect } from 'react';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
 
@@ -24,7 +30,18 @@ interface Props {
   onNext: () => void;
 }
 
-const containerStyle = { width: '100%', height: '250px' };
+const mapContainerCollapsed = {
+  width: '100%',
+  height: 0,
+  overflow: 'hidden',
+  transition: 'height 0.3s ease',
+};
+
+const mapContainerExpanded = {
+  width: '100%',
+  height: '250px',
+  transition: 'height 0.3s ease',
+};
 
 interface AutocompleteProps {
   value: string | undefined;
@@ -104,7 +121,6 @@ export default function LocationStep({
     })();
   }, [artistLocation, marker, setWarning]);
 
-  if (!isLoaded) return <p>Loading map...</p>;
   return (
     <div className="space-y-4">
       <p className="text-sm text-gray-600">Where is the show?</p>
@@ -120,16 +136,16 @@ export default function LocationStep({
           />
         )}
       />
-      {marker && (
-        <GoogleMap
-          center={marker}
-          zoom={14}
-          mapContainerStyle={containerStyle}
-          data-testid="map"
-        >
-          <Marker position={marker} />
-        </GoogleMap>
-      )}
+      <div
+        style={marker ? mapContainerExpanded : mapContainerCollapsed}
+        data-testid="map-container"
+      >
+        {marker && isLoaded && (
+          <GoogleMap center={marker} zoom={14} mapContainerStyle={{ width: '100%', height: '100%' }} data-testid="map">
+            <Marker position={marker} />
+          </GoogleMap>
+        )}
+      </div>
       <button
         type="button"
         className="mt-2 text-sm text-indigo-600 underline"


### PR DESCRIPTION
## Summary
- wait for an address selection before rendering the Google Map
- collapse the map area until coordinates exist
- document deferred map loading
- keep existing Location step test verifying map appears after selection

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68513581d7e4832ea0ff4bbbcb58c934