### PR TITLE
Add FAQ and contact pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,3 +823,8 @@ The `HelpPrompt` component renders quick links to the FAQ and contact page. It
 appears beneath the booking confirmation banner in chat, on the booking details
 page, and at the bottom of the client bookings page so users always know where
 to get assistance.
+
+### Support Pages
+
+Dedicated **FAQ** and **Contact** pages provide self-service help. They are
+accessible from the main navigation on desktop and through the mobile menu.

--- a/frontend/src/app/contact/__tests__/ContactPage.test.tsx
+++ b/frontend/src/app/contact/__tests__/ContactPage.test.tsx
@@ -1,0 +1,26 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import ContactPage from '../page';
+
+jest.mock('@/components/layout/MainLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
+
+describe('ContactPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders contact heading', async () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ContactPage />);
+    });
+    expect(div.textContent).toContain('Contact Support');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,0 +1,26 @@
+import MainLayout from '@/components/layout/MainLayout';
+import Link from 'next/link';
+
+export default function ContactPage() {
+  return (
+    <MainLayout>
+      <div className="prose max-w-2xl mx-auto">
+        <h1>Contact Support</h1>
+        <p>
+          Email us at{' '}
+          <a href="mailto:support@example.com" className="text-indigo-600 hover:underline">
+            support@example.com
+          </a>
+           and we'll get back to you shortly.
+        </p>
+        <p>
+          You can also check our{' '}
+          <Link href="/faq" className="text-indigo-600 hover:underline">
+            FAQ
+          </Link>
+           for quick answers.
+        </p>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/app/faq/__tests__/FaqPage.test.tsx
+++ b/frontend/src/app/faq/__tests__/FaqPage.test.tsx
@@ -1,0 +1,27 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import FaqPage from '../page';
+
+// simplify MainLayout for unit test
+jest.mock('@/components/layout/MainLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
+
+describe('FaqPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders FAQ heading', async () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<FaqPage />);
+    });
+    expect(div.textContent).toContain('Frequently Asked Questions');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/faq/page.tsx
+++ b/frontend/src/app/faq/page.tsx
@@ -1,0 +1,20 @@
+import MainLayout from '@/components/layout/MainLayout';
+import Link from 'next/link';
+
+export default function FaqPage() {
+  return (
+    <MainLayout>
+      <div className="prose max-w-2xl mx-auto">
+        <h1>Frequently Asked Questions</h1>
+        <p>Find answers to common questions about using our booking platform.</p>
+        <p>
+          Still need help?{' '}
+          <Link href="/contact" className="text-indigo-600 hover:underline">
+            Contact support
+          </Link>
+          .
+        </p>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -15,6 +15,8 @@ const baseNavigation = [
   { name: 'Home', href: '/' },
   { name: 'Artists', href: '/artists' },
   { name: 'Services', href: '/services' },
+  { name: 'FAQ', href: '/faq' },
+  { name: 'Contact', href: '/contact' },
 ];
 
 function classNames(...classes: string[]) {


### PR DESCRIPTION
## Summary
- add simple FAQ and contact pages under `frontend/src/app`
- include the routes in desktop and mobile navigation
- document support pages in README
- test new pages

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852ac3e4258832ea679fff61cbc9014