### PR TITLE
Update booking link in MessageThread

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -441,7 +441,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
         {bookingConfirmed && (
           <>
             <Link
-              href={`/booking-requests/${bookingRequestId}`}
+              href={
+                bookingDetails
+                  ? `/dashboard/client/bookings/${bookingDetails.id}`
+                  : `/booking-requests/${bookingRequestId}`
+              }
               aria-label="View booking details"
               data-testid="view-booking-link"
               className="mt-2 inline-block text-indigo-600 hover:underline text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -478,7 +478,9 @@ describe('MessageThread component', () => {
     });
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
-    const viewLink = container.querySelector('a[href="/booking-requests/1"]');
+    const viewLink = container.querySelector(
+      'a[href="/dashboard/client/bookings/1"]',
+    );
     expect(viewLink).not.toBeNull();
     const dashboardLink = container.querySelector(
       'a[href="/dashboard/client/bookings/1"]',


### PR DESCRIPTION
## Summary
- link to dashboard booking details when booking info is available
- adjust MessageThread test to expect the new path

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68528fce30b4832e8d4943fde81343ef