### PR TITLE
Improve mobile accessibility of booking steps

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -39,7 +39,7 @@ This document outlines key friction points in the current booking wizard and pro
 
 ## Global Recommendations
 * Show a simple progress bar above the form steps. The bar scrolls naturally with the page instead of sticking under the header.
-* Ensure all buttons have at least 44×44 px tappable area and sufficient contrast.
+* Ensure all buttons have at least 44×44 px tappable area and sufficient contrast. ✅ Implemented across booking steps in June 2025.
 * Defer maps and heavy images until after the initial step loads.
 * Provide skeleton loaders for availability checks and quote calculations.
 * Maintain the existing <code>MobileBottomNav</code> for consistent navigation.

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -46,7 +46,7 @@ export default function DateTimeStep({
           return isMobile ? (
             <input
               type="date"
-              className="border p-2 rounded w-full"
+              className="border p-2 rounded w-full min-h-[44px]"
               min={format(new Date(), 'yyyy-MM-dd')}
               name={field.name}
               ref={field.ref}
@@ -71,7 +71,7 @@ export default function DateTimeStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -81,14 +81,14 @@ export default function DateTimeStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
           <button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -32,7 +32,7 @@ export default function GuestsStep({
           <input
             type="number"
             min={1}
-            className="border p-3 rounded w-full text-lg"
+            className="border p-3 rounded w-full text-lg min-h-[44px]"
             {...field}
             autoFocus={!isMobile}
           />
@@ -43,7 +43,7 @@ export default function GuestsStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -53,14 +53,14 @@ export default function GuestsStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
           <button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -83,7 +83,7 @@ function AutocompleteInput({ value, onChange, onSelect, isLoaded }: Autocomplete
   return (
     <input
       ref={inputRef}
-      className="border p-2 w-full"
+      className="border p-2 w-full min-h-[44px]"
       placeholder="Search address"
       onChange={(e) => onChange(e.target.value)}
       data-testid="autocomplete-input"
@@ -148,7 +148,7 @@ export default function LocationStep({
       </div>
       <button
         type="button"
-        className="mt-2 text-sm text-indigo-600 underline"
+        className="mt-2 text-sm text-indigo-600 underline px-4 py-2 rounded inline-block min-h-[44px]"
         onClick={() => {
           navigator.geolocation.getCurrentPosition(
             (pos) => {
@@ -165,7 +165,7 @@ export default function LocationStep({
         Use my location
       </button>
       <span
-        className="ml-1 text-gray-400 cursor-help"
+        className="ml-1 text-gray-500 cursor-help"
         title="A warning appears if this address is over 100km from the artist."
       >
         ?
@@ -176,7 +176,7 @@ export default function LocationStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -186,14 +186,14 @@ export default function LocationStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
           <button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -61,7 +61,7 @@ export default function NotesStep({
         render={({ field }) => (
           <textarea
             rows={3}
-            className="border p-2 rounded w-full"
+            className="border p-2 rounded w-full min-h-[44px]"
             {...field}
             autoFocus={!isMobile}
           />
@@ -73,7 +73,12 @@ export default function NotesStep({
         render={({ field }) => <input type="hidden" {...field} />}
       />
       <label className="block text-sm font-medium">Attachment (optional)</label>
-      <input type="file" aria-label="Upload attachment" onChange={handleFileChange} />
+      <input
+        type="file"
+        aria-label="Upload attachment"
+        className="min-h-[44px]"
+        onChange={handleFileChange}
+      />
       {uploading && (
         <div
           className="flex items-center gap-2 mt-2"
@@ -96,7 +101,7 @@ export default function NotesStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -106,7 +111,7 @@ export default function NotesStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
@@ -114,7 +119,7 @@ export default function NotesStep({
             type="button"
             onClick={onNext}
             disabled={uploading}
-            className={`w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition ${uploading ? 'opacity-50 cursor-not-allowed' : ''}`}
+            className={`w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px] ${uploading ? 'opacity-50 cursor-not-allowed' : ''}`}
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -30,7 +30,7 @@ export default function ReviewStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -40,7 +40,7 @@ export default function ReviewStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
@@ -48,7 +48,7 @@ export default function ReviewStep({
             type="button"
             onClick={onSubmit}
             disabled={submitting}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:opacity-50 min-h-[44px]"
           >
             {submitting ? 'Submitting...' : step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -26,7 +26,7 @@ export default function SoundStep({
         render={({ field }) => (
           <fieldset className="space-y-2">
             <legend className="font-medium">Is sound needed?</legend>
-            <label className="flex items-center space-x-2">
+            <label className="flex items-center space-x-2 py-2">
               <input
                 type="radio"
                 name={field.name}
@@ -36,7 +36,7 @@ export default function SoundStep({
               />
               <span>Yes</span>
             </label>
-            <label className="flex items-center space-x-2">
+            <label className="flex items-center space-x-2 py-2">
               <input
                 type="radio"
                 name={field.name}
@@ -54,7 +54,7 @@ export default function SoundStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -64,14 +64,14 @@ export default function SoundStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
           <button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -44,7 +44,7 @@ export default function VenueStep({
                 <button
                   type="button"
                   onClick={() => setSheetOpen(true)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md text-left"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-md text-left min-h-[44px]"
                   ref={buttonRef}
                 >
                   {field.value
@@ -60,7 +60,7 @@ export default function VenueStep({
                   <fieldset className="p-4 space-y-2">
                     <legend className="font-medium">Venue Type</legend>
                     {options.map((opt, idx) => (
-                      <label key={opt.value} className="flex items-center space-x-2">
+                      <label key={opt.value} className="flex items-center space-x-2 py-2">
                         <input
                           ref={idx === 0 ? firstRadioRef : undefined}
                           type="radio"
@@ -82,7 +82,7 @@ export default function VenueStep({
               <fieldset className="space-y-2">
                 <legend className="font-medium">Venue Type</legend>
                 {options.map((opt) => (
-                  <label key={opt.value} className="flex items-center space-x-2">
+                  <label key={opt.value} className="flex items-center space-x-2 py-2">
                     <input
                       type="radio"
                       name={field.name}
@@ -103,7 +103,7 @@ export default function VenueStep({
           <button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Back
           </button>
@@ -113,14 +113,14 @@ export default function VenueStep({
           <button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition"
+            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
           >
             Save Draft
           </button>
           <button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
           </button>


### PR DESCRIPTION
## Summary
- enlarge tap targets in booking steps to meet 44×44 px guidance
- update color contrast of tooltip icon
- note improved compliance in `MOBILE_UX_REPORT`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68513b3c6e94832ea793be01ebbbf76f