### PR TITLE
Add HelpPrompt to client quotes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,8 @@ instructions.
 
 The `HelpPrompt` component renders quick links to the FAQ and contact page. It
 appears beneath the booking confirmation banner in chat, on the booking details
-page, and at the bottom of the client bookings page so users always know where
+page, at the bottom of the client bookings page, and now on the client quotes
+page so users always know where
 to get assistance.
 
 ### Support Pages

--- a/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
+++ b/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
@@ -108,4 +108,28 @@ describe('ClientQuotesPage', () => {
     });
     div.remove();
   });
+
+  it('renders the help prompt', async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: 1, user_type: 'client', email: 'c@example.com' },
+    });
+    (getMyClientQuotes as jest.Mock).mockResolvedValue({ data: [] });
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ClientQuotesPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+
+    const help = div.querySelector('[data-testid="help-prompt"]');
+    expect(help).not.toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
 });

--- a/frontend/src/app/dashboard/client/quotes/page.tsx
+++ b/frontend/src/app/dashboard/client/quotes/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import { getMyClientQuotes } from '@/lib/api';
+import { HelpPrompt } from '@/components/ui';
 import type { Quote } from '@/types';
 
 export default function ClientQuotesPage() {
@@ -120,6 +121,7 @@ export default function ClientQuotesPage() {
             ))}
           </ul>
         )}
+        <HelpPrompt />
       </div>
     </MainLayout>
   );


### PR DESCRIPTION
## Summary
- show `HelpPrompt` at bottom of Client Quotes page
- test HelpPrompt render
- document HelpPrompt location in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852ba2540f8832e8461f3d00f032742