### PR TITLE
Add optional depositAmount prop to PaymentModal

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ Sending `full: true` charges the remaining balance and marks the booking paid. O
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
 
 When a client accepts a quote in the chat thread, the frontend now prompts them to pay a deposit via this endpoint. Successful payments update the booking's `payment_status` and display a confirmation banner.
+The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -77,6 +77,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [showQuoteModal, setShowQuoteModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
+  const [depositAmount, setDepositAmount] = useState<number | undefined>(
+    undefined,
+  );
   const [paymentStatus, setPaymentStatus] = useState<string | null>(null);
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -262,14 +265,17 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       try {
         await acceptQuoteV2(quoteId);
         setBookingConfirmed(true);
-        setShowPaymentModal(true);
         const q = await getQuoteV2(quoteId);
+        setDepositAmount(q.data.total * 0.5);
+        setShowPaymentModal(true);
         setQuotes((prev) => ({ ...prev, [quoteId]: q.data }));
       } catch (err) {
         console.warn('Failed to accept quote via V2, trying legacy endpoint', err);
         try {
           await updateQuoteAsClient(quoteId, { status: 'accepted_by_client' });
           const q = await getQuoteV2(quoteId);
+          setDepositAmount(q.data.total * 0.5);
+          setShowPaymentModal(true);
           setQuotes((prev) => ({ ...prev, [quoteId]: q.data }));
         } catch (legacyErr) {
           console.error('Failed to accept quote', legacyErr);
@@ -707,8 +713,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             onClose={() => {
               setShowPaymentModal(false);
               setPaymentError(null);
+              setDepositAmount(undefined);
             }}
             bookingRequestId={bookingRequestId}
+            depositAmount={depositAmount}
             onSuccess={(status) => {
               setPaymentStatus(status);
               setShowPaymentModal(false);

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Button from '../ui/Button';
 import { createPayment } from '@/lib/api';
 
@@ -8,6 +8,7 @@ interface PaymentModalProps {
   bookingRequestId: number;
   onSuccess: (status: string) => void;
   onError: (msg: string) => void;
+  depositAmount?: number;
 }
 
 const PaymentModal: React.FC<PaymentModalProps> = ({
@@ -16,11 +17,20 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
   bookingRequestId,
   onSuccess,
   onError,
+  depositAmount,
 }) => {
-  const [amount, setAmount] = useState('');
+  const [amount, setAmount] = useState(
+    depositAmount !== undefined ? depositAmount.toString() : '',
+  );
   const [full, setFull] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && depositAmount !== undefined) {
+      setAmount(depositAmount.toString());
+    }
+  }, [depositAmount, open]);
 
   if (!open) return null;
 

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -14,10 +14,18 @@ describe('PaymentModal', () => {
     const root = createRoot(div);
     await act(async () => {
       root.render(
-        <PaymentModal open bookingRequestId={1} onClose={() => {}} onSuccess={onSuccess} onError={() => {}} />,
+        <PaymentModal
+          open
+          bookingRequestId={1}
+          onClose={() => {}}
+          onSuccess={onSuccess}
+          onError={() => {}}
+          depositAmount={50}
+        />,
       );
     });
     const input = div.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input.value).toBe('50');
     await act(async () => {
       input.value = '25';
       input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));


### PR DESCRIPTION
## Summary
- allow passing a `depositAmount` to `PaymentModal` and pre-fill input
- surface deposit amount when accepting a quote
- reset deposit when closing payment modal
- document that deposit field defaults to half the quote total
- update PaymentModal test to verify input value

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851844e5bd4832e8d043fd46bcdd94a