### PR TITLE
Add Message Artist links to booking pages

### DIFF
--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -120,6 +120,15 @@ export default function BookingDetailsPage() {
               Add to calendar
             </button>
           )}
+          {booking.source_quote?.booking_request_id && (
+            <Link
+              href={`/booking-requests/${booking.source_quote.booking_request_id}`}
+              className="text-indigo-600 underline text-sm"
+              data-testid="message-artist-link"
+            >
+              Message Artist
+            </Link>
+          )}
           <Link
             href="/dashboard/client/bookings"
             className="text-indigo-600 underline text-sm"

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -112,6 +112,15 @@ function BookingList({
               You rated {b.review.rating}/5
             </p>
           )}
+          {b.source_quote?.booking_request_id && (
+            <Link
+              href={`/booking-requests/${b.source_quote.booking_request_id}`}
+              className="mt-2 text-indigo-600 hover:underline text-sm"
+              data-testid="message-artist-link"
+            >
+              Message Artist
+            </Link>
+          )}
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- link to booking request thread from booking details page
- show same "Message Artist" link in client bookings list
- test message artist links on booking pages

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852990ca078832e8827118044056ea6