### PR TITLE
Handle WebSocket auth failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
   with cached dependencies.
 * **WebSocket closes immediately**: Ensure the booking request exists and that
   your authentication token is valid. Invalid tokens or missing requests cause
-  the server to close the connection and log a warning.
+  the server to close the connection with code `4401` and log a warning.
 
 ---
 

--- a/backend/app/api/api_ws.py
+++ b/backend/app/api/api_ws.py
@@ -7,6 +7,9 @@ from fastapi import (
 )
 from starlette.exceptions import WebSocketException
 from starlette import status as ws_status
+
+# Custom WebSocket close codes mirroring HTTP status codes
+WS_4401_UNAUTHORIZED = 4401
 from sqlalchemy.orm import Session
 from typing import Dict, List, Any
 from jose import JWTError, jwt
@@ -55,7 +58,7 @@ async def booking_request_ws(
     user: User | None = None
     if not token:
         logger.warning("Rejecting WebSocket for request %s: missing token", request_id)
-        raise WebSocketException(code=ws_status.WS_1008_POLICY_VIOLATION, reason="Missing token")
+        raise WebSocketException(code=WS_4401_UNAUTHORIZED, reason="Missing token")
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         email = payload.get("sub")
@@ -63,10 +66,10 @@ async def booking_request_ws(
             user = db.query(User).filter(User.email == email).first()
     except JWTError:
         logger.warning("Rejecting WebSocket for request %s: invalid token", request_id)
-        raise WebSocketException(code=ws_status.WS_1008_POLICY_VIOLATION, reason="Invalid token")
+        raise WebSocketException(code=WS_4401_UNAUTHORIZED, reason="Invalid token")
     if not user:
         logger.warning("Rejecting WebSocket for request %s: user not found", request_id)
-        raise WebSocketException(code=ws_status.WS_1008_POLICY_VIOLATION, reason="Invalid token")
+        raise WebSocketException(code=WS_4401_UNAUTHORIZED, reason="Invalid token")
     booking_request = crud_booking_request.get_booking_request(
         db, request_id=request_id
     )
@@ -74,13 +77,15 @@ async def booking_request_ws(
         logger.warning(
             "Rejecting WebSocket for request %s: booking request not found", request_id
         )
-        raise WebSocketException(code=ws_status.WS_1008_POLICY_VIOLATION, reason="Request not found")
+        raise WebSocketException(code=WS_4401_UNAUTHORIZED, reason="Request not found")
 
     if user and user.id not in [booking_request.client_id, booking_request.artist_id]:
         logger.warning(
-            "Rejecting WebSocket for request %s: unauthorized user %s", request_id, user.id
+            "Rejecting WebSocket for request %s: unauthorized user %s",
+            request_id,
+            user.id,
         )
-        raise WebSocketException(code=ws_status.WS_1008_POLICY_VIOLATION, reason="Unauthorized")
+        raise WebSocketException(code=WS_4401_UNAUTHORIZED, reason="Unauthorized")
 
     await manager.connect(request_id, websocket)
     try:

--- a/backend/tests/test_ws.py
+++ b/backend/tests/test_ws.py
@@ -1,0 +1,87 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models.base import BaseModel
+from app.api.dependencies import get_db
+from app.models import User, UserType, BookingRequest, BookingRequestStatus
+from starlette.websockets import WebSocketDisconnect
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    artist = User(
+        email="artist@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.ARTIST,
+    )
+    client = User(
+        email="client@test.com",
+        password="x",
+        first_name="C",
+        last_name="L",
+        user_type=UserType.CLIENT,
+    )
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+    br = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        status=BookingRequestStatus.PENDING_QUOTE,
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+    db.close()
+    return br, artist, client
+
+
+def test_ws_missing_token():
+    Session = setup_app()
+    br, _, _ = create_data(Session)
+    client = TestClient(app)
+
+    ws = client.websocket_connect(f"/api/v1/ws/booking-requests/{br.id}")
+    with pytest.raises(Exception):
+        ws.send_text("ping")
+
+    app.dependency_overrides.clear()
+
+
+def test_ws_invalid_token():
+    Session = setup_app()
+    br, _, _ = create_data(Session)
+    client = TestClient(app)
+
+    ws = client.websocket_connect(f"/api/v1/ws/booking-requests/{br.id}?token=bad")
+    with pytest.raises(Exception):
+        ws.send_text("ping")
+
+    app.dependency_overrides.clear()

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -138,7 +138,13 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     typeof window !== 'undefined' ? localStorage.getItem('token') : '';
   const { onMessage: onSocketMessage } = useWebSocket(
     `${wsBase}${API_V1}/ws/booking-requests/${bookingRequestId}?token=${token}`,
-    () => setWsFailed(true),
+    (e) => {
+      if (e?.code === 4401) {
+        setErrorMsg('Authentication error. Please sign in again.');
+      } else {
+        setWsFailed(true);
+      }
+    },
   );
 
   useEffect(


### PR DESCRIPTION
## Summary
- use custom `4401` WebSocket close codes instead of `WS_1008_POLICY_VIOLATION`
- surface auth failures in MessageThread
- expose close event in `useWebSocket`
- document new close code
- add WebSocket auth error tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685143ef4ba0832e97923896b2f0e3c2