### PR TITLE
Store payment IDs and show receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
+- Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.

--- a/backend/alembic/versions/ae1027e1d3a1_add_payment_id_to_booking_simple.py
+++ b/backend/alembic/versions/ae1027e1d3a1_add_payment_id_to_booking_simple.py
@@ -1,0 +1,22 @@
+"""add_payment_id_to_booking_simple
+
+Revision ID: ae1027e1d3a1
+Revises: 9b1c0d4a7c3c
+Create Date: 2025-07-25 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ae1027e1d3a1'
+down_revision: Union[str, None] = '9b1c0d4a7c3c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('bookings_simple', sa.Column('payment_id', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('bookings_simple', 'payment_id')

--- a/backend/app/api/api_payment.py
+++ b/backend/app/api/api_payment.py
@@ -59,6 +59,7 @@ def create_payment(
     booking.deposit_amount = Decimal(str(payment_in.amount))
     booking.deposit_paid = True
     booking.payment_status = "paid" if payment_in.full else "deposit_paid"
+    booking.payment_id = charge.get("id")
     db.commit()
     db.refresh(booking)
 

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -138,6 +138,12 @@ def ensure_booking_simple_columns(engine: Engine) -> None:
     add_column_if_missing(
         engine,
         "bookings_simple",
+        "payment_id",
+        "payment_id VARCHAR",
+    )
+    add_column_if_missing(
+        engine,
+        "bookings_simple",
         "deposit_amount",
         "deposit_amount NUMERIC(10, 2)"
     )

--- a/backend/app/models/booking_simple.py
+++ b/backend/app/models/booking_simple.py
@@ -23,6 +23,7 @@ class BookingSimple(BaseModel):
     date = Column(DateTime, nullable=True)
     location = Column(String, nullable=True)
     payment_status = Column(String, nullable=False, default="pending")
+    payment_id = Column(String, nullable=True)
     deposit_amount = Column(Numeric(10, 2), nullable=True, default=0)
     deposit_paid = Column(Boolean, nullable=False, default=False)
 

--- a/backend/app/schemas/quote_v2.py
+++ b/backend/app/schemas/quote_v2.py
@@ -46,6 +46,7 @@ class BookingSimpleRead(BaseModel):
     date: Optional[datetime] = None
     location: Optional[str] = None
     payment_status: str
+    payment_id: Optional[str] = None
     deposit_amount: Optional[Decimal] = None
     deposit_paid: bool
     created_at: datetime

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -129,6 +129,7 @@ def test_booking_simple_columns():
     assert "date" in column_names
     assert "location" in column_names
     assert "payment_status" in column_names
+    assert "payment_id" in column_names
     assert "deposit_amount" in column_names
     assert "deposit_paid" in column_names
 

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -110,6 +110,7 @@ def test_create_deposit(monkeypatch):
     assert booking.deposit_amount == Decimal('50')
     assert booking.deposit_paid is True
     assert booking.payment_status == 'deposit_paid'
+    assert booking.payment_id == 'ch_test'
     db.close()
     if prev_db is not None:
         app.dependency_overrides[get_db] = prev_db

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -85,6 +85,19 @@ export default function BookingDetailsPage() {
             {booking.payment_status})
           </p>
         )}
+        {booking.payment_id && (
+          <p>
+            <a
+              href={`/api/v1/payments/${booking.payment_id}/receipt`}
+              target="_blank"
+              rel="noopener"
+              className="text-indigo-600 underline text-sm"
+              data-testid="booking-receipt-link"
+            >
+              View receipt
+            </a>
+          </p>
+        )}
         <div className="mt-2 space-x-4">
           {booking.payment_status === 'pending' && (
             <button
@@ -119,8 +132,12 @@ export default function BookingDetailsPage() {
         onClose={() => setShowPayment(false)}
         bookingRequestId={booking.source_quote?.booking_request_id || booking.id}
         depositAmount={booking.deposit_amount}
-        onSuccess={() => {
-          setBooking({ ...booking, payment_status: 'deposit_paid' });
+        onSuccess={({ paymentId }) => {
+          setBooking({
+            ...booking,
+            payment_status: 'deposit_paid',
+            payment_id: paymentId ?? booking.payment_id,
+          });
           setShowPayment(false);
         }}
         onError={() => {}}

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -52,4 +52,41 @@ describe('BookingDetailsPage', () => {
     act(() => { root.unmount(); });
     div.remove();
   });
+
+  it('shows receipt link when payment_id is present', async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: '2' });
+    (getBookingDetails as jest.Mock).mockResolvedValue({
+      data: {
+        id: 2,
+        artist_id: 2,
+        client_id: 3,
+        service_id: 4,
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        status: 'confirmed',
+        total_price: 100,
+        notes: '',
+        deposit_amount: 50,
+        payment_status: 'deposit_paid',
+        payment_id: 'pay_123',
+        service: { title: 'Gig' },
+        client: { id: 3 },
+      },
+    });
+    (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
+
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<BookingDetailsPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const link = div.querySelector('[data-testid="booking-receipt-link"]');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute('href')).toBe('/api/v1/payments/pay_123/receipt');
+
+    act(() => { root.unmount(); });
+    div.remove();
+  });
 });

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -6,6 +6,7 @@ interface PaymentSuccess {
   status: string;
   amount: number;
   receiptUrl?: string;
+  paymentId?: string;
 }
 
 interface PaymentModalProps {
@@ -89,6 +90,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
         status: full ? 'paid' : 'deposit_paid',
         amount: Number(amount),
         receiptUrl,
+        paymentId,
       });
     } catch (err) {
       console.error('Failed to create payment', err);

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -37,6 +37,7 @@ describe('PaymentModal', () => {
       status: 'deposit_paid',
       amount: 50,
       receiptUrl: '/api/v1/payments/pay_1/receipt',
+      paymentId: 'pay_1',
     });
     root.unmount();
   });
@@ -69,6 +70,7 @@ describe('PaymentModal', () => {
       status: 'deposit_paid',
       amount: 30,
       receiptUrl: '/api/v1/payments/pay_2/receipt',
+      paymentId: 'pay_2',
     });
     root.unmount();
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,8 @@ export interface Booking {
   deposit_amount?: number | null;
   /** Current payment status, e.g. 'pending', 'deposit_paid', 'paid' */
   payment_status?: string;
+  /** ID from the payment gateway used to fetch receipts */
+  payment_id?: string | null;
   artist: ArtistProfile;
   client: User;
   service: Service;


### PR DESCRIPTION
## Summary
- track payment_id on BookingSimple model and schema
- save payment_id when creating payments
- add migration and DB util for payment_id
- show receipt links in booking details
- expose paymentId via PaymentModal and update booking on success
- document receipt tracking in README
- test persistence and UI receipt link

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685281d7abb8832ea18a08ff17184cf5