### PR TITLE
Enhance payment banner with receipt link

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -13,7 +13,7 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
-import { getFullImageUrl } from '@/lib/utils';
+import { getFullImageUrl, formatCurrency } from '@/lib/utils';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Message, MessageCreate, QuoteV2 } from '@/types';
@@ -81,6 +81,8 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     undefined,
   );
   const [paymentStatus, setPaymentStatus] = useState<string | null>(null);
+  const [paymentAmount, setPaymentAmount] = useState<number | null>(null);
+  const [receiptUrl, setReceiptUrl] = useState<string | null>(null);
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [wsFailed, setWsFailed] = useState(false);
@@ -415,7 +417,20 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             className="rounded-lg bg-blue-50 border border-blue-200 p-4 text-sm text-blue-800 mt-2"
             data-testid="payment-status-banner"
           >
-            {paymentStatus === 'paid' ? 'Payment completed.' : 'Deposit received.'}
+            {paymentStatus === 'paid'
+              ? 'Payment completed.'
+              : `Deposit of ${formatCurrency(paymentAmount ?? depositAmount ?? 0)} received.`}
+            {receiptUrl && (
+              <a
+                href={receiptUrl}
+                target="_blank"
+                rel="noopener"
+                data-testid="booking-receipt-link"
+                className="ml-2 underline"
+              >
+                View receipt
+              </a>
+            )}
           </div>
         )}
         {paymentError && (
@@ -727,8 +742,10 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             }}
             bookingRequestId={bookingRequestId}
             depositAmount={depositAmount}
-            onSuccess={(status) => {
+            onSuccess={({ status, amount, receiptUrl: url }) => {
               setPaymentStatus(status);
+              setPaymentAmount(amount);
+              setReceiptUrl(url ?? null);
               setShowPaymentModal(false);
               setPaymentError(null);
             }}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -626,6 +626,80 @@ describe('MessageThread component', () => {
     });
   });
 
+  it('shows receipt link after paying deposit', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Quote',
+          message_type: 'quote',
+          quote_id: 10,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 10,
+        status: 'pending',
+        services: [],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 0,
+        total: 100,
+        artist_id: 2,
+        client_id: 1,
+        booking_request_id: 1,
+        created_at: '',
+        updated_at: '',
+      },
+    });
+    (api.acceptQuoteV2 as jest.Mock).mockResolvedValue({ data: {} });
+    (api.createPayment as jest.Mock).mockResolvedValue({
+      data: { payment_id: 'pay_2' },
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const acceptBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Accept',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const payBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Pay',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      payBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const banner = container.querySelector('[data-testid="payment-status-banner"]');
+    expect(banner?.textContent).toMatch(/Deposit.*50/);
+    const link = document.querySelector('[data-testid="booking-receipt-link"]');
+    expect(link).not.toBeNull();
+  });
+
   it('shows an alert when the WebSocket fails', async () => {
     await act(async () => {
       root.render(<MessageThread bookingRequestId={1} />);

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -8,7 +8,9 @@ jest.mock('@/lib/api');
 
 describe('PaymentModal', () => {
   it('submits payment', async () => {
-    (api.createPayment as jest.Mock).mockResolvedValue({ data: {} });
+    (api.createPayment as jest.Mock).mockResolvedValue({
+      data: { payment_id: 'pay_1' },
+    });
     const onSuccess = jest.fn();
     const div = document.createElement('div');
     const root = createRoot(div);
@@ -26,16 +28,16 @@ describe('PaymentModal', () => {
     });
     const input = div.querySelector('input[type="number"]') as HTMLInputElement;
     expect(input.value).toBe('50');
-    await act(async () => {
-      input.value = '25';
-      input.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
-    });
     const button = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Pay') as HTMLButtonElement;
     await act(async () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(api.createPayment).toHaveBeenCalled();
-    expect(onSuccess).toHaveBeenCalledWith('deposit_paid');
+    expect(onSuccess).toHaveBeenCalledWith({
+      status: 'deposit_paid',
+      amount: 50,
+      receiptUrl: '/api/v1/payments/pay_1/receipt',
+    });
     root.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- extend `PaymentModal` success handling to return amount and receipt URL
- store payment amount/receipt in `MessageThread` and show deposit paid banner
- display a receipt link in the payment status banner
- adjust unit tests for updated payment workflow

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851b4583b40832e946e7d4eba2d2439