### PR TITLE
Fix payment modal deposit defaults

### DIFF
--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -118,7 +118,7 @@ export default function BookingDetailsPage() {
         open={showPayment}
         onClose={() => setShowPayment(false)}
         bookingRequestId={booking.source_quote?.booking_request_id || booking.id}
-        depositAmount={booking.deposit_amount || undefined}
+        depositAmount={booking.deposit_amount}
         onSuccess={() => {
           setBooking({ ...booking, payment_status: 'deposit_paid' });
           setShowPayment(false);

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -241,7 +241,11 @@ export default function ClientBookingsPage() {
         <PaymentModal
           open={showPayment}
           bookingRequestId={paymentBookingRequestId}
-          depositAmount={paymentDeposit}
+          depositAmount={
+            paymentDeposit !== undefined
+              ? paymentDeposit
+              : [...upcoming, ...past].find((b) => b.id === paymentBookingId)?.deposit_amount
+          }
           onClose={() => setShowPayment(false)}
           onSuccess={(result) => {
             setUpcoming((prev) =>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -806,7 +806,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               setDepositAmount(undefined);
             }}
             bookingRequestId={bookingRequestId}
-            depositAmount={depositAmount}
+            depositAmount={
+              depositAmount !== undefined
+                ? depositAmount
+                : bookingDetails?.deposit_amount
+            }
             onSuccess={({ status, amount, receiptUrl: url }) => {
               setPaymentStatus(status);
               setPaymentAmount(amount);

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -34,8 +34,8 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
   const modalRef = useRef<HTMLFormElement | null>(null);
 
   useEffect(() => {
-    if (open && depositAmount !== undefined) {
-      setAmount(depositAmount.toString());
+    if (open) {
+      setAmount(depositAmount !== undefined ? depositAmount.toString() : '');
     }
   }, [depositAmount, open]);
 

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -72,4 +72,55 @@ describe('PaymentModal', () => {
     });
     root.unmount();
   });
+
+  it('prefills amount from prop when reopened', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <PaymentModal
+          open
+          bookingRequestId={3}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          onError={() => {}}
+          depositAmount={40}
+        />,
+      );
+    });
+    const input = div.querySelector('input[type="number"]') as HTMLInputElement;
+    act(() => {
+      input.value = '75';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await act(async () => {
+      root.render(
+        <PaymentModal
+          open={false}
+          bookingRequestId={3}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          onError={() => {}}
+          depositAmount={40}
+        />,
+      );
+    });
+
+    await act(async () => {
+      root.render(
+        <PaymentModal
+          open
+          bookingRequestId={3}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          onError={() => {}}
+          depositAmount={40}
+        />,
+      );
+    });
+    const reopened = div.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(reopened.value).toBe('40');
+    root.unmount();
+  });
 });


### PR DESCRIPTION
## Summary
- reset PaymentModal amount from props whenever it opens
- fallback to booking details deposit when depositAmount state is undefined
- test reopening PaymentModal retains default deposit

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68527fedf9f0832eb21ecd7f50d63848