### PR TITLE
Implement half-deposit on quote acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
+  The deposit amount defaults to half of the accepted quote total.
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -121,7 +121,7 @@ def accept_quote(db: Session, quote_id: int) -> models.BookingSimple:
         confirmed=True,
         # No charge is triggered yet; payment will be collected later
         payment_status="pending",
-        deposit_amount=0,
+        deposit_amount=db_quote.total * Decimal("0.5"),
         deposit_paid=False,
     )
     db.add(booking)

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -98,7 +98,7 @@ def test_create_and_accept_quote():
     assert booking.client_id == client.id
     assert booking.confirmed is True
     assert booking.payment_status == "pending"
-    assert booking.deposit_amount == 0
+    assert booking.deposit_amount == quote.total * Decimal("0.5")
     assert booking.deposit_paid is False
 
     db_booking = db.query(Booking).filter(Booking.quote_id == quote.id).first()


### PR DESCRIPTION
## Summary
- set `BookingSimple.deposit_amount` to half of quote total when accepting a quote
- test that deposit amount equals 50% of quote total
- document deposit default in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68528ef6ced0832ea03fce588435f9dd