### PR TITLE
Add booking view link after confirmation

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react';
 import { motion } from 'framer-motion';
 import Image from 'next/image';
+import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl } from '@/lib/utils';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
@@ -382,6 +383,16 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           >
             🎉 Booking confirmed for {artistName}! You’ll receive follow-up emails and details.
           </div>
+        )}
+        {bookingConfirmed && (
+          <Link
+            href={`/booking-requests/${bookingRequestId}`}
+            aria-label="View booking details"
+            data-testid="view-booking-link"
+            className="mt-2 inline-block text-indigo-600 hover:underline text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          >
+            View booking
+          </Link>
         )}
         {paymentStatus && (
           <div

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -467,6 +467,8 @@ describe('MessageThread component', () => {
     });
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
+    const link = container.querySelector('a[href="/booking-requests/1"]');
+    expect(link).not.toBeNull();
   });
 
   it('opens payment modal after accepting quote', async () => {


### PR DESCRIPTION
## Summary
- allow users to jump to the booking page once confirmation banner appears
- test for the booking link in MessageThread component

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851826353d4832e8aa182f0e1f65903