### PR TITLE
Add artist links to quote tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 
 * **Endpoints** under `/api/v1/sound-providers` and `/api/v1/quotes/calculate`.
 * Frontend pages: `/sound-providers`, `/quote-calculator`.
+* These pages now appear in the artist navigation menu.
 * Quote API factors travel distance, provider fees, and accommodation.
 * Providers can now be edited and artists may rank preferred providers via `/sound-providers`.
 * New quote endpoints: `POST /api/v1/quotes`, `GET /api/v1/quotes/{id}`, and

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -376,9 +376,15 @@ export default function DashboardPage() {
             ]}
           />
           {user.user_type === 'artist' && (
-            <div className="mt-2">
+            <div className="mt-2 space-x-4">
               <Link href="/dashboard/quotes" className="text-indigo-600 hover:underline text-sm">
                 View All Quotes
+              </Link>
+              <Link href="/sound-providers" className="text-indigo-600 hover:underline text-sm">
+                Sound Providers
+              </Link>
+              <Link href="/quote-calculator" className="text-indigo-600 hover:underline text-sm">
+                Quote Calculator
               </Link>
             </div>
           )}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -11,7 +11,7 @@ import BookingRequestIcon from './BookingRequestIcon';
 import MobileMenuDrawer from './MobileMenuDrawer';
 import MobileBottomNav from './MobileBottomNav';
 
-const navigation = [
+const baseNavigation = [
   { name: 'Home', href: '/' },
   { name: 'Artists', href: '/artists' },
   { name: 'Services', href: '/services' },
@@ -25,6 +25,13 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const { user, logout } = useAuth();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
+  const navigation = [...baseNavigation];
+  if (user?.user_type === 'artist') {
+    navigation.push(
+      { name: 'Sound Providers', href: '/sound-providers' },
+      { name: 'Quote Calculator', href: '/quote-calculator' },
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-indigo-50 to-white">

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -14,7 +14,7 @@ describe('MainLayout user menu', () => {
     jest.clearAllMocks();
   });
 
-  it('shows Quotes link for artist users', async () => {
+  it('shows artist links for artist users', async () => {
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, email: 'a@test.com', user_type: 'artist' } as User, logout: jest.fn() });
     const div = document.createElement('div');
     document.body.appendChild(div);
@@ -23,6 +23,8 @@ describe('MainLayout user menu', () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
     await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Sound Providers');
+    expect(div.textContent).toContain('Quote Calculator');
     const menuBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent?.includes('Open user menu')) as HTMLButtonElement;
     expect(menuBtn).toBeTruthy();
     await act(async () => {

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -4,7 +4,12 @@ import { act } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 import type { User } from '@/types';
 
-const nav = [{ name: 'Home', href: '/' }, { name: 'Artists', href: '/artists' }];
+const nav = [
+  { name: 'Home', href: '/' },
+  { name: 'Artists', href: '/artists' },
+  { name: 'Sound Providers', href: '/sound-providers' },
+  { name: 'Quote Calculator', href: '/quote-calculator' },
+];
 
 describe('MobileMenuDrawer', () => {
   let container: HTMLDivElement;
@@ -42,9 +47,11 @@ describe('MobileMenuDrawer', () => {
     const bodyText = document.body.textContent || '';
     expect(bodyText).toContain('Home');
     expect(bodyText).toContain('Artists');
+    expect(bodyText).toContain('Sound Providers');
+    expect(bodyText).toContain('Quote Calculator');
   });
 
-  it('shows Quotes link for artists', async () => {
+  it('shows artist links for artists', async () => {
     await act(async () => {
       root.render(
         React.createElement(MobileMenuDrawer, {
@@ -62,6 +69,8 @@ describe('MobileMenuDrawer', () => {
     });
     const body = document.body.textContent || '';
     expect(body).toContain('Quotes');
+    expect(body).toContain('Sound Providers');
+    expect(body).toContain('Quote Calculator');
   });
 
   it('shows My Bookings link for clients', async () => {


### PR DESCRIPTION
## Summary
- update README with nav note
- add Sound Providers and Quote Calculator links for artists
- surface those links from the dashboard
- check new routes in MobileMenuDrawer and MainLayout tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68517e53d638832e815513e742dc7cfc