### PR TITLE
Add BottomSheet component and integrate with VenueStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,9 +471,9 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Mobile devices use native date and time pickers for faster input.
 * Each step appears in a white card with rounded corners and a subtle shadow.
 * The progress bar sticks below the header so progress is always visible while scrolling.
-* Venue picker uses a bottom-sheet on small screens to avoid keyboard overlap.
-  The sheet now traps focus for accessibility and closes when you press
-  `Escape` or tap outside.
+* Venue picker uses a reusable `<BottomSheet>` component on small screens to
+  avoid keyboard overlap. The sheet traps focus for accessibility and closes when
+  you press `Escape` or tap outside.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
 * Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
 * Steps now animate with **framer-motion** and the progress dots stay clickable for all completed steps.

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -1,5 +1,8 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
+import { useState, useRef } from 'react';
+import useIsMobile from '@/hooks/useIsMobile';
+import { BottomSheet } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -18,45 +21,81 @@ export default function VenueStep({
   onSaveDraft,
   onNext,
 }: Props) {
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const firstRadioRef = useRef<HTMLInputElement>(null);
+
+  const options = [
+    { value: 'indoor', label: 'Indoor' },
+    { value: 'outdoor', label: 'Outdoor' },
+    { value: 'hybrid', label: 'Hybrid' },
+  ];
+
   return (
     <div className="space-y-4">
       <Controller
         name="venueType"
         control={control}
         render={({ field }) => (
-          <fieldset className="space-y-2">
-            <legend className="font-medium">Venue Type</legend>
-            <label className="flex items-center space-x-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="indoor"
-                checked={field.value === 'indoor'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>Indoor</span>
-            </label>
-            <label className="flex items-center space-x-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="outdoor"
-                checked={field.value === 'outdoor'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>Outdoor</span>
-            </label>
-            <label className="flex items-center space-x-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="hybrid"
-                checked={field.value === 'hybrid'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>Hybrid</span>
-            </label>
-          </fieldset>
+          <>
+            {isMobile ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setSheetOpen(true)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md text-left"
+                  ref={buttonRef}
+                >
+                  {field.value
+                    ? `Venue: ${field.value.charAt(0).toUpperCase()}${field.value.slice(1)}`
+                    : 'Select venue type'}
+                </button>
+                <BottomSheet
+                  open={sheetOpen}
+                  onClose={() => setSheetOpen(false)}
+                  initialFocus={firstRadioRef}
+                  testId="bottom-sheet"
+                >
+                  <fieldset className="p-4 space-y-2">
+                    <legend className="font-medium">Venue Type</legend>
+                    {options.map((opt, idx) => (
+                      <label key={opt.value} className="flex items-center space-x-2">
+                        <input
+                          ref={idx === 0 ? firstRadioRef : undefined}
+                          type="radio"
+                          name={field.name}
+                          value={opt.value}
+                          checked={field.value === opt.value}
+                          onChange={(e) => {
+                            field.onChange(e.target.value);
+                            setSheetOpen(false);
+                          }}
+                        />
+                        <span>{opt.label}</span>
+                      </label>
+                    ))}
+                  </fieldset>
+                </BottomSheet>
+              </>
+            ) : (
+              <fieldset className="space-y-2">
+                <legend className="font-medium">Venue Type</legend>
+                {options.map((opt) => (
+                  <label key={opt.value} className="flex items-center space-x-2">
+                    <input
+                      type="radio"
+                      name={field.name}
+                      value={opt.value}
+                      checked={field.value === opt.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                    <span>{opt.label}</span>
+                  </label>
+                ))}
+              </fieldset>
+            )}
+          </>
         )}
       />
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -4,6 +4,20 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import VenueStep from '../VenueStep';
 
+function MobileWrapper() {
+  const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
+  return (
+    <VenueStep
+      control={control as unknown as Control<FieldValues>}
+      step={2}
+      steps={['one', 'two', 'three']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
+    />
+  );
+}
+
 function Wrapper() {
   const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
   return (
@@ -48,5 +62,49 @@ describe('VenueStep radio buttons', () => {
       outdoor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(outdoor.checked).toBe(true);
+  });
+});
+
+describe('VenueStep bottom sheet mobile', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+  });
+
+  it('opens sheet and restores focus', async () => {
+    await act(async () => {
+      root.render(React.createElement(MobileWrapper));
+    });
+    const openButton = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      openButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const sheet = document.querySelector('[data-testid="bottom-sheet"]');
+    expect(sheet).not.toBeNull();
+    const outdoor = sheet?.querySelector('input[value="outdoor"]') as HTMLInputElement;
+    act(() => {
+      outdoor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(document.querySelector('[data-testid="bottom-sheet"]')).toBeNull();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.activeElement).toBe(openButton);
   });
 });

--- a/frontend/src/components/ui/BottomSheet.tsx
+++ b/frontend/src/components/ui/BottomSheet.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { Fragment, useEffect, useRef } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  initialFocus?: React.RefObject<HTMLElement>;
+  children: React.ReactNode;
+  testId?: string;
+}
+
+export default function BottomSheet({
+  open,
+  onClose,
+  initialFocus,
+  children,
+  testId,
+}: BottomSheetProps) {
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      previouslyFocused.current = document.activeElement as HTMLElement;
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    onClose();
+    previouslyFocused.current?.focus();
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog
+        as="div"
+        className="fixed inset-0 z-50 overflow-hidden"
+        onClose={handleClose}
+        initialFocus={initialFocus}
+        data-testid={testId}
+      >
+        <div className="absolute inset-0 overflow-hidden">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="absolute inset-0 bg-gray-600 bg-opacity-75 transition-opacity" />
+          </Transition.Child>
+          <div className="pointer-events-none fixed inset-x-0 bottom-0 flex max-h-full">
+            <Transition.Child
+              as={Fragment}
+              enter="transform transition ease-in-out duration-300"
+              enterFrom="translate-y-full"
+              enterTo="translate-y-0"
+              leave="transform transition ease-in-out duration-300"
+              leaveFrom="translate-y-0"
+              leaveTo="translate-y-full"
+            >
+              <Dialog.Panel className="pointer-events-auto w-full rounded-t-lg bg-white shadow-xl">
+                {children}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { default as Stepper } from './Stepper';
 export { default as TextInput } from './TextInput';
 export { default as Toast } from './Toast';
 export { default as TimeAgo } from './TimeAgo';
+export { default as BottomSheet } from './BottomSheet';


### PR DESCRIPTION
## Summary
- add `<BottomSheet>` UI component with focus trapping
- use bottom sheet in `VenueStep` when on mobile screens
- restore focus after sheet closes
- update unit tests for mobile bottom sheet
- document new reusable bottom sheet in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851398abf78832ea5bd83cb8a377f62