### PR TITLE
Format currency across quote and payment components

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
-* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `50.00 due by Jan 1, 2025`.
+* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `R50.00 due by Jan 1, 2025`.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
@@ -757,7 +757,7 @@ When a client accepts a quote in the chat thread, the frontend now prompts them 
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
 Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}?pay=1` where they can complete the deposit.
-The alert now displays the deposit amount and due date so clients know exactly what to pay and by when. The drawer also parses these values so the list shows `50.00 due by Jan 1, 2025` under the title.
+The alert now displays the deposit amount and due date so clients know exactly what to pay and by when. The drawer also parses these values so the list shows `R50.00 due by Jan 1, 2025` under the title.
 Clients can also pay outstanding deposits later from the bookings page. Each
 pending booking shows a **Pay deposit** button that fetches the latest deposit
 amount from the server before opening the payment modal.

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Button from '../ui/Button';
 import { createPayment } from '@/lib/api';
+import { formatCurrency } from '@/lib/utils';
 
 interface PaymentSuccess {
   status: string;
@@ -129,7 +130,8 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
           </label>
           {depositDueBy && (
             <p className="text-sm text-gray-600">
-              Due by {new Date(depositDueBy).toLocaleDateString()}
+              {formatCurrency(Number((depositAmount ?? amount) || 0))} due by{' '}
+              {new Date(depositDueBy).toLocaleDateString()}
             </p>
           )}
           <label className="flex items-center gap-2 text-sm">

--- a/frontend/src/components/booking/QuoteCard.tsx
+++ b/frontend/src/components/booking/QuoteCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '../ui/Button';
 import { QuoteV2 } from '@/types';
+import { formatCurrency } from '@/lib/utils';
 
 interface Props {
   quote: QuoteV2;
@@ -27,19 +28,19 @@ const QuoteCard: React.FC<Props> = ({ quote, isClient, onAccept, onDecline, book
       </div>
       <ul className="list-disc list-inside text-sm mb-1">
         {quote.services.map((s, i) => (
-          <li key={i}>{s.description} – {Number(s.price).toFixed(2)}</li>
+          <li key={i}>{s.description} – {formatCurrency(Number(s.price))}</li>
         ))}
       </ul>
-      <p className="text-sm">Sound fee: {Number(quote.sound_fee).toFixed(2)}</p>
-      <p className="text-sm">Travel fee: {Number(quote.travel_fee).toFixed(2)}</p>
+      <p className="text-sm">Sound fee: {formatCurrency(Number(quote.sound_fee))}</p>
+      <p className="text-sm">Travel fee: {formatCurrency(Number(quote.travel_fee))}</p>
       {quote.accommodation && (
         <p className="text-sm">Accommodation: {quote.accommodation}</p>
       )}
-      <p className="text-sm font-medium">Subtotal: {Number(quote.subtotal).toFixed(2)}</p>
+      <p className="text-sm font-medium">Subtotal: {formatCurrency(Number(quote.subtotal))}</p>
       {quote.discount && (
-        <p className="text-sm">Discount: {Number(quote.discount).toFixed(2)}</p>
+        <p className="text-sm">Discount: {formatCurrency(Number(quote.discount))}</p>
       )}
-      <p className="font-semibold">Total: {Number(quote.total).toFixed(2)}</p>
+      <p className="font-semibold">Total: {formatCurrency(Number(quote.total))}</p>
       {quote.expires_at && (
         <span className="text-xs text-gray-500">Expires {new Date(quote.expires_at).toLocaleString()}</span>
       )}

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Button from '../ui/Button';
 import { ServiceItem, QuoteV2Create, QuoteTemplate } from '@/types';
 import { getQuoteTemplates } from '@/lib/api';
+import { formatCurrency } from '@/lib/utils';
 
 interface Props {
   open: boolean;
@@ -169,9 +170,9 @@ const SendQuoteModal: React.FC<Props> = ({
             ))}
           </select>
           <div className="text-sm mt-2">
-            Subtotal: {subtotal.toFixed(2)}
+            Subtotal: {formatCurrency(subtotal)}
             <br />
-            Total: {total.toFixed(2)}
+            Total: {formatCurrency(total)}
           </div>
         </div>
         <div className="flex justify-end gap-2 mt-4">

--- a/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/PaymentModal.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act } from 'react';
 import PaymentModal from '../PaymentModal';
 import * as api from '@/lib/api';
+import { formatCurrency } from '@/lib/utils';
 
 jest.mock('@/lib/api');
 
@@ -155,7 +156,7 @@ describe('PaymentModal', () => {
     const note = div.querySelector('p.text-sm.text-gray-600');
     expect(note).not.toBeNull();
     expect(note?.textContent).toContain(
-      `Due by ${new Date(due).toLocaleDateString()}`,
+      `${formatCurrency(25)} due by ${new Date(due).toLocaleDateString()}`,
     );
     root.unmount();
   });

--- a/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
+++ b/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import QuoteCard from '../QuoteCard';
 import { act } from 'react';
+import { formatCurrency } from '@/lib/utils';
 
 const quote = {
   id: 1,
@@ -30,6 +31,7 @@ describe('QuoteCard', () => {
       );
     });
     expect(div.textContent).toContain('Perf');
-    expect(div.textContent).toContain('130');
+    expect(div.textContent).toContain(formatCurrency(100));
+    expect(div.textContent).toContain(formatCurrency(130));
   });
 });

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act } from 'react';
 import SendQuoteModal from '../SendQuoteModal';
 import * as api from '@/lib/api';
+import { formatCurrency } from '@/lib/utils';
 
 jest.mock('@/lib/api');
 
@@ -48,6 +49,47 @@ describe('SendQuoteModal', () => {
     expect(inputs[0].value).toBe('5');
     expect(inputs[1].value).toBe('1');
     expect(inputs[2].value).toBe('2');
+    root.unmount();
+  });
+
+  it('shows formatted totals', async () => {
+    (api.getQuoteTemplates as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          artist_id: 2,
+          name: 'Base',
+          services: [{ description: 'A', price: 5 }],
+          sound_fee: 1,
+          travel_fee: 2,
+          accommodation: null,
+          discount: null,
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+    });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <SendQuoteModal
+          open
+          onClose={() => {}}
+          onSubmit={() => {}}
+          artistId={2}
+          clientId={3}
+          bookingRequestId={4}
+        />,
+      );
+    });
+    const select = div.querySelector('select') as HTMLSelectElement;
+    await act(async () => {
+      select.value = '1';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    const summary = div.querySelector('div.text-sm.mt-2') as HTMLDivElement;
+    expect(summary.textContent).toContain(formatCurrency(8));
     root.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- show currency using `formatCurrency` in QuoteCard, SendQuoteModal and PaymentModal
- update related unit tests to expect formatted currency
- display deposit amount with currency in PaymentModal
- update deposit examples in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852fcc15ff8832ea5d54c0eed238688