### PR TITLE
Add booking request update control

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New `/dashboard/bookings` page lists all bookings with links to their quotes.
 * The dashboard Bookings tab now includes a **View All Bookings** link.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
+* Artists can update or decline booking requests from the dashboard via a new **Update Request** modal.
 * Improved dashboard stats layout with monthly earnings card.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { format } from "date-fns";
 import { formatCurrency, normalizeService } from "@/lib/utils";
 import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
+import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
 import OverviewAccordion from "@/components/dashboard/OverviewAccordion";
 import SectionList from "@/components/dashboard/SectionList";
 import DashboardTabs from "@/components/dashboard/DashboardTabs";
@@ -157,6 +158,7 @@ export default function DashboardPage() {
   const [error, setError] = useState("");
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
+  const [requestToUpdate, setRequestToUpdate] = useState<BookingRequest | null>(null);
   const [activeTab, setActiveTab] = useState<'requests' | 'bookings' | 'services'>('requests');
 
   // Aggregated totals for dashboard statistics
@@ -426,6 +428,15 @@ export default function DashboardPage() {
                     >
                       View Chat
                     </Link>
+                    {user.user_type === 'artist' && (
+                      <button
+                        type="button"
+                        onClick={() => setRequestToUpdate(req)}
+                        className="ml-4 mt-2 inline-block text-indigo-600 hover:underline text-sm"
+                      >
+                        Update
+                      </button>
+                    )}
                     {req.accepted_quote_id && (
                       <Link
                         href={`/quotes/${req.accepted_quote_id}`}
@@ -552,6 +563,18 @@ export default function DashboardPage() {
           service={editingService}
           onClose={() => setEditingService(null)}
           onServiceUpdated={handleServiceUpdated}
+        />
+      )}
+      {requestToUpdate && (
+        <UpdateRequestModal
+          isOpen={!!requestToUpdate}
+          request={requestToUpdate}
+          onClose={() => setRequestToUpdate(null)}
+          onUpdated={(updated) =>
+            setBookingRequests((prev) =>
+              prev.map((r) => (r.id === updated.id ? updated : r)),
+            )
+          }
         />
       )}
     </MainLayout>

--- a/frontend/src/components/dashboard/UpdateRequestModal.tsx
+++ b/frontend/src/components/dashboard/UpdateRequestModal.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { BookingRequest } from '@/types';
+import { updateBookingRequestArtist, postMessageToBookingRequest } from '@/lib/api';
+
+interface UpdateRequestModalProps {
+  isOpen: boolean;
+  request: BookingRequest;
+  onClose: () => void;
+  onUpdated: (req: BookingRequest) => void;
+}
+
+export default function UpdateRequestModal({
+  isOpen,
+  request,
+  onClose,
+  onUpdated,
+}: UpdateRequestModalProps) {
+  const [status, setStatus] = useState(request.status);
+  const [note, setNote] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await updateBookingRequestArtist(request.id, { status });
+      if (note.trim()) {
+        await postMessageToBookingRequest(request.id, { content: note.trim() });
+      }
+      onUpdated(res.data);
+      onClose();
+    } catch (err) {
+      console.error('Failed to update request', err);
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center transition-opacity">
+      <div className="relative mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white transform transition-transform duration-200">
+        <div className="mt-3 text-center">
+          <h3 className="text-lg leading-6 font-medium text-gray-900">Update Request</h3>
+          <form onSubmit={handleSubmit} className="mt-2 px-7 py-3 space-y-4 text-left">
+            <div>
+              <label htmlFor="status" className="block text-sm font-medium text-gray-700">Status</label>
+              <select
+                id="status"
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              >
+                <option value="pending_quote">Pending Quote</option>
+                <option value="quote_provided">Quote Provided</option>
+                <option value="request_declined">Declined</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="note" className="block text-sm font-medium text-gray-700">Note to client</label>
+              <textarea
+                id="note"
+                rows={3}
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              />
+            </div>
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <div className="items-center px-4 py-3 space-x-2 text-right">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 bg-gray-200 text-gray-700 text-base font-medium rounded-md shadow-sm hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import api from '../api';
+import api, { updateBookingRequestArtist } from '../api';
 import type { AxiosRequestConfig } from 'axios';
 
 describe('request interceptor', () => {
@@ -42,6 +42,18 @@ describe('request interceptor', () => {
     expect(() => handler(config)).not.toThrow();
     expect(config.headers!.Authorization).toBeUndefined();
     g.window = win;
+  });
+});
+
+describe('updateBookingRequestArtist', () => {
+  it('calls the correct endpoint', async () => {
+    const spy = jest.spyOn(api, 'put').mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await updateBookingRequestArtist(5, { status: 'request_declined' });
+    expect(spy).toHaveBeenCalledWith(
+      '/api/v1/booking-requests/5/artist',
+      { status: 'request_declined' },
+    );
+    spy.mockRestore();
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -257,6 +257,12 @@ export const updateBookingRequest = (
   data: Partial<BookingRequestCreate> & { status?: string }
 ) => api.put<BookingRequest>(`${API_V1}/booking-requests/${id}/client`, data);
 
+// Update a booking request as the artist (e.g., decline)
+export const updateBookingRequestArtist = (
+  id: number,
+  data: { status?: string }
+) => api.put<BookingRequest>(`${API_V1}/booking-requests/${id}/artist`, data);
+
 // Create a new quote (artist → client) for an existing booking request:
 //    POST /api/v1/quotes/
 // Body must match QuoteCreate interface.


### PR DESCRIPTION
## Summary
- add `updateBookingRequestArtist` helper
- create `UpdateRequestModal` for artists
- allow request updates from dashboard list
- test update logic and API helper
- document dashboard update option

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515212f1e8832e892739fc0b6836a5