### PR TITLE
Add fake payment gateway toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ Returns the PDF receipt for a completed payment.
 Sending `full: true` charges the remaining balance and marks the booking paid. Omitting it records a deposit and sets the status to `deposit_paid`.
 The endpoint now verifies the booking belongs to the authenticated client and returns **403 Forbidden** if another user attempts payment.
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
+Set `PAYMENT_GATEWAY_FAKE=1` in the environment to bypass the real gateway during local testing. When enabled, `/api/v1/payments` returns a dummy `payment_id` and immediately marks the booking paid.
 
 When a client accepts a quote in the chat thread, the frontend now prompts them to pay a deposit via this endpoint. Successful payments update the booking's `payment_status` and display a confirmation banner.
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.

--- a/backend/tests/test_payment.py
+++ b/backend/tests/test_payment.py
@@ -147,6 +147,42 @@ def test_create_deposit(monkeypatch):
         app.dependency_overrides.pop(get_current_active_client, None)
 
 
+def test_create_deposit_fake(monkeypatch):
+    Session = setup_app()
+    client_user, br_id, Session = create_records(Session)
+    prev_db = app.dependency_overrides.get(get_db)
+    prev_client = app.dependency_overrides.get(get_current_active_client)
+    app.dependency_overrides[get_current_active_client] = override_client(
+        client_user
+    )
+
+    def should_not_call(*args, **kwargs):
+        raise AssertionError("httpx.post should not be called")
+
+    monkeypatch.setattr(api_payment.httpx, "post", should_not_call)
+    monkeypatch.setattr(api_payment, "PAYMENT_GATEWAY_FAKE", "1")
+    client = TestClient(app)
+    res = client.post(
+        "/api/v1/payments/", json={"booking_request_id": br_id, "amount": 50}
+    )
+    assert res.status_code == 201
+    db = Session()
+    booking = db.query(BookingSimple).first()
+    assert booking.deposit_amount == Decimal("50")
+    assert booking.deposit_paid is True
+    assert booking.payment_status == "deposit_paid"
+    assert booking.payment_id.startswith("fake_")
+    db.close()
+    if prev_db is not None:
+        app.dependency_overrides[get_db] = prev_db
+    else:
+        app.dependency_overrides.pop(get_db, None)
+    if prev_client is not None:
+        app.dependency_overrides[get_current_active_client] = prev_client
+    else:
+        app.dependency_overrides.pop(get_current_active_client, None)
+
+
 def test_get_receipt(tmp_path):
     payment_id = "abc123"
     receipts_dir = tmp_path / "static" / "receipts"


### PR DESCRIPTION
## Summary
- bypass payment gateway when `PAYMENT_GATEWAY_FAKE` is set
- test payment endpoint in both real and fake modes
- document fake gateway environment variable

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852c33b87b0832eb6c3e8fd82b65d4d