### PR TITLE
Handle deposit and booking alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
+* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -91,6 +91,24 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       metadata,
     };
   }
+  if (/deposit payment due/i.test(n.content) || /deposit due/i.test(n.content)) {
+    const subtitle =
+      n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;
+    return {
+      title: 'Deposit Due',
+      subtitle,
+      icon: '💰',
+    };
+  }
+  if (/new booking/i.test(n.content)) {
+    const subtitle =
+      n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;
+    return {
+      title: 'Booking Confirmed',
+      subtitle,
+      icon: '📅',
+    };
+  }
   if (/quote accepted/i.test(n.content)) {
     const match = n.content.match(/Quote accepted by (.+)/i);
     const rawTitle = match ? `Quote accepted by ${match[1]}` : 'Quote accepted';

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import NotificationListItem from '../NotificationListItem';
+import NotificationListItem, { parseItem } from '../NotificationListItem';
 import type { UnifiedNotification } from '@/types';
 
 const baseNotification: UnifiedNotification = {
@@ -41,5 +41,29 @@ describe('NotificationListItem', () => {
     });
     const span = container.querySelector('span[title]');
     expect(span?.getAttribute('title')).toBe('Alice');
+  });
+
+  it('parses deposit due notifications', () => {
+    const n: UnifiedNotification = {
+      type: 'deposit_due',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Deposit payment due for booking #5',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.title).toBe('Deposit Due');
+    expect(parsed.icon).toBe('💰');
+  });
+
+  it('parses new booking notifications', () => {
+    const n: UnifiedNotification = {
+      type: 'new_booking',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'New booking #5 confirmed',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.title).toBe('Booking Confirmed');
+    expect(parsed.icon).toBe('📅');
   });
 });


### PR DESCRIPTION
## Summary
- parse deposit-due and new-booking notifications in `parseItem`
- test the new parsing cases
- document icons for deposit and booking alerts

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685293ca6b68832ea7daaf42f21824a9