### PR TITLE
Enable client reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Google Maps and large images load lazily once in view to reduce first paint time.
 - Client dashboards now include a bookings list with upcoming and past filters via `/api/v1/bookings/my-bookings?status=`.
 - Artists can mark bookings completed or cancelled and download confirmed bookings as calendar (.ics) files.
+- Clients can leave a star rating and comment once a booking is marked completed. Service detail pages now display these reviews.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -80,4 +80,46 @@ describe('ClientBookingsPage', () => {
     });
     div.remove();
   });
+
+  it('shows review button for completed bookings', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+    });
+    (getMyClientBookings as jest.Mock)
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: 9,
+            artist_id: 2,
+            client_id: 1,
+            service_id: 4,
+            start_time: new Date().toISOString(),
+            end_time: new Date().toISOString(),
+            status: 'completed',
+            total_price: 100,
+            notes: '',
+            service: { title: 'Gig' },
+            client: { id: 1 },
+          },
+        ],
+      });
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+
+    await act(async () => {
+      root.render(<ClientBookingsPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(div.textContent).toContain('Leave review');
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
 });

--- a/frontend/src/app/services/[id]/__tests__/ServiceDetailPage.test.tsx
+++ b/frontend/src/app/services/[id]/__tests__/ServiceDetailPage.test.tsx
@@ -1,0 +1,62 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import React from 'react';
+import ServiceDetailPage from '../page';
+import { getService, getServiceReviews } from '@/lib/api';
+import { useParams, usePathname } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  usePathname: jest.fn(),
+}));
+
+describe('ServiceDetailPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches service and reviews', async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: '1' });
+    (usePathname as jest.Mock).mockReturnValue('/services/1');
+    (getService as jest.Mock).mockResolvedValue({
+      data: {
+        id: 1,
+        title: 'Service',
+        description: 'Desc',
+        price: 50,
+        duration_minutes: 30,
+        artist_id: 1,
+      },
+    });
+    (getServiceReviews as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          booking_id: 3,
+          rating: 4,
+          comment: 'Good',
+          created_at: '',
+          updated_at: '',
+          client: { first_name: 'A' },
+        },
+      ],
+    });
+
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ServiceDetailPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(getService).toHaveBeenCalledWith(1);
+    expect(getServiceReviews).toHaveBeenCalledWith(1);
+    expect(div.textContent).toContain('Good');
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/services/[id]/page.tsx
+++ b/frontend/src/app/services/[id]/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import { getService, getServiceReviews } from '@/lib/api';
+import { Service, Review } from '@/types';
+import { formatCurrency } from '@/lib/utils';
+import { StarIcon } from '@heroicons/react/24/outline';
+
+export default function ServiceDetailPage() {
+  const params = useParams();
+  const serviceId = Number(params.id);
+  const [service, setService] = useState<Service | null>(null);
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!serviceId) return;
+    const fetch = async () => {
+      try {
+        const [sRes, rRes] = await Promise.all([
+          getService(serviceId),
+          getServiceReviews(serviceId),
+        ]);
+        setService(sRes.data);
+        setReviews(rRes.data);
+      } catch (err) {
+        console.error('Failed to load service', err);
+        setError('Failed to load service');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetch();
+  }, [serviceId]);
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <div className="p-8">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  if (error || !service) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error || 'Service not found'}</div>
+      </MainLayout>
+    );
+  }
+
+  const average =
+    reviews.length > 0
+      ? (
+          reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
+        ).toFixed(1)
+      : null;
+
+  return (
+    <MainLayout>
+      <div className="max-w-3xl mx-auto p-4 space-y-6">
+        <div className="bg-white shadow rounded-md p-6">
+          <h1 className="text-2xl font-bold mb-2">{service.title}</h1>
+          {service.description && (
+            <p className="text-gray-600 mb-2">{service.description}</p>
+          )}
+          <p className="text-gray-800 font-semibold">
+            {formatCurrency(Number(service.price))} — {service.duration_minutes} min
+          </p>
+          {average && (
+            <p className="mt-2 flex items-center text-sm text-gray-700">
+              <StarIcon className="h-4 w-4 mr-1 text-yellow-400" /> {average} / 5
+            </p>
+          )}
+        </div>
+        <section>
+          <h2 className="text-xl font-semibold mb-4">Reviews ({reviews.length})</h2>
+          {reviews.length === 0 ? (
+            <p className="text-gray-600">No reviews yet.</p>
+          ) : (
+            <ul className="space-y-4">
+              {reviews.map((r) => (
+                <li key={r.id} className="bg-white p-4 rounded-md shadow">
+                  <div className="flex items-center mb-1">
+                    {[...Array(5)].map((_, i) => (
+                      <StarIcon
+                        key={`s-${r.id}-${i}`}
+                        className={`h-4 w-4 ${i < r.rating ? 'text-yellow-400' : 'text-gray-300'}`}
+                      />
+                    ))}
+                    {r.client?.first_name && (
+                      <span className="ml-2 text-sm text-gray-700">{r.client.first_name}</span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-600">{r.comment}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </MainLayout>
+  );
+}
+

--- a/frontend/src/components/review/ReviewFormModal.tsx
+++ b/frontend/src/components/review/ReviewFormModal.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { createReviewForBooking } from '@/lib/api';
+import { Review } from '@/types';
+import { Button } from '@/components/ui';
+
+interface Props {
+  isOpen: boolean;
+  bookingId: number;
+  onClose: () => void;
+  onSubmitted: (review: Review) => void;
+}
+
+interface FormData {
+  rating: number;
+  comment: string;
+}
+
+export default function ReviewFormModal({
+  isOpen,
+  bookingId,
+  onClose,
+  onSubmitted,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ defaultValues: { rating: 5, comment: '' } });
+
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const onSubmit: SubmitHandler<FormData> = async (data) => {
+    setServerError(null);
+    try {
+      const res = await createReviewForBooking(bookingId, data);
+      onSubmitted(res.data);
+      reset();
+      onClose();
+    } catch (err: unknown) {
+      console.error('Review submission error:', err);
+      const msg =
+        err instanceof Error ? err.message : 'Failed to submit review.';
+      setServerError(msg);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-md shadow-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">Leave a Review</h3>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label htmlFor="rating" className="block text-sm font-medium text-gray-700">Rating</label>
+            <select
+              id="rating"
+              {...register('rating', { required: true, valueAsNumber: true })}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            >
+              {[1,2,3,4,5].map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+            {errors.rating && (
+              <p className="text-xs text-red-600 mt-1">Rating is required</p>
+            )}
+          </div>
+          <div>
+            <label htmlFor="comment" className="block text-sm font-medium text-gray-700">Comment</label>
+            <textarea
+              id="comment"
+              rows={3}
+              {...register('comment')}
+              className="mt-1 block w-full border border-gray-300 rounded-md p-2"
+            />
+          </div>
+          {serverError && <p className="text-sm text-red-600">{serverError}</p>}
+          <div className="flex justify-end space-x-2">
+            <Button type="button" variant="secondary" onClick={onClose} disabled={isSubmitting}>Cancel</Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Submitting...' : 'Submit'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
+++ b/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
@@ -1,0 +1,56 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import React from 'react';
+import ReviewFormModal from '../ReviewFormModal';
+import { createReviewForBooking } from '@/lib/api';
+
+jest.mock('@/lib/api');
+
+describe('ReviewFormModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits review and closes', async () => {
+    (createReviewForBooking as jest.Mock).mockResolvedValue({
+      data: { id: 1, booking_id: 1, rating: 5, comment: 'Great', created_at: '', updated_at: '' },
+    });
+    const onClose = jest.fn();
+    const onSubmitted = jest.fn();
+    const div = document.createElement('div');
+    const root = createRoot(div);
+
+    await act(async () => {
+      root.render(
+        <ReviewFormModal isOpen bookingId={1} onClose={onClose} onSubmitted={onSubmitted} />,
+      );
+    });
+
+    const select = div.querySelector('select') as HTMLSelectElement;
+    const textarea = div.querySelector('textarea') as HTMLTextAreaElement;
+    act(() => {
+      select.value = '5';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      textarea.value = 'Great';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const form = div.querySelector('form') as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(createReviewForBooking).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ rating: 5 }),
+    );
+    expect(onSubmitted).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -7,6 +7,9 @@ import api, {
   updateQuoteAsArtist,
   updateQuoteAsClient,
   confirmQuoteBooking,
+  createReviewForBooking,
+  getReview,
+  getServiceReviews,
 } from '../api';
 import type { AxiosRequestConfig } from 'axios';
 
@@ -183,6 +186,38 @@ describe('confirmQuoteBooking', () => {
       .mockResolvedValue({ data: {} } as unknown as { data: unknown });
     await confirmQuoteBooking(3);
     expect(spy).toHaveBeenCalledWith('/api/v1/quotes/3/confirm-booking', {});
+    spy.mockRestore();
+  });
+});
+
+describe('review helpers', () => {
+  it('creates a booking review', async () => {
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await createReviewForBooking(2, { rating: 5 });
+    expect(spy).toHaveBeenCalledWith(
+      '/api/v1/reviews/bookings/2/reviews',
+      { rating: 5 },
+    );
+    spy.mockRestore();
+  });
+
+  it('fetches a single review', async () => {
+    const spy = jest
+      .spyOn(api, 'get')
+      .mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await getReview(5);
+    expect(spy).toHaveBeenCalledWith('/api/v1/reviews/5');
+    spy.mockRestore();
+  });
+
+  it('gets service reviews', async () => {
+    const spy = jest
+      .spyOn(api, 'get')
+      .mockResolvedValue({ data: [] } as unknown as { data: unknown });
+    await getServiceReviews(7);
+    expect(spy).toHaveBeenCalledWith('/api/v1/services/7/reviews');
     spy.mockRestore();
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -231,6 +231,14 @@ export const createReviewForBooking = (
     data
   );
 
+// read a single review by booking id: GET /api/v1/reviews/{booking_id}
+export const getReview = (bookingId: number) =>
+  api.get<Review>(`${API_V1}/reviews/${bookingId}`);
+
+// list reviews for a service: GET /api/v1/services/{service_id}/reviews
+export const getServiceReviews = (serviceId: number) =>
+  api.get<Review[]>(`${API_V1}/services/${serviceId}/reviews`);
+
 // list reviews for an artist: GET /api/v1/reviews/artist-profiles/{artist_id}/reviews
 export const getArtistReviews = (artistUserId: number) =>
   api.get<Review[]>(


### PR DESCRIPTION
## Summary
- add API helpers for reviews
- add modal for leaving booking reviews
- show review button on client bookings page
- add service detail page with reviews
- test review helpers and components

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851603cf5e8832e8c67c0a3da72e1f8