### PR TITLE
Handle service id when accepting quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `booking_request` set to `null` to prevent serialization cycles.
 * Accepting a Quote V2 now also creates a formal booking visible on the artist dashboard.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
+* `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
+  parameter when the related booking request was created without one.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
 * Legacy quotes can still be accepted or rejected via `PUT /api/v1/quotes/{id}/client` when the newer `/accept` route is unavailable.
 * Artists can save **Quote Templates** via `/api/v1/quote-templates` and apply them when composing a quote.

--- a/backend/app/api/api_quote_v2.py
+++ b/backend/app/api/api_quote_v2.py
@@ -65,9 +65,13 @@ def read_quote(quote_id: int, db: Session = Depends(get_db)):
 
 
 @router.post("/quotes/{quote_id}/accept", response_model=schemas.BookingSimpleRead)
-def accept_quote(quote_id: int, db: Session = Depends(get_db)):
+def accept_quote(
+    quote_id: int,
+    db: Session = Depends(get_db),
+    service_id: int | None = None,
+):
     try:
-        booking = crud_quote_v2.accept_quote(db, quote_id)
+        booking = crud_quote_v2.accept_quote(db, quote_id, service_id=service_id)
         logger.info("Quote %s accepted creating booking %s", quote_id, booking.id)
         return booking
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- allow supplying `service_id` when accepting a quote
- update API to forward the new optional parameter
- document the new `service_id` parameter for `/quotes/{id}/accept`
- test accepting a quote where the booking request initially had no service

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c1b6f270832e8bdf1ea14fa0dee6