### PR TITLE
Update chat colors to use brand palette

### DIFF
--- a/frontend/src/components/booking/ChatThreadView.tsx
+++ b/frontend/src/components/booking/ChatThreadView.tsx
@@ -22,7 +22,7 @@ export default function ChatThreadView({
     <div className="h-screen flex justify-center px-4 sm:px-6 py-6">
       <div className="max-w-2xl w-full mx-auto bg-white shadow-lg rounded-2xl overflow-hidden border flex flex-col">
         <header
-          className="sticky top-0 z-10 bg-[#2F2B5C] text-white px-4 py-3 flex items-center justify-between rounded-t-2xl"
+          className="sticky top-0 z-10 bg-brand-dark text-white px-4 py-3 flex items-center justify-between rounded-t-2xl"
         >
           <h2 className="font-medium" data-testid="contact-name">
             Chat with {contactName}

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -404,7 +404,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 py-6">
       <div className="bg-white shadow-lg rounded-2xl overflow-hidden border flex flex-col min-h-[70vh]">
-        <header className="sticky top-0 z-10 bg-[#2F2B5C] text-white px-4 py-3 flex items-center justify-between">
+        <header className="sticky top-0 z-10 bg-brand-dark text-white px-4 py-3 flex items-center justify-between">
           <span className="font-medium">
             Chat with {user?.user_type === 'artist' ? clientName : artistName}
           </span>
@@ -569,7 +569,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               )}
               {group.messages.map((msg, mIdx) => {
                 const bubbleClass = isSelf
-                  ? 'bg-[#4F46E5] text-white self-end'
+                  ? 'bg-brand text-white self-end'
                   : isSystem
                     ? 'bg-gray-200 text-gray-900 self-start'
                     : 'bg-gray-100 text-gray-800 self-start';

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -2,7 +2,7 @@ import { buttonVariants } from '../buttonVariants';
 
 describe('buttonVariants', () => {
   it('provides classes for primary buttons', () => {
-    expect(buttonVariants.primary).toMatch('bg-blue-600');
+    expect(buttonVariants.primary).toMatch('bg-brand');
   });
 
   it('provides classes for secondary buttons', () => {

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,5 +1,5 @@
 export const buttonVariants = {
-  primary: 'bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-700',
+  primary: 'bg-brand hover:bg-brand-dark text-white focus:ring-brand-dark',
   secondary:
     'bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',


### PR DESCRIPTION
## Summary
- switch chat headers and bubbles to `bg-brand`/`bg-brand-dark`
- adjust primary button variant to the brand palette
- update corresponding test

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685304487948832eaca2ebf52bc464a2