### PR TITLE
Add deposit payment button on bookings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ When a client accepts a quote in the chat thread, the frontend now prompts them 
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
 Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}` where they can complete the deposit.
+Clients can also pay outstanding deposits later from the bookings page via the **Pay deposit** button.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import BookingDetailsPage from '../[id]/page';
 import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
-import { useParams, usePathname } from 'next/navigation';
+import { useParams } from 'next/navigation';
 
 jest.mock('@/lib/api');
 jest.mock('next/navigation', () => ({


### PR DESCRIPTION
## Summary
- allow paying deposit from the bookings list
- fetch booking details and open PaymentModal
- test deposit flow from bookings page
- document paying deposits directly from bookings page

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68527b44538c832e8f7d99ee714c3adf