### PR TITLE
Add deposit payment flow after quote acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,8 @@ POST /api/v1/payments
 Sending `full: true` charges the remaining balance and marks the booking paid. Omitting it records a deposit and sets the status to `deposit_paid`.
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
 
+When a client accepts a quote in the chat thread, the frontend now prompts them to pay a deposit via this endpoint. Successful payments update the booking's `payment_status` and display a confirmation banner.
+
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 
 `DEFAULT_CURRENCY` in `frontend/src/lib/constants.ts` exports this value for use across the app. Call `formatCurrency(value, currency?, locale?)` from `frontend/src/lib/utils.ts` to format amounts consistently. UI labels such as "Price" and "Hourly Rate" automatically display this currency.

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import Button from '../ui/Button';
+import { createPayment } from '@/lib/api';
+
+interface PaymentModalProps {
+  open: boolean;
+  onClose: () => void;
+  bookingRequestId: number;
+  onSuccess: (status: string) => void;
+  onError: (msg: string) => void;
+}
+
+const PaymentModal: React.FC<PaymentModalProps> = ({
+  open,
+  onClose,
+  bookingRequestId,
+  onSuccess,
+  onError,
+}) => {
+  const [amount, setAmount] = useState('');
+  const [full, setFull] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const handlePay = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await createPayment({
+        booking_request_id: bookingRequestId,
+        amount: Number(amount),
+        full,
+      });
+      onSuccess(full ? 'paid' : 'deposit_paid');
+    } catch (err) {
+      console.error('Failed to create payment', err);
+      const msg = (err as Error).message;
+      setError(msg);
+      onError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-sm p-4">
+        <h2 className="text-lg font-medium mb-2">Pay Deposit</h2>
+        <div className="space-y-2">
+          <input
+            type="number"
+            className="w-full border rounded p-1"
+            placeholder="Amount"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={full}
+              onChange={(e) => setFull(e.target.checked)}
+            />
+            Pay full amount
+          </label>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </div>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handlePay} isLoading={loading}>
+            Pay
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentModal;

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -469,6 +469,57 @@ describe('MessageThread component', () => {
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
   });
 
+  it('opens payment modal after accepting quote', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Quote',
+          message_type: 'quote',
+          quote_id: 7,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 7,
+        status: 'pending',
+        services: [],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 0,
+        total: 0,
+        artist_id: 2,
+        client_id: 1,
+        booking_request_id: 1,
+        created_at: '',
+        updated_at: '',
+      },
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const acceptBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Accept',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const modalHeading = container.querySelector('h2');
+    expect(modalHeading?.textContent).toBe('Pay Deposit');
+  });
+
   it('shows an alert when the WebSocket fails', async () => {
     await act(async () => {
       root.render(<MessageThread bookingRequestId={1} />);

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -1,0 +1,33 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import PaymentModal from '../PaymentModal';
+import * as api from '@/lib/api';
+
+jest.mock('@/lib/api');
+
+describe('PaymentModal', () => {
+  it('submits payment', async () => {
+    (api.createPayment as jest.Mock).mockResolvedValue({ data: {} });
+    const onSuccess = jest.fn();
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <PaymentModal open bookingRequestId={1} onClose={() => {}} onSuccess={onSuccess} onError={() => {}} />,
+      );
+    });
+    const input = div.querySelector('input[type="number"]') as HTMLInputElement;
+    await act(async () => {
+      input.value = '25';
+      input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
+    });
+    const button = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Pay') as HTMLButtonElement;
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(api.createPayment).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith('deposit_paid');
+    root.unmount();
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import api, { updateBookingRequestArtist } from '../api';
+import api, { updateBookingRequestArtist, createPayment } from '../api';
 import type { AxiosRequestConfig } from 'axios';
 
 describe('request interceptor', () => {
@@ -53,6 +53,15 @@ describe('updateBookingRequestArtist', () => {
       '/api/v1/booking-requests/5/artist',
       { status: 'request_declined' },
     );
+    spy.mockRestore();
+  });
+});
+
+describe('createPayment', () => {
+  it('posts to the payments endpoint', async () => {
+    const spy = jest.spyOn(api, 'post').mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await createPayment({ booking_request_id: 3, amount: 50 });
+    expect(spy).toHaveBeenCalledWith('/api/v1/payments', { booking_request_id: 3, amount: 50 });
     spy.mockRestore();
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -374,6 +374,13 @@ export const calculateQuote = (params: {
   accommodation_cost?: number;
 }) => api.post<QuoteCalculationResponse>(`${API_V1}/quotes/calculate`, params);
 
+// ─── PAYMENTS ───────────────────────────────────────────────────────────────
+export const createPayment = (data: {
+  booking_request_id: number;
+  amount: number;
+  full?: boolean;
+}) => api.post(`${API_V1}/payments`, data);
+
 // ─── NOTIFICATIONS ───────────────────────────────────────────────────────────
 export const getNotifications = (skip = 0, limit = 20) =>
   api.get<Notification[]>(


### PR DESCRIPTION
## Summary
- trigger payment modal after accepting a quote
- handle deposit payment via new `createPayment` helper
- track payment status in message thread
- document deposit payment workflow
- test payment helper and modal behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68515552e0a8832e841b366b3cea4de9