### PR TITLE
Add skeleton loaders for availability and quote calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` in `bookings_simple`.
 - Booking wizard includes a required **Guests** step.
+- Date picker and quote calculator show skeleton loaders while data fetches.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/app/quote-calculator/__tests__/page.test.tsx
+++ b/frontend/src/app/quote-calculator/__tests__/page.test.tsx
@@ -1,0 +1,46 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import QuoteCalculatorPage from '../page';
+import * as api from '@/lib/api';
+
+jest.mock('@/lib/api');
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MockMainLayout';
+  return Mock;
+});
+
+function setup() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('QuoteCalculatorPage loaders', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('shows a skeleton while providers load', async () => {
+    let resolve: (value: { data: [] }) => void;
+    (api.getSoundProviders as jest.Mock).mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(<QuoteCalculatorPage />);
+    });
+    const skeleton = container.querySelector('[data-testid="provider-skeleton"]');
+    expect(skeleton).not.toBeNull();
+    act(() => resolve({ data: [] }));
+    await act(async () => {});
+    expect(container.querySelector('[data-testid="provider-skeleton"]')).toBeNull();
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/frontend/src/app/quote-calculator/page.tsx
+++ b/frontend/src/app/quote-calculator/page.tsx
@@ -12,11 +12,14 @@ export default function QuoteCalculatorPage() {
   const [accommodation, setAccommodation] = useState('');
   const [result, setResult] = useState<QuoteCalculationResponse | null>(null);
   const [providers, setProviders] = useState<SoundProvider[]>([]);
+  const [loadingProviders, setLoadingProviders] = useState(false);
 
   useEffect(() => {
+    setLoadingProviders(true);
     getSoundProviders()
       .then((res) => setProviders(res.data))
-      .catch(() => setProviders([]));
+      .catch(() => setProviders([]))
+      .finally(() => setLoadingProviders(false));
   }, []);
 
   const onSubmit = async (e: React.FormEvent) => {
@@ -62,18 +65,25 @@ export default function QuoteCalculatorPage() {
           </div>
           <div>
             <label className="block text-sm font-medium">Sound Provider</label>
-            <select
-              className="border p-2 rounded w-full"
-              value={providerId}
-              onChange={(e) => setProviderId(e.target.value)}
-            >
-              <option value="">None</option>
-              {providers.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
+            {loadingProviders ? (
+              <div
+                data-testid="provider-skeleton"
+                className="h-10 w-full rounded bg-gray-200 animate-pulse"
+              />
+            ) : (
+              <select
+                className="border p-2 rounded w-full"
+                value={providerId}
+                onChange={(e) => setProviderId(e.target.value)}
+              >
+                <option value="">None</option>
+                {providers.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
           <div>
             <label className="block text-sm font-medium">Accommodation Cost</label>

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -74,6 +74,7 @@ export default function BookingWizard({
   } = useBooking();
   const router = useRouter();
   const [unavailable, setUnavailable] = useState<string[]>([]);
+  const [loadingAvailability, setLoadingAvailability] = useState(false);
   const [artistLocation, setArtistLocation] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -104,9 +105,11 @@ export default function BookingWizard({
 
   useEffect(() => {
     if (!artistId) return;
+    setLoadingAvailability(true);
     getArtistAvailability(artistId)
       .then((res) => setUnavailable(res.data.unavailable_dates))
-      .catch(() => setUnavailable([]));
+      .catch(() => setUnavailable([]))
+      .finally(() => setLoadingAvailability(false));
     getArtist(artistId)
       .then((res) => setArtistLocation(res.data.location || null))
       .catch(() => setArtistLocation(null));
@@ -224,6 +227,7 @@ export default function BookingWizard({
           <DateTimeStep
             control={control as unknown as Control<FieldValues>}
             unavailable={unavailable}
+            loading={loadingAvailability}
             step={index}
             steps={steps}
             onBack={prev}

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -133,6 +133,28 @@ describe('BookingWizard flow', () => {
     expect((progressButtons[2] as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it('shows a loader while fetching availability', async () => {
+    let resolve: (value: { data: { unavailable_dates: string[] } }) => void;
+    (api.getArtistAvailability as jest.Mock).mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+    act(() => {
+      root.unmount();
+    });
+    container.innerHTML = '';
+    root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(Wrapper));
+    });
+    const skeleton = container.querySelector('[data-testid="calendar-skeleton"]');
+    expect(skeleton).not.toBeNull();
+    act(() => resolve({ data: { unavailable_dates: [] } }));
+    await act(async () => {});
+    expect(container.querySelector('[data-testid="calendar-skeleton"]')).toBeNull();
+  });
+
   it('renders a sticky progress indicator', () => {
     const wrapper = container.querySelector('[aria-label="Progress"]')?.parentElement;
     expect(wrapper?.className).toContain('sticky');

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -9,6 +9,8 @@ import useIsMobile from '@/hooks/useIsMobile';
 interface Props {
   control: Control<FieldValues>;
   unavailable: string[];
+  /** Show a skeleton calendar while availability loads */
+  loading?: boolean;
   step: number;
   steps: string[];
   onBack: () => void;
@@ -19,6 +21,7 @@ interface Props {
 export default function DateTimeStep({
   control,
   unavailable,
+  loading = false,
   step,
   steps,
   onBack,
@@ -35,37 +38,44 @@ export default function DateTimeStep({
   return (
     <div className="space-y-4">
       <p className="text-sm text-gray-600">When should we perform?</p>
-      <Controller
-        name="date"
-        control={control}
-        render={({ field }) => {
-          const currentValue =
-            field.value && typeof field.value === 'string'
-              ? parseISO(field.value)
-              : field.value;
-          return isMobile ? (
-            <input
-              type="date"
-              className="border p-2 rounded w-full min-h-[44px]"
-              min={format(new Date(), 'yyyy-MM-dd')}
-              name={field.name}
-              ref={field.ref}
-              onBlur={field.onBlur}
-              value={currentValue ? format(currentValue, 'yyyy-MM-dd') : ''}
-              onChange={(e) => field.onChange(e.target.value)}
-            />
-          ) : (
-            <Calendar
-              {...field}
-              value={currentValue}
-              locale="en-US"
-              formatLongDate={formatLongDate}
-              onChange={(date) => field.onChange(date as Date)}
-              tileDisabled={tileDisabled}
-            />
-          );
-        }}
-      />
+      {loading ? (
+        <div
+          data-testid="calendar-skeleton"
+          className="h-72 bg-gray-200 rounded animate-pulse"
+        />
+      ) : (
+        <Controller
+          name="date"
+          control={control}
+          render={({ field }) => {
+            const currentValue =
+              field.value && typeof field.value === 'string'
+                ? parseISO(field.value)
+                : field.value;
+            return isMobile ? (
+              <input
+                type="date"
+                className="border p-2 rounded w-full min-h-[44px]"
+                min={format(new Date(), 'yyyy-MM-dd')}
+                name={field.name}
+                ref={field.ref}
+                onBlur={field.onBlur}
+                value={currentValue ? format(currentValue, 'yyyy-MM-dd') : ''}
+                onChange={(e) => field.onChange(e.target.value)}
+              />
+            ) : (
+              <Calendar
+                {...field}
+                value={currentValue}
+                locale="en-US"
+                formatLongDate={formatLongDate}
+                onChange={(date) => field.onChange(date as Date)}
+                tileDisabled={tileDisabled}
+              />
+            );
+          }}
+        />
+      )}
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
           <button

--- a/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
@@ -21,6 +21,22 @@ function Wrapper() {
   );
 }
 
+function LoadingWrapper() {
+  const { control } = useForm();
+  return (
+    <DateTimeStep
+      control={control as unknown as Control<FieldValues>}
+      unavailable={[]}
+      loading
+      step={0}
+      steps={['one']}
+      onBack={() => {}}
+      onSaveDraft={() => {}}
+      onNext={() => {}}
+    />
+  );
+}
+
 describe('DateTimeStep mobile input', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
@@ -52,5 +68,13 @@ describe('DateTimeStep mobile input', () => {
     expect(input).not.toBeNull();
     expect(input.value).toBe('2025-06-20');
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders a skeleton when loading', async () => {
+    await act(async () => {
+      root.render(React.createElement(LoadingWrapper));
+    });
+    const skeleton = container.querySelector('[data-testid="calendar-skeleton"]');
+    expect(skeleton).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- display skeleton loader in DateTimeStep while availability loads
- show skeleton while provider list loads on Quote Calculator page
- update BookingWizard to pass loading state
- test new loading behaviour
- note loader feature in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68513c9d90a8832ebdce8ea3135f2bc3