### PR TITLE
Add focus-visible ring to Stepper component

### DIFF
--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -41,7 +41,7 @@ export default function Stepper({ steps, currentStep, maxStepCompleted, onStepCl
               key={label}
               onClick={() => i <= maxStep && i !== currentStep && onStepClick(i)}
               disabled={i > maxStep || i === currentStep}
-              className={`flex flex-col items-center text-sm focus:outline-none ${
+              className={`flex flex-col items-center text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                 i > maxStep
                   ? 'cursor-not-allowed'
                   : i === currentStep

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -99,4 +99,19 @@ describe('Stepper progress bar', () => {
     expect(buttons[1].className).toContain('cursor-default');
     expect(buttons[1].className).not.toContain('cursor-not-allowed');
   });
+
+  it('applies focus ring when navigating with the keyboard', () => {
+    act(() => {
+      root.render(
+        <Stepper steps={["One", "Two"]} currentStep={0} onStepClick={() => {}} />,
+      );
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+      button.focus();
+    });
+    expect(button.className).toContain('focus-visible:ring-2');
+    expect(button.className).toContain('focus-visible:ring-indigo-500');
+  });
 });


### PR DESCRIPTION
## Summary
- style Stepper button with focus-visible ring classes
- test that focus ring classes exist when focusing via keyboard

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852f197df14832e87e8e337062ea4d7