### PR TITLE
Add quotes navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New `/dashboard/quotes` page lets artists manage their quotes. Endpoints
   `GET /api/v1/quotes/me/artist`, `PUT /api/v1/quotes/{id}/artist`, and
   `POST /api/v1/quotes/{id}/confirm-booking` allow updates and confirmations.
+* The dashboard stats section now includes a **View All Quotes** link so artists can quickly jump to their quotes list.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
 * Artists can update or decline booking requests from the dashboard via a new **Update Request** modal.
 * Improved dashboard stats layout with monthly earnings card.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -504,6 +504,32 @@ describe('DashboardPage accepted quote label', () => {
   });
 });
 
+describe('DashboardPage quotes link', () => {
+  it('shows link to artist quotes', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist', email: 'a@example.com' } });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const link = container.querySelector('a[href="/dashboard/quotes"]');
+    expect(link).toBeTruthy();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
 describe('DashboardPage request updates', () => {
   it('updates request status when form submitted', async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -365,17 +365,24 @@ export default function DashboardPage() {
 
           {/* Stats */}
           <div className="mt-8">
-            <OverviewAccordion
-              primaryStats={[
-                { label: 'Total Bookings', value: bookings.length },
-                { label: 'Total Earnings', value: formatCurrency(totalEarnings) },
-              ]}
-              secondaryStats={[
-                { label: 'Total Services', value: servicesCount },
-                { label: 'Earnings This Month', value: formatCurrency(earningsThisMonth) },
-              ]}
-            />
-          </div>
+          <OverviewAccordion
+            primaryStats={[
+              { label: 'Total Bookings', value: bookings.length },
+              { label: 'Total Earnings', value: formatCurrency(totalEarnings) },
+            ]}
+            secondaryStats={[
+              { label: 'Total Services', value: servicesCount },
+              { label: 'Earnings This Month', value: formatCurrency(earningsThisMonth) },
+            ]}
+          />
+          {user.user_type === 'artist' && (
+            <div className="mt-2">
+              <Link href="/dashboard/quotes" className="text-indigo-600 hover:underline text-sm">
+                View All Quotes
+              </Link>
+            </div>
+          )}
+        </div>
 
           {user.user_type === "artist" && activeTab === 'services' && (
             <button

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -109,6 +109,21 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                               )}
                             </Menu.Item>
                           )}
+                          {user && user.user_type === 'artist' && (
+                            <Menu.Item>
+                              {({ active }) => (
+                                <Link
+                                  href="/dashboard/quotes"
+                                  className={classNames(
+                                    active ? 'bg-gray-100' : '',
+                                    'block px-4 py-2 text-sm text-gray-700'
+                                  )}
+                                >
+                                  Quotes
+                                </Link>
+                              )}
+                            </Menu.Item>
+                          )}
                           <Menu.Item>
                             {({ active }) => (
                               <button

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -97,18 +97,27 @@ export default function MobileMenuDrawer({
                     </Link>
                     {user.user_type === 'artist' && (
                       <Link
-                        href="/dashboard/profile/edit"
-                        onClick={onClose}
-                        className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                      >
-                        Edit Profile
-                      </Link>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => {
-                        logout();
-                        onClose();
+                    href="/dashboard/profile/edit"
+                    onClick={onClose}
+                    className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                  >
+                    Edit Profile
+                  </Link>
+                )}
+                {user.user_type === 'artist' && (
+                  <Link
+                    href="/dashboard/quotes"
+                    onClick={onClose}
+                    className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                  >
+                    Quotes
+                  </Link>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    logout();
+                    onClose();
                       }}
                       className="block w-full text-left px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                     >

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -1,0 +1,35 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import MainLayout from '../MainLayout';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/link', () => ({ __esModule: true, default: (props: any) => <a {...props} /> }));
+jest.mock('next/navigation', () => ({ usePathname: () => '/', useRouter: () => ({}) }));
+
+describe('MainLayout user menu', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows Quotes link for artist users', async () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, email: 'a@test.com', user_type: 'artist' }, logout: jest.fn() });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(React.createElement(MainLayout, { children: React.createElement('div') }));
+    });
+    await act(async () => { await Promise.resolve(); });
+    const menuBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent?.includes('Open user menu')) as HTMLButtonElement;
+    expect(menuBtn).toBeTruthy();
+    await act(async () => {
+      menuBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Quotes');
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+});

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -42,4 +42,24 @@ describe('MobileMenuDrawer', () => {
     expect(bodyText).toContain('Home');
     expect(bodyText).toContain('Artists');
   });
+
+  it('shows Quotes link for artists', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          user: { user_type: 'artist' } as any,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const body = document.body.textContent || '';
+    expect(body).toContain('Quotes');
+  });
 });


### PR DESCRIPTION
## Summary
- link to `/dashboard/quotes` from dashboard stats
- add Quotes link to artist menus
- document how to access quotes
- test DashboardPage, MobileMenuDrawer, and MainLayout for new links

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851655b7c18832e86fcb64a79ac82c3