### PR TITLE
Update booking link path

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -449,7 +449,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               View booking
             </Link>
             <Link
-              href="/dashboard/client/bookings"
+              href={
+                bookingDetails
+                  ? `/dashboard/client/bookings/${bookingDetails.id}`
+                  : '/dashboard/client/bookings'
+              }
               aria-label="Go to My Bookings"
               data-testid="my-bookings-link"
               className="mt-2 ml-4 inline-block text-indigo-600 hover:underline text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -473,11 +473,16 @@ describe('MessageThread component', () => {
     await act(async () => {
       await Promise.resolve();
     });
+    await act(async () => {
+      await Promise.resolve();
+    });
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
     const viewLink = container.querySelector('a[href="/booking-requests/1"]');
     expect(viewLink).not.toBeNull();
-    const dashboardLink = container.querySelector('a[href="/dashboard/client/bookings"]');
+    const dashboardLink = container.querySelector(
+      'a[href="/dashboard/client/bookings/1"]',
+    );
     expect(dashboardLink).not.toBeNull();
     const help = container.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();
@@ -497,6 +502,14 @@ describe('MessageThread component', () => {
           timestamp: new Date().toISOString(),
         },
       ],
+    });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({
+      data: {
+        id: 42,
+        service: { title: 'Gig' },
+        start_time: '2024-01-01T00:00:00Z',
+        deposit_amount: 50,
+      },
     });
     (api.getQuoteV2 as jest.Mock).mockResolvedValue({
       data: {
@@ -521,7 +534,14 @@ describe('MessageThread component', () => {
     await act(async () => {
       await Promise.resolve();
     });
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(api.getBookingDetails).toHaveBeenCalledWith(42);
+    const dashboardLink = container.querySelector(
+      'a[href="/dashboard/client/bookings/42"]',
+    );
+    expect(dashboardLink).not.toBeNull();
   });
 
   it('opens payment modal after accepting quote', async () => {


### PR DESCRIPTION
## Summary
- navigate to booking detail after confirmation
- check new booking URL in tests when details loaded

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685287cac24c832ea02639bc50820683