### PR TITLE
Fix quote creation response serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   quotes directly from the notification list.
 * Quote API responses omit the nested `booking_request` field to avoid
   circular references.
+* POST `/api/v1/booking-requests/{id}/quotes` now returns a Quote with
+  `booking_request` set to `null` to prevent serialization cycles.
 * Accepting a Quote V2 now also creates a formal booking visible on the artist dashboard.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.

--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -94,6 +94,8 @@ def create_quote_for_request(
             quote_id=new_quote.id,
             attachment_url=None,
         )
+        # Avoid circular references when serialized by Pydantic models
+        new_quote.booking_request = None
         return new_quote
     except ValueError as e:
         logger.warning(

--- a/backend/tests/test_quote_endpoint.py
+++ b/backend/tests/test_quote_endpoint.py
@@ -1,0 +1,92 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models.base import BaseModel
+from app.api.dependencies import get_db, get_current_active_artist
+from app.models import User, UserType, BookingRequest, BookingRequestStatus
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    artist = User(
+        email="artist@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.ARTIST,
+        is_active=True,
+    )
+    client = User(
+        email="client@test.com",
+        password="x",
+        first_name="C",
+        last_name="L",
+        user_type=UserType.CLIENT,
+        is_active=True,
+    )
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+    br = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        status=BookingRequestStatus.PENDING_QUOTE,
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+    db.close()
+    return artist, br
+
+
+def test_create_quote_endpoint_returns_201():
+    Session = setup_app()
+    artist, br = create_data(Session)
+
+    def override_artist():
+        return artist
+
+    prev = app.dependency_overrides.get(get_current_active_artist)
+    app.dependency_overrides[get_current_active_artist] = override_artist
+
+    client_api = TestClient(app)
+    payload = {
+        "booking_request_id": br.id,
+        "quote_details": "details",
+        "price": "10.00",
+        "currency": "ZAR",
+    }
+    res = client_api.post(f"/api/v1/booking-requests/{br.id}/quotes", json=payload)
+    assert res.status_code == 201
+    data = res.json()
+    assert data["booking_request_id"] == br.id
+    assert "booking_request" not in data
+
+    if prev is not None:
+        app.dependency_overrides[get_current_active_artist] = prev
+    else:
+        app.dependency_overrides.pop(get_current_active_artist, None)


### PR DESCRIPTION
## Summary
- prevent cyclic serialization when creating quotes
- add regression test for quote creation endpoint
- document quote API behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852bfda7078832e825ce498796a5dea