### PR TITLE
Add HelpPrompt on booking details

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,5 +805,6 @@ instructions.
 ### Help Prompt
 
 The `HelpPrompt` component renders quick links to the FAQ and contact page. It
-appears beneath the booking confirmation banner in chat and at the bottom of the
-client bookings page so users always know where to get assistance.
+appears beneath the booking confirmation banner in chat, on the booking details
+page, and at the bottom of the client bookings page so users always know where
+to get assistance.

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import PaymentModal from '@/components/booking/PaymentModal';
 import toast from '@/components/ui/Toast';
+import { HelpPrompt } from '@/components/ui';
 import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
 import type { Booking } from '@/types';
 import { formatCurrency } from '@/lib/utils';
@@ -126,6 +127,7 @@ export default function BookingDetailsPage() {
             Back to bookings
           </Link>
         </div>
+        <HelpPrompt />
       </div>
       <PaymentModal
         open={showPayment}

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -89,4 +89,39 @@ describe('BookingDetailsPage', () => {
     act(() => { root.unmount(); });
     div.remove();
   });
+
+  it('renders the help prompt', async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: '3' });
+    (getBookingDetails as jest.Mock).mockResolvedValue({
+      data: {
+        id: 3,
+        artist_id: 2,
+        client_id: 3,
+        service_id: 4,
+        start_time: new Date().toISOString(),
+        end_time: new Date().toISOString(),
+        status: 'confirmed',
+        total_price: 100,
+        notes: '',
+        deposit_amount: 50,
+        payment_status: 'pending',
+        service: { title: 'Gig' },
+        client: { id: 3 },
+      },
+    });
+    (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
+
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<BookingDetailsPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const help = div.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
+
+    act(() => { root.unmount(); });
+    div.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- show HelpPrompt on individual booking details page
- extend BookingDetailsPage tests for HelpPrompt
- document new HelpPrompt location in README

## Testing
- `./scripts/test-all.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685289896f20832ea9c8b93bbad1d764