### PR TITLE
Add deposit payment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Python** 3.12
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
-- Bookings now track `payment_status` in `bookings_simple`.
+- Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.
 - Google Maps and large images load lazily once in view to reduce first paint time.
@@ -694,6 +694,7 @@ POST /api/v1/payments
  Required: booking_request_id, amount
  Optional: full (bool)
 ```
+Sending `full: true` charges the remaining balance and marks the booking paid. Omitting it records a deposit and sets the status to `deposit_paid`.
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.

--- a/backend/alembic/versions/80a1b6c7d8a9_add_deposit_columns_to_booking_simple.py
+++ b/backend/alembic/versions/80a1b6c7d8a9_add_deposit_columns_to_booking_simple.py
@@ -1,0 +1,29 @@
+"""add_deposit_columns_to_booking_simple
+
+Revision ID: 80a1b6c7d8a9
+Revises: 662cfa8a683d
+Create Date: 2025-07-20 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '80a1b6c7d8a9'
+down_revision: Union[str, None] = '662cfa8a683d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('bookings_simple', sa.Column('deposit_amount', sa.Numeric(10, 2), nullable=True))
+    op.add_column(
+        'bookings_simple',
+        sa.Column('deposit_paid', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute("UPDATE bookings_simple SET deposit_paid = FALSE")
+    op.alter_column('bookings_simple', 'deposit_paid', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('bookings_simple', 'deposit_paid')
+    op.drop_column('bookings_simple', 'deposit_amount')

--- a/backend/app/api/api_payment.py
+++ b/backend/app/api/api_payment.py
@@ -3,11 +3,16 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from typing import Optional
 import logging
+import os
+from decimal import Decimal
+import httpx
 
-from ..models import User
+from ..models import User, BookingSimple, QuoteV2
 from .dependencies import get_db, get_current_active_client
 
 logger = logging.getLogger(__name__)
+
+PAYMENT_GATEWAY_URL = os.getenv("PAYMENT_GATEWAY_URL", "https://example.com")
 
 router = APIRouter(tags=["payments"])
 
@@ -22,11 +27,39 @@ def create_payment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_client),
 ):
-    # Placeholder: real integration would call a payment gateway
     logger.info(
         "Process payment for request %s amount %s full=%s",
         payment_in.booking_request_id,
         payment_in.amount,
         payment_in.full,
     )
-    return {"status": "ok"}
+
+    booking = (
+        db.query(BookingSimple)
+        .join(QuoteV2, BookingSimple.quote_id == QuoteV2.id)
+        .filter(QuoteV2.booking_request_id == payment_in.booking_request_id)
+        .first()
+    )
+    if not booking:
+        logger.warning("Booking not found for request %s", payment_in.booking_request_id)
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Booking not found")
+
+    try:
+        response = httpx.post(
+            f"{PAYMENT_GATEWAY_URL}/charges",
+            json={"amount": payment_in.amount, "currency": "ZAR"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        charge = response.json()
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.error("Payment gateway error: %s", exc, exc_info=True)
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="Payment gateway error")
+
+    booking.deposit_amount = Decimal(str(payment_in.amount))
+    booking.deposit_paid = True
+    booking.payment_status = "paid" if payment_in.full else "deposit_paid"
+    db.commit()
+    db.refresh(booking)
+
+    return {"status": "ok", "payment_id": charge.get("id")}

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -98,6 +98,8 @@ def accept_quote(db: Session, quote_id: int) -> models.BookingSimple:
         confirmed=True,
         # No charge is triggered yet; payment will be collected later
         payment_status="pending",
+        deposit_amount=0,
+        deposit_paid=False,
     )
     db.add(booking)
     db.commit()

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -135,6 +135,18 @@ def ensure_booking_simple_columns(engine: Engine) -> None:
         "payment_status",
         "payment_status VARCHAR NOT NULL DEFAULT 'pending'",
     )
+    add_column_if_missing(
+        engine,
+        "bookings_simple",
+        "deposit_amount",
+        "deposit_amount NUMERIC(10, 2)"
+    )
+    add_column_if_missing(
+        engine,
+        "bookings_simple",
+        "deposit_paid",
+        "deposit_paid BOOLEAN NOT NULL DEFAULT FALSE",
+    )
 
 
 def ensure_mfa_columns(engine: Engine) -> None:

--- a/backend/app/models/booking_simple.py
+++ b/backend/app/models/booking_simple.py
@@ -1,4 +1,12 @@
-from sqlalchemy import Column, Integer, ForeignKey, Boolean, DateTime, String
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey,
+    Boolean,
+    DateTime,
+    String,
+    Numeric,
+)
 from sqlalchemy.orm import relationship
 
 from .base import BaseModel
@@ -15,6 +23,8 @@ class BookingSimple(BaseModel):
     date = Column(DateTime, nullable=True)
     location = Column(String, nullable=True)
     payment_status = Column(String, nullable=False, default="pending")
+    deposit_amount = Column(Numeric(10, 2), nullable=True, default=0)
+    deposit_paid = Column(Boolean, nullable=False, default=False)
 
     quote = relationship("QuoteV2")
     artist = relationship("User", foreign_keys=[artist_id])

--- a/backend/app/schemas/quote_v2.py
+++ b/backend/app/schemas/quote_v2.py
@@ -46,6 +46,8 @@ class BookingSimpleRead(BaseModel):
     date: Optional[datetime] = None
     location: Optional[str] = None
     payment_status: str
+    deposit_amount: Optional[Decimal] = None
+    deposit_paid: bool
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -129,6 +129,8 @@ def test_booking_simple_columns():
     assert "date" in column_names
     assert "location" in column_names
     assert "payment_status" in column_names
+    assert "deposit_amount" in column_names
+    assert "deposit_paid" in column_names
 
 
 def test_mfa_columns():

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -1,0 +1,121 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from decimal import Decimal
+
+from app.main import app
+from app.models import User, UserType, BookingRequest, QuoteV2, QuoteStatusV2, BookingSimple
+from app.models.base import BaseModel
+from app.api.dependencies import get_db, get_current_active_client
+import app.api.api_payment as api_payment
+
+
+def setup_app():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_records(Session):
+    db = Session()
+    client = User(email='client@test.com', password='x', first_name='c', last_name='l', user_type=UserType.CLIENT)
+    artist = User(email='artist@test.com', password='x', first_name='a', last_name='r', user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = QuoteV2(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[],
+        sound_fee=0,
+        travel_fee=0,
+        subtotal=Decimal('100'),
+        total=Decimal('100'),
+        status=QuoteStatusV2.ACCEPTED,
+    )
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+
+    booking = BookingSimple(
+        quote_id=quote.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        confirmed=True,
+        payment_status='pending',
+        deposit_amount=0,
+        deposit_paid=False,
+    )
+    db.add(booking)
+    db.commit()
+    db.refresh(booking)
+
+    # return objects still bound to the session so dependency overrides work
+    return client, br.id, Session
+
+
+def override_client(user):
+    def _override():
+        return user
+    return _override
+
+
+def test_create_deposit(monkeypatch):
+    Session = setup_app()
+    client_user, br_id, Session = create_records(Session)
+    prev_db = app.dependency_overrides.get(get_db)
+    prev_client = app.dependency_overrides.get(get_current_active_client)
+    app.dependency_overrides[get_current_active_client] = override_client(client_user)
+
+    def fake_post(url, json, timeout=10):
+        class Resp:
+            status_code = 201
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'id': 'ch_test', 'status': 'succeeded'}
+        return Resp()
+
+    monkeypatch.setattr(api_payment.httpx, 'post', fake_post)
+    client = TestClient(app)
+    res = client.post('/api/v1/payments/', json={'booking_request_id': br_id, 'amount': 50})
+    assert res.status_code == 201
+    db = Session()
+    booking = db.query(BookingSimple).first()
+    assert booking.deposit_amount == Decimal('50')
+    assert booking.deposit_paid is True
+    assert booking.payment_status == 'deposit_paid'
+    db.close()
+    if prev_db is not None:
+        app.dependency_overrides[get_db] = prev_db
+    else:
+        app.dependency_overrides.pop(get_db, None)
+    if prev_client is not None:
+        app.dependency_overrides[get_current_active_client] = prev_client
+    else:
+        app.dependency_overrides.pop(get_current_active_client, None)

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -84,6 +84,8 @@ def test_create_and_accept_quote():
     assert booking.client_id == client.id
     assert booking.confirmed is True
     assert booking.payment_status == "pending"
+    assert booking.deposit_amount == 0
+    assert booking.deposit_paid is False
 
     db_booking = db.query(Booking).filter(Booking.quote_id == quote.id).first()
     assert db_booking is not None


### PR DESCRIPTION
## Summary
- integrate payment gateway in `api_payment` for deposits
- track deposit amounts and statuses in `BookingSimple`
- generate Alembic migration for new columns
- ensure DB utils create deposit columns automatically
- extend quote acceptance to initialize deposit fields
- document deposit payments in README
- add tests covering deposit payments

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68514080ba54832e8d97ed3c25e30654