### PR TITLE
Implement booking details page and update deposit notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Payment processing now emits structured logs instead of printing to stdout so tr
 When a client accepts a quote in the chat thread, the frontend now prompts them to pay a deposit via this endpoint. Successful payments update the booking's `payment_status` and display a confirmation banner.
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
-Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings?booking_id={booking_id}` where they can complete the deposit.
+Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}` where they can complete the deposit.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -115,7 +115,7 @@ def notify_deposit_due(db: Session, user: Optional[User], booking_id: int) -> No
         user_id=user.id,
         type=NotificationType.DEPOSIT_DUE,
         message=message,
-        link=f"/dashboard/client/bookings?booking_id={booking_id}",
+        link=f"/dashboard/client/bookings/{booking_id}",
     )
     logger.info("Notify %s: %s", user.email, message)
     _send_sms(user.phone_number, message)

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -388,4 +388,4 @@ def test_accept_quote_deposit_notification_link():
     from app.models import NotificationType
     notifs = crud_notification.get_notifications_for_user(db, client.id)
     deposit = next(n for n in notifs if n.type == NotificationType.DEPOSIT_DUE)
-    assert deposit.link == f"/dashboard/client/bookings?booking_id={booking.id}"
+    assert deposit.link == f"/dashboard/client/bookings/{booking.id}"

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import MainLayout from '@/components/layout/MainLayout';
+import PaymentModal from '@/components/booking/PaymentModal';
+import toast from '@/components/ui/Toast';
+import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
+import type { Booking } from '@/types';
+import { formatCurrency } from '@/lib/utils';
+
+export default function BookingDetailsPage() {
+  const params = useParams();
+  const id = Number(params.id);
+
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showPayment, setShowPayment] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    const fetchBooking = async () => {
+      try {
+        const res = await getBookingDetails(id);
+        setBooking(res.data);
+      } catch (err) {
+        console.error('Failed to load booking', err);
+        setError('Failed to load booking');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBooking();
+  }, [id]);
+
+  const handleDownload = useCallback(async () => {
+    if (!booking) return;
+    try {
+      const res = await downloadBookingIcs(booking.id);
+      const blob = new Blob([res.data], { type: 'text/calendar' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `booking-${booking.id}.ics`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Calendar download error', err);
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to download calendar',
+      );
+    }
+  }, [booking]);
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <div className="p-8">Loading...</div>
+      </MainLayout>
+    );
+  }
+
+  if (error || !booking) {
+    return (
+      <MainLayout>
+        <div className="p-8 text-red-600">{error || 'Booking not found'}</div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="max-w-xl mx-auto p-4 space-y-3">
+        <h1 className="text-xl font-semibold">{booking.service.title}</h1>
+        <p className="text-sm text-gray-700">
+          {new Date(booking.start_time).toLocaleString()}
+        </p>
+        {booking.deposit_amount !== undefined && (
+          <p className="text-sm text-gray-700">
+            Deposit: {formatCurrency(Number(booking.deposit_amount || 0))} (
+            {booking.payment_status})
+          </p>
+        )}
+        <div className="mt-2 space-x-4">
+          {booking.payment_status === 'pending' && (
+            <button
+              type="button"
+              onClick={() => setShowPayment(true)}
+              className="text-indigo-600 underline text-sm"
+              data-testid="pay-deposit-button"
+            >
+              Pay deposit
+            </button>
+          )}
+          {booking.status === 'confirmed' && (
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="text-indigo-600 underline text-sm"
+              data-testid="add-calendar-button"
+            >
+              Add to calendar
+            </button>
+          )}
+          <Link
+            href="/dashboard/client/bookings"
+            className="text-indigo-600 underline text-sm"
+          >
+            Back to bookings
+          </Link>
+        </div>
+      </div>
+      <PaymentModal
+        open={showPayment}
+        onClose={() => setShowPayment(false)}
+        bookingRequestId={booking.source_quote?.booking_request_id || booking.id}
+        depositAmount={booking.deposit_amount || undefined}
+        onSuccess={() => {
+          setBooking({ ...booking, payment_status: 'deposit_paid' });
+          setShowPayment(false);
+        }}
+        onError={() => {}}
+      />
+    </MainLayout>
+  );
+}

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import BookingDetailsPage from '../[id]/page';
+import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
+import { useParams, usePathname } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard/client/bookings/1'),
+}));
+
+describe('BookingDetailsPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders booking details and shows pay button when pending', async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: '1' });
+    (getBookingDetails as jest.Mock).mockResolvedValue({
+      data: {
+        id: 1,
+        artist_id: 2,
+        client_id: 3,
+        service_id: 4,
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        status: 'confirmed',
+        total_price: 100,
+        notes: '',
+        deposit_amount: 50,
+        payment_status: 'pending',
+        service: { title: 'Gig' },
+        client: { id: 3 },
+      },
+    });
+    (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
+
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<BookingDetailsPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(getBookingDetails).toHaveBeenCalledWith(1);
+    expect(div.textContent).toContain('Gig');
+    const pay = div.querySelector('[data-testid="pay-deposit-button"]');
+    expect(pay).not.toBeNull();
+
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- create client booking details page with Pay deposit and calendar actions
- adjust MainLayout nav links implicitly via test setups
- add BookingDetailsPage tests
- link deposit notifications directly to booking details
- update README about deposit links

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685279351770832e923b175d0252e3b6