### PR TITLE
Add deposit amount and due date to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ When a client accepts a quote in the chat thread, the frontend now prompts them 
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
 Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}` where they can complete the deposit.
+The alert now displays the deposit amount and due date so clients know exactly what to pay and by when.
 Clients can also pay outstanding deposits later from the bookings page. Each
 pending booking shows a **Pay deposit** button that fetches the latest deposit
 amount from the server before opening the payment modal.

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -142,6 +142,12 @@ def accept_quote(db: Session, quote_id: int) -> models.BookingSimple:
     client = db_quote.client or db.query(models.User).get(db_quote.client_id)
     notify_quote_accepted(db, artist, db_quote.id, db_quote.booking_request_id)
     notify_new_booking(db, client, booking.id)
-    notify_deposit_due(db, client, booking.id)
+    notify_deposit_due(
+        db,
+        client,
+        booking.id,
+        float(booking.deposit_amount or 0),
+        booking.deposit_due_by,
+    )
 
     return booking

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,6 +1,6 @@
-import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from datetime import datetime
 
 from app.models import (
     User,
@@ -399,7 +399,9 @@ def test_status_update_creates_notification_for_client():
     db.refresh(br)
 
     update = BookingRequestUpdateByArtist(status=BookingRequestStatus.REQUEST_DECLINED)
-    api_booking_request.update_booking_request_by_artist(br.id, update, db, current_artist=artist)
+    api_booking_request.update_booking_request_by_artist(
+        br.id, update, db, current_artist=artist
+    )
 
     notifs = crud_notification.get_notifications_for_user(db, client.id)
     assert len(notifs) == 1
@@ -437,7 +439,9 @@ def test_status_update_creates_notification_for_artist():
     db.refresh(br)
 
     update = BookingRequestUpdateByClient(status=BookingRequestStatus.REQUEST_WITHDRAWN)
-    api_booking_request.update_booking_request_by_client(br.id, update, db, current_user=client)
+    api_booking_request.update_booking_request_by_client(
+        br.id, update, db, current_user=client
+    )
 
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
@@ -446,18 +450,19 @@ def test_status_update_creates_notification_for_artist():
 
 def test_format_notification_message_new_types():
     msg_deposit = format_notification_message(
-        NotificationType.DEPOSIT_DUE, booking_id=42
+        NotificationType.DEPOSIT_DUE,
+        booking_id=42,
+        deposit_amount=50.0,
+        deposit_due_by=datetime(2025, 1, 1),
     )
     msg_review = format_notification_message(
         NotificationType.REVIEW_REQUEST, booking_id=42
     )
-    msg_quote = format_notification_message(
-        NotificationType.QUOTE_ACCEPTED, quote_id=7
-    )
+    msg_quote = format_notification_message(NotificationType.QUOTE_ACCEPTED, quote_id=7)
     msg_booking = format_notification_message(
         NotificationType.NEW_BOOKING, booking_id=8
     )
-    assert msg_deposit == "Deposit payment due for booking #42"
+    assert msg_deposit == "Deposit of 50.00 due by 2025-01-01 for booking #42"
     assert msg_review == "Please review your booking #42"
     assert msg_quote == "Quote #7 accepted"
     assert msg_booking == "New booking #8"
@@ -547,4 +552,3 @@ def test_personalized_video_notifications_suppressed_until_final():
     notifs_after = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs_after) == 1
     assert notifs_after[0].type == NotificationType.NEW_BOOKING_REQUEST
-


### PR DESCRIPTION
## Summary
- include deposit amount and due date in DEPOSIT_DUE notification messages
- pass these fields when accepting a quote
- adjust tests for new message format
- document deposit alert details

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852a075cec8832eb2b5941d04927388