### PR TITLE
Add deposit due date to bookings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
   The deposit amount defaults to half of the accepted quote total.
+- A new `deposit_due_by` field records when the deposit should be paid.
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.

--- a/backend/alembic/versions/c8f4f76b2a6b_add_deposit_due_by_to_booking_simple.py
+++ b/backend/alembic/versions/c8f4f76b2a6b_add_deposit_due_by_to_booking_simple.py
@@ -1,0 +1,22 @@
+"""add deposit_due_by column to booking_simple
+
+Revision ID: c8f4f76b2a6b
+Revises: ae1027e1d3a1
+Create Date: 2025-08-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'c8f4f76b2a6b'
+down_revision: Union[str, None] = 'ae1027e1d3a1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('bookings_simple', sa.Column('deposit_due_by', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('bookings_simple', 'deposit_due_by')

--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -12,6 +12,7 @@ from ..models.user import User, UserType
 from ..models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
 from ..models.service import Service
 from ..models.booking import Booking, BookingStatus
+from ..models.booking_simple import BookingSimple
 from ..schemas.booking import BookingCreate, BookingUpdate, BookingResponse
 from .dependencies import (
     get_current_user,
@@ -258,6 +259,14 @@ def read_booking_details(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have permission to view this booking.",
         )
+
+    simple = (
+        db.query(BookingSimple)
+        .filter(BookingSimple.quote_id == booking.quote_id)
+        .first()
+    )
+    if simple:
+        booking.deposit_due_by = simple.deposit_due_by
 
     return booking
 

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -122,6 +123,7 @@ def accept_quote(db: Session, quote_id: int) -> models.BookingSimple:
         # No charge is triggered yet; payment will be collected later
         payment_status="pending",
         deposit_amount=db_quote.total * Decimal("0.5"),
+        deposit_due_by=db_quote.created_at + timedelta(days=7),
         deposit_paid=False,
     )
     db.add(booking)

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -150,6 +150,12 @@ def ensure_booking_simple_columns(engine: Engine) -> None:
     add_column_if_missing(
         engine,
         "bookings_simple",
+        "deposit_due_by",
+        "deposit_due_by DATETIME"
+    )
+    add_column_if_missing(
+        engine,
+        "bookings_simple",
         "deposit_paid",
         "deposit_paid BOOLEAN NOT NULL DEFAULT FALSE",
     )

--- a/backend/app/models/booking_simple.py
+++ b/backend/app/models/booking_simple.py
@@ -25,6 +25,7 @@ class BookingSimple(BaseModel):
     payment_status = Column(String, nullable=False, default="pending")
     payment_id = Column(String, nullable=True)
     deposit_amount = Column(Numeric(10, 2), nullable=True, default=0)
+    deposit_due_by = Column(DateTime, nullable=True)
     deposit_paid = Column(Boolean, nullable=False, default=False)
 
     quote = relationship("QuoteV2")

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -37,6 +37,7 @@ class BookingResponse(BookingBase):
     total_price: Annotated[Decimal, Field()]
     created_at: datetime
     updated_at: datetime
+    deposit_due_by: Optional[datetime] = None
 
     # Include nested details for frontend dashboard
     client: Optional[UserResponse] = None

--- a/backend/app/schemas/quote_v2.py
+++ b/backend/app/schemas/quote_v2.py
@@ -49,6 +49,7 @@ class BookingSimpleRead(BaseModel):
     payment_status: str
     payment_id: Optional[str] = None
     deposit_amount: Optional[Decimal] = None
+    deposit_due_by: Optional[datetime] = None
     deposit_paid: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -99,14 +99,14 @@ def test_create_and_accept_quote():
     assert booking.confirmed is True
     assert booking.payment_status == "pending"
     assert booking.deposit_amount == quote.total * Decimal("0.5")
+    from datetime import timedelta
+    assert booking.deposit_due_by == quote.created_at + timedelta(days=7)
     assert booking.deposit_paid is False
 
     db_booking = db.query(Booking).filter(Booking.quote_id == quote.id).first()
     assert db_booking is not None
     assert db_booking.service_id == service.id
     assert db_booking.start_time == br.proposed_datetime_1
-    from datetime import timedelta
-
     assert db_booking.end_time == br.proposed_datetime_1 + timedelta(
         minutes=service.duration_minutes
     )

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -86,6 +86,11 @@ export default function BookingDetailsPage() {
             {booking.payment_status})
           </p>
         )}
+        {booking.deposit_due_by && (
+          <p className="text-sm text-gray-700">
+            Deposit due by {new Date(booking.deposit_due_by).toLocaleDateString()}
+          </p>
+        )}
         {booking.payment_id && (
           <p>
             <a

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -36,6 +36,7 @@ describe('BookingDetailsPage', () => {
         total_price: 100,
         notes: '',
         deposit_amount: 50,
+        deposit_due_by: new Date('2024-01-08').toISOString(),
         payment_status: 'pending',
         service: { title: 'Gig' },
         client: { id: 3 },
@@ -52,6 +53,7 @@ describe('BookingDetailsPage', () => {
 
     expect(getBookingDetails).toHaveBeenCalledWith(1);
     expect(div.textContent).toContain('Gig');
+    expect(div.textContent).toContain('Deposit due');
     const pay = div.querySelector('[data-testid="pay-deposit-button"]');
     expect(pay).not.toBeNull();
 
@@ -73,6 +75,7 @@ describe('BookingDetailsPage', () => {
         total_price: 100,
         notes: '',
         deposit_amount: 50,
+        deposit_due_by: new Date('2024-01-08').toISOString(),
         payment_status: 'deposit_paid',
         payment_id: 'pay_123',
         service: { title: 'Gig' },
@@ -110,6 +113,7 @@ describe('BookingDetailsPage', () => {
         total_price: 100,
         notes: '',
         deposit_amount: 50,
+        deposit_due_by: new Date('2024-01-08').toISOString(),
         payment_status: 'pending',
         service: { title: 'Gig' },
         client: { id: 3 },
@@ -145,6 +149,7 @@ describe('BookingDetailsPage', () => {
         total_price: 100,
         notes: '',
         deposit_amount: 50,
+        deposit_due_by: new Date('2024-01-08').toISOString(),
         payment_status: 'deposit_paid',
         service: { title: 'Gig' },
         client: { id: 3 },

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -433,7 +433,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 {bookingDetails.service?.title} on{' '}
                 {new Date(bookingDetails.start_time).toLocaleString()}. Deposit{' '}
                 {formatCurrency(depositAmount ?? bookingDetails.deposit_amount ?? 0)}
-                {' '}due.
+                {bookingDetails.deposit_due_by
+                  ? ` due by ${new Date(bookingDetails.deposit_due_by).toLocaleDateString()}`
+                  : ' due.'}
               </>
             )}
           </div>

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -50,6 +50,7 @@ describe('MessageThread component', () => {
         service: { title: 'Gig' },
         start_time: '2024-01-01T00:00:00Z',
         deposit_amount: 50,
+        deposit_due_by: '2024-01-08T00:00:00Z',
       },
     });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
@@ -478,6 +479,7 @@ describe('MessageThread component', () => {
     });
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
+    expect(banner?.textContent).toContain('due by');
     const viewLink = container.querySelector(
       'a[href="/dashboard/client/bookings/1"]',
     );
@@ -511,6 +513,7 @@ describe('MessageThread component', () => {
         service: { title: 'Gig' },
         start_time: '2024-01-01T00:00:00Z',
         deposit_amount: 50,
+        deposit_due_by: '2024-01-08T00:00:00Z',
       },
     });
     (api.getQuoteV2 as jest.Mock).mockResolvedValue({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -66,6 +66,8 @@ export interface Booking {
   notes: string;
   /** Amount paid as a deposit toward this booking */
   deposit_amount?: number | null;
+  /** Date when the deposit is due */
+  deposit_due_by?: string | null;
   /** Current payment status, e.g. 'pending', 'deposit_paid', 'paid' */
   payment_status?: string;
   /** ID from the payment gateway used to fetch receipts */
@@ -192,6 +194,7 @@ export interface BookingSimple {
   date?: string | null;
   location?: string | null;
   payment_status: string;
+  deposit_due_by?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- add `deposit_due_by` column to `BookingSimple`
- compute deposit due date when accepting a quote
- surface `deposit_due_by` on booking details endpoint and schemas
- show due date in booking confirmation and details UI
- update related backend and frontend tests
- document new field in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68529c12a1c4832e9ed88897c4e6e187