### PR TITLE
Add HelpPrompt component

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,3 +797,9 @@ Update these colors in `frontend/tailwind.config.js` and
 config also scans `src/styles/**/*` so constants like `buttonVariants.ts` are
 included in the final build. See `frontend/README.md` for detailed theming
 instructions.
+
+### Help Prompt
+
+The `HelpPrompt` component renders quick links to the FAQ and contact page. It
+appears beneath the booking confirmation banner in chat and at the bottom of the
+client bookings page so users always know where to get assistance.

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -82,6 +82,8 @@ describe('ClientBookingsPage', () => {
     expect(div.textContent).toContain('Deposit Paid');
     expect(div.textContent).toContain('Requested');
     expect(div.textContent).toContain('Completed');
+    const help = div.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
 
     act(() => {
       root.unmount();
@@ -126,6 +128,8 @@ describe('ClientBookingsPage', () => {
     await act(async () => { await Promise.resolve(); });
 
     expect(div.textContent).toContain('Leave review');
+    const help = div.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
 
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -8,6 +8,7 @@ import type { Booking, Review } from '@/types';
 import ReviewFormModal from '@/components/review/ReviewFormModal';
 import { format } from 'date-fns';
 import { formatCurrency } from '@/lib/utils';
+import { HelpPrompt } from '@/components/ui';
 
 interface BookingWithReview extends Booking {
   review?: Review | null;
@@ -185,6 +186,7 @@ export default function ClientBookingsPage() {
             <BookingList items={past} onReview={handleOpenReview} />
           )}
         </section>
+        <HelpPrompt />
       </div>
       {reviewId && (
         <ReviewFormModal

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl, formatCurrency } from '@/lib/utils';
+import HelpPrompt from '../ui/HelpPrompt';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Booking, Message, MessageCreate, QuoteV2 } from '@/types';
@@ -473,6 +474,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 Add to calendar
               </button>
             )}
+            <HelpPrompt />
           </>
         )}
         {paymentStatus && (

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -479,6 +479,8 @@ describe('MessageThread component', () => {
     expect(viewLink).not.toBeNull();
     const dashboardLink = container.querySelector('a[href="/dashboard/client/bookings"]');
     expect(dashboardLink).not.toBeNull();
+    const help = container.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
   });
 
   it('opens payment modal after accepting quote', async () => {
@@ -536,6 +538,8 @@ describe('MessageThread component', () => {
     expect(payBtn).not.toBeNull();
     const calBtn = container.querySelector('[data-testid="add-calendar-button"]');
     expect(calBtn).not.toBeNull();
+    const help = container.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
   });
 
   it('falls back to legacy endpoint when accept fails', async () => {

--- a/frontend/src/components/ui/HelpPrompt.tsx
+++ b/frontend/src/components/ui/HelpPrompt.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Link from 'next/link';
+import clsx from 'clsx';
+
+interface HelpPromptProps {
+  className?: string;
+}
+
+export default function HelpPrompt({ className }: HelpPromptProps) {
+  return (
+    <div
+      className={clsx(
+        'mt-4 rounded-lg bg-indigo-50 p-4 text-sm text-indigo-900 flex flex-col sm:flex-row sm:items-center sm:justify-between',
+        className,
+      )}
+      data-testid="help-prompt"
+    >
+      <span className="font-medium">Need help?</span>
+      <span className="mt-2 flex gap-4 sm:mt-0">
+        <Link href="/faq" className="text-indigo-600 hover:underline">
+          FAQ
+        </Link>
+        <Link href="/contact" className="text-indigo-600 hover:underline">
+          Contact support
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -6,3 +6,4 @@ export { default as TextInput } from './TextInput';
 export { default as Toast } from './Toast';
 export { default as TimeAgo } from './TimeAgo';
 export { default as BottomSheet } from './BottomSheet';
+export { default as HelpPrompt } from './HelpPrompt';


### PR DESCRIPTION
## Summary
- create HelpPrompt component with FAQ and contact links
- show HelpPrompt under booking confirmation banner and on client bookings page
- document the HelpPrompt component
- update related unit tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68526f6d3448832eacb77b5d44d7718c