### PR TITLE
Add client bookings page and API filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.
 - Google Maps and large images load lazily once in view to reduce first paint time.
+- Client dashboards now include a bookings list with upcoming and past filters via `/api/v1/bookings/my-bookings?status=`.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/backend/tests/test_client_bookings_status.py
+++ b/backend/tests/test_client_bookings_status.py
@@ -1,0 +1,130 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from datetime import datetime
+
+from app.main import app
+from app.models.base import BaseModel
+from app.models import User, UserType, Service, Booking, BookingStatus
+from app.api.dependencies import get_db, get_current_active_client
+
+
+def setup_app():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    client = User(
+        email='client@test.com',
+        password='x',
+        first_name='C',
+        last_name='L',
+        user_type=UserType.CLIENT,
+    )
+    artist = User(
+        email='artist@test.com',
+        password='x',
+        first_name='A',
+        last_name='R',
+        user_type=UserType.ARTIST,
+    )
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title='Gig',
+        price=100,
+        duration_minutes=60,
+        service_type='Live Performance',
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    upcoming = Booking(
+        artist_id=artist.id,
+        client_id=client.id,
+        service_id=service.id,
+        start_time=datetime(2030, 1, 1, 12, 0, 0),
+        end_time=datetime(2030, 1, 1, 13, 0, 0),
+        status=BookingStatus.CONFIRMED,
+        total_price=100,
+    )
+    past = Booking(
+        artist_id=artist.id,
+        client_id=client.id,
+        service_id=service.id,
+        start_time=datetime(2020, 1, 1, 12, 0, 0),
+        end_time=datetime(2020, 1, 1, 13, 0, 0),
+        status=BookingStatus.COMPLETED,
+        total_price=100,
+    )
+    db.add_all([upcoming, past])
+    db.commit()
+    db.close()
+    return client
+
+
+def test_filter_upcoming_and_past():
+    Session = setup_app()
+    client_user = create_data(Session)
+
+    def override_client():
+        return client_user
+
+    app.dependency_overrides[get_current_active_client] = override_client
+    api_client = TestClient(app)
+
+    res_upcoming = api_client.get('/api/v1/bookings/my-bookings?status=upcoming')
+    assert res_upcoming.status_code == 200
+    data_upcoming = res_upcoming.json()
+    assert len(data_upcoming) == 1
+    assert data_upcoming[0]['status'] == 'confirmed'
+
+    res_past = api_client.get('/api/v1/bookings/my-bookings?status=past')
+    assert res_past.status_code == 200
+    data_past = res_past.json()
+    assert len(data_past) == 1
+    assert data_past[0]['status'] == 'completed'
+
+    app.dependency_overrides.clear()
+
+
+def test_invalid_status_returns_422(caplog):
+    Session = setup_app()
+    client_user = create_data(Session)
+
+    def override_client():
+        return client_user
+
+    app.dependency_overrides[get_current_active_client] = override_client
+    api_client = TestClient(app)
+
+    caplog.set_level('WARNING')
+    response = api_client.get('/api/v1/bookings/my-bookings?status=bad')
+    assert response.status_code == 422
+    assert 'Invalid status filter' in response.json()['detail']
+    assert any('Invalid status filter' in r.getMessage() for r in caplog.records)
+
+    app.dependency_overrides.clear()

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import ClientBookingsPage from '../page';
+import { getMyClientBookings } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard/client/bookings'),
+}));
+
+describe('ClientBookingsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders upcoming and past bookings', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+    });
+    (getMyClientBookings as jest.Mock)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            artist_id: 2,
+            client_id: 1,
+            service_id: 4,
+            start_time: new Date().toISOString(),
+            end_time: new Date().toISOString(),
+            status: 'confirmed',
+            total_price: 100,
+            notes: '',
+            service: { title: 'Gig' },
+            client: { id: 1 },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 2,
+            artist_id: 2,
+            client_id: 1,
+            service_id: 4,
+            start_time: new Date().toISOString(),
+            end_time: new Date().toISOString(),
+            status: 'completed',
+            total_price: 200,
+            notes: '',
+            service: { title: 'Gig' },
+            client: { id: 1 },
+          },
+        ],
+      });
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+
+    await act(async () => {
+      root.render(<ClientBookingsPage />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getMyClientBookings).toHaveBeenCalledWith({ status: 'upcoming' });
+    expect(getMyClientBookings).toHaveBeenCalledWith({ status: 'past' });
+    expect(div.textContent).toContain('Upcoming Bookings');
+    expect(div.textContent).toContain('Past Bookings');
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import MainLayout from '@/components/layout/MainLayout';
+import { useAuth } from '@/contexts/AuthContext';
+import { getMyClientBookings } from '@/lib/api';
+import type { Booking } from '@/types';
+import { format } from 'date-fns';
+import { formatCurrency } from '@/lib/utils';
+
+function BookingList({ items }: { items: Booking[] }) {
+  return (
+    <ul className="space-y-3">
+      {items.map((b) => (
+        <li key={b.id} className="bg-white p-4 shadow rounded-lg">
+          <div className="font-medium text-gray-900">{b.service.title}</div>
+          <div className="text-sm text-gray-500">
+            {format(new Date(b.start_time), 'MMM d, yyyy h:mm a')}
+          </div>
+          <div className="mt-2 flex justify-between items-center">
+            <span
+              className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
+                b.status === 'completed'
+                  ? 'bg-green-100 text-green-800'
+                  : b.status === 'cancelled'
+                  ? 'bg-red-100 text-red-800'
+                  : b.status === 'confirmed'
+                  ? 'bg-blue-100 text-blue-800'
+                  : 'bg-yellow-100 text-yellow-800'
+              }`}
+            >
+              {b.status}
+            </span>
+            <span className="text-sm text-gray-500">
+              {formatCurrency(Number(b.total_price))}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ClientBookingsPage() {
+  const { user } = useAuth();
+  const [upcoming, setUpcoming] = useState<Booking[]>([]);
+  const [past, setPast] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchData = async () => {
+      try {
+        const [upRes, pastRes] = await Promise.all([
+          getMyClientBookings({ status: 'upcoming' }),
+          getMyClientBookings({ status: 'past' }),
+        ]);
+        setUpcoming(upRes.data);
+        setPast(pastRes.data);
+      } catch (err) {
+        console.error('Failed to load client bookings', err);
+        setError('Failed to load bookings');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (user.user_type === 'client') {
+      fetchData();
+    } else {
+      setLoading(false);
+      setError('Access denied');
+    }
+  }, [user]);
+
+  if (!user) {
+    return (
+      <MainLayout>
+        <div className="p-8">Please log in to view your bookings.</div>
+      </MainLayout>
+    );
+  }
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <div className="flex justify-center items-center min-h-[60vh]">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error}</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-3xl mx-auto p-4 space-y-6">
+        <section>
+          <h1 className="text-xl font-semibold mb-2">Upcoming Bookings</h1>
+          {upcoming.length === 0 ? (
+            <p>No upcoming bookings.</p>
+          ) : (
+            <BookingList items={upcoming} />
+          )}
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Past Bookings</h2>
+          {past.length === 0 ? (
+            <p>No past bookings.</p>
+          ) : (
+            <BookingList items={past} />
+          )}
+        </section>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -198,8 +198,8 @@ export const createBooking = (data: Partial<Booking>) =>
   api.post(`${API_V1}/bookings`, data);
 
 // client’s bookings: GET /api/v1/bookings/my-bookings
-export const getMyClientBookings = () =>
-  api.get<Booking[]>(`${API_V1}/bookings/my-bookings`);
+export const getMyClientBookings = (params: { status?: string } = {}) =>
+  api.get<Booking[]>(`${API_V1}/bookings/my-bookings`, { params });
 
 // artist’s bookings: GET /api/v1/bookings/artist-bookings
 export const getMyArtistBookings = () =>


### PR DESCRIPTION
## Summary
- filter client bookings by status in backend
- document new booking filters
- fetch bookings by status from the API library
- add dashboard page for clients showing upcoming and past bookings
- test new client bookings page and backend filter logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68514c6edc80832e8a4a00d0b9515456