### PR TITLE
Parse deposit details from notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
-* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations.
+* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `50.00 due by Jan 1, 2025`.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
@@ -739,7 +739,7 @@ When a client accepts a quote in the chat thread, the frontend now prompts them 
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
 Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}?pay=1` where they can complete the deposit.
-The alert now displays the deposit amount and due date so clients know exactly what to pay and by when.
+The alert now displays the deposit amount and due date so clients know exactly what to pay and by when. The drawer also parses these values so the list shows `50.00 due by Jan 1, 2025` under the title.
 Clients can also pay outstanding deposits later from the bookings page. Each
 pending booking shows a **Pay deposit** button that fetches the latest deposit
 amount from the server before opening the payment modal.

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -91,9 +91,22 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       metadata,
     };
   }
-  if (/deposit payment due/i.test(n.content) || /deposit due/i.test(n.content)) {
-    const subtitle =
+  if (/deposit.*due/i.test(n.content)) {
+    let subtitle =
       n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;
+    const match = n.content.match(/Deposit of\s*([\d.,]+)\s*due(?:\s*by\s*(\d{4}-\d{2}-\d{2}))?/i);
+    if (match) {
+      const [, amt, dateStr] = match;
+      const parts: string[] = [];
+      if (amt) {
+        parts.push(`${amt}`);
+      }
+      if (dateStr) {
+        const formatted = format(new Date(dateStr), 'MMM d, yyyy');
+        parts.push(`due by ${formatted}`);
+      }
+      subtitle = parts.join(' ');
+    }
     return {
       title: 'Deposit Due',
       subtitle,

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -55,6 +55,18 @@ describe('NotificationListItem', () => {
     expect(parsed.icon).toBe('💰');
   });
 
+  it('extracts amount and due date from deposit reminder', () => {
+    const n: UnifiedNotification = {
+      type: 'deposit_due',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Deposit of 50.00 due by 2025-01-01 for booking #42',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.subtitle).toBe('50.00 due by Jan 1, 2025');
+    expect(parsed.icon).toBe('💰');
+  });
+
   it('parses new booking notifications', () => {
     const n: UnifiedNotification = {
       type: 'new_booking',


### PR DESCRIPTION
## Summary
- parse deposit amount and due date from notification messages
- show parsed values in NotificationListItem
- test parsing of deposit reminder notifications
- document drawer subtitle behavior for deposit reminders

## Testing
- `JEST_WORKERS=2 ./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852b762c26c832e98cef86c920fcbe7