### PR TITLE
Add deposit info and timeline to client bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
+- Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.
 - Google Maps and large images load lazily once in view to reduce first paint time.

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -18,7 +18,7 @@ describe('ClientBookingsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('renders upcoming and past bookings', async () => {
+  it('renders upcoming and past bookings with deposit info', async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
       user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
@@ -36,6 +36,8 @@ describe('ClientBookingsPage', () => {
             status: 'confirmed',
             total_price: 100,
             notes: '',
+            deposit_amount: 50,
+            payment_status: 'deposit_paid',
             service: { title: 'Gig' },
             client: { id: 1 },
           },
@@ -53,6 +55,8 @@ describe('ClientBookingsPage', () => {
             status: 'completed',
             total_price: 200,
             notes: '',
+            deposit_amount: 100,
+            payment_status: 'paid',
             service: { title: 'Gig' },
             client: { id: 1 },
           },
@@ -74,6 +78,10 @@ describe('ClientBookingsPage', () => {
     expect(getMyClientBookings).toHaveBeenCalledWith({ status: 'past' });
     expect(div.textContent).toContain('Upcoming Bookings');
     expect(div.textContent).toContain('Past Bookings');
+    expect(div.textContent).toContain('Deposit:');
+    expect(div.textContent).toContain('Deposit Paid');
+    expect(div.textContent).toContain('Requested');
+    expect(div.textContent).toContain('Completed');
 
     act(() => {
       root.unmount();
@@ -100,6 +108,8 @@ describe('ClientBookingsPage', () => {
             status: 'completed',
             total_price: 100,
             notes: '',
+            deposit_amount: 50,
+            payment_status: 'deposit_paid',
             service: { title: 'Gig' },
             client: { id: 1 },
           },

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -46,6 +46,37 @@ function BookingList({
               {formatCurrency(Number(b.total_price))}
             </span>
           </div>
+          {b.deposit_amount !== undefined && (
+            <div className="text-sm text-gray-500 mt-1">
+              Deposit: {formatCurrency(Number(b.deposit_amount || 0))} (
+              {b.payment_status})
+            </div>
+          )}
+          <div className="flex justify-between text-xs text-gray-500 mt-2">
+            {['Requested', 'Confirmed', 'Deposit Paid',
+              b.status === 'cancelled' ? 'Cancelled' : 'Completed'].map(
+              (step, idx) => {
+                const activeIdx =
+                  b.status === 'pending'
+                    ? 0
+                    : b.status === 'confirmed'
+                      ? b.payment_status === 'deposit_paid' || b.payment_status === 'paid'
+                        ? 2
+                        : 1
+                      : 3;
+                return (
+                  <span
+                    key={step}
+                    className={
+                      idx <= activeIdx ? 'font-semibold text-indigo-600 flex-1 text-center' : 'flex-1 text-center'
+                    }
+                  >
+                    {step}
+                  </span>
+                );
+              },
+            )}
+          </div>
           {b.status === 'completed' && !b.review && (
             <button
               type="button"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,6 +64,10 @@ export interface Booking {
   status: "pending" | "confirmed" | "completed" | "cancelled";
   total_price: number;
   notes: string;
+  /** Amount paid as a deposit toward this booking */
+  deposit_amount?: number | null;
+  /** Current payment status, e.g. 'pending', 'deposit_paid', 'paid' */
+  payment_status?: string;
   artist: ArtistProfile;
   client: User;
   service: Service;


### PR DESCRIPTION
## Summary
- extend `Booking` type with optional deposit fields
- show deposit amount and payment status on client bookings list
- display horizontal timeline of booking progress
- update tests for new UI elements
- document feature in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851c2b83054832ebb13a14db754f001