### PR TITLE
Add deposit due date to PaymentModal

### DIFF
--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -153,6 +153,7 @@ export default function BookingDetailsPage() {
         onClose={() => setShowPayment(false)}
         bookingRequestId={booking.source_quote?.booking_request_id || booking.id}
         depositAmount={booking.deposit_amount}
+        depositDueBy={booking.deposit_due_by ?? undefined}
         onSuccess={({ paymentId }) => {
           setBooking({
             ...booking,

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -307,6 +307,10 @@ export default function ClientBookingsPage() {
               ? paymentDeposit
               : [...upcoming, ...past].find((b) => b.id === paymentBookingId)?.deposit_amount
           }
+          depositDueBy={
+            [...upcoming, ...past].find((b) => b.id === paymentBookingId)?.deposit_due_by ??
+            undefined
+          }
           onClose={() => setShowPayment(false)}
           onSuccess={(result) => {
             setUpcoming((prev) =>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -821,6 +821,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 ? depositAmount
                 : bookingDetails?.deposit_amount
             }
+            depositDueBy={bookingDetails?.deposit_due_by ?? undefined}
             onSuccess={({ status, amount, receiptUrl: url }) => {
               setPaymentStatus(status);
               setPaymentAmount(amount);

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -16,6 +16,7 @@ interface PaymentModalProps {
   onSuccess: (result: PaymentSuccess) => void;
   onError: (msg: string) => void;
   depositAmount?: number;
+  depositDueBy?: string;
 }
 
 const PaymentModal: React.FC<PaymentModalProps> = ({
@@ -25,6 +26,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
   onSuccess,
   onError,
   depositAmount,
+  depositDueBy,
 }) => {
   const [amount, setAmount] = useState(
     depositAmount !== undefined ? depositAmount.toString() : '',
@@ -125,6 +127,11 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
               onChange={(e) => setAmount(e.target.value)}
             />
           </label>
+          {depositDueBy && (
+            <p className="text-sm text-gray-600">
+              Due by {new Date(depositDueBy).toLocaleDateString()}
+            </p>
+          )}
           <label className="flex items-center gap-2 text-sm">
             <input
               type="checkbox"

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -134,4 +134,29 @@ describe('PaymentModal', () => {
     expect(reopened.value).toBe('40');
     root.unmount();
   });
+
+  it('shows deposit due date when provided', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    const due = '2024-01-05T00:00:00Z';
+    await act(async () => {
+      root.render(
+        <PaymentModal
+          open
+          bookingRequestId={4}
+          onClose={() => {}}
+          onSuccess={() => {}}
+          onError={() => {}}
+          depositAmount={25}
+          depositDueBy={due}
+        />,
+      );
+    });
+    const note = div.querySelector('p.text-sm.text-gray-600');
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain(
+      `Due by ${new Date(due).toLocaleDateString()}`,
+    );
+    root.unmount();
+  });
 });


### PR DESCRIPTION
## Summary
- support an optional depositDueBy date in `PaymentModal`
- pass `booking.deposit_due_by` from dashboard pages and MessageThread
- display a note for the due date under the amount input
- test that the due date note renders when provided

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852b8efd674832ea6be908de58856ac