### PR TITLE
Switch booking steps to reusable Button component

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,8 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 ## UI Theme
 
 Reusable style constants are defined in `src/styles`. Button variants come from
-`buttonVariants.ts` so colors stay consistent across the app. The Tailwind
+`buttonVariants.ts` so colors stay consistent across the app. A new `link`
+variant provides a text-only style for inline actions. The Tailwind
 configuration includes this directory in its `content` array so these constant
 class names are preserved during production builds.
 

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
+import { Button } from '../../ui';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { format, parseISO } from 'date-fns';
@@ -78,30 +79,32 @@ export default function DateTimeStep({
       )}
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -2,6 +2,7 @@
 // Larger touch targets and contextual help improve usability on mobile.
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import useIsMobile from '@/hooks/useIsMobile';
+import { Button } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -40,30 +41,32 @@ export default function GuestsStep({
       />
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -13,6 +13,7 @@ const Marker = dynamic(
   { ssr: false },
 );
 import { useRef, useState, useEffect } from 'react';
+import { Button } from '../../ui';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
 
 // Keeping the libraries array stable avoids unnecessary re-renders from
@@ -210,9 +211,10 @@ export default function LocationStep({
           </>
         )}
       </div>
-      <button
+      <Button
         type="button"
-        className="mt-2 text-sm text-indigo-600 underline px-4 py-2 rounded inline-block min-h-[44px]"
+        variant="link"
+        className="mt-2 text-sm inline-block min-h-[44px]"
         onClick={() => {
           navigator.geolocation.getCurrentPosition(
             (pos) => {
@@ -227,7 +229,7 @@ export default function LocationStep({
         }}
       >
         Use my location
-      </button>
+      </Button>
       <span
         className="ml-1 text-gray-500 cursor-help"
         title="A warning appears if this address is over 100km from the artist."
@@ -237,30 +239,32 @@ export default function LocationStep({
       {geoError && <p className="text-red-600 text-sm">{geoError}</p>}
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -5,6 +5,7 @@ import useIsMobile from '@/hooks/useIsMobile';
 import { uploadBookingAttachment } from '@/lib/api';
 import toast from '../../ui/Toast';
 import { useState } from 'react';
+import { Button } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -98,31 +99,33 @@ export default function NotesStep({
       )}
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
             disabled={uploading}
-            className={`w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px] ${uploading ? 'opacity-50 cursor-not-allowed' : ''}`}
+            className={`w-full sm:w-auto min-h-[44px] ${uploading ? 'cursor-not-allowed opacity-50' : ''}`}
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 // Final review step showing a summary of all selections.
 import SummarySidebar from '../SummarySidebar';
+import { Button } from '../../ui';
 
 interface Props {
   step: number;
@@ -27,31 +28,34 @@ export default function ReviewStep({
       </p>
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onSubmit}
             disabled={submitting}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition disabled:opacity-50 min-h-[44px]"
+            isLoading={submitting}
+            className="w-full sm:w-auto min-h-[44px]"
           >
-            {submitting ? 'Submitting...' : step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Control, Controller, FieldValues } from 'react-hook-form';
+import { Button } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -51,30 +52,32 @@ export default function SoundStep({
       />
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -2,7 +2,7 @@
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import { useState, useRef } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
-import { BottomSheet } from '../../ui';
+import { BottomSheet, Button } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -41,16 +41,17 @@ export default function VenueStep({
           <>
             {isMobile ? (
               <>
-                <button
+                <Button
                   type="button"
                   onClick={() => setSheetOpen(true)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-md text-left min-h-[44px]"
+                  variant="secondary"
+                  className="w-full text-left min-h-[44px]"
                   ref={buttonRef}
                 >
                   {field.value
                     ? `Venue: ${field.value.charAt(0).toUpperCase()}${field.value.slice(1)}`
                     : 'Select venue type'}
-                </button>
+                </Button>
                 <BottomSheet
                   open={sheetOpen}
                   onClose={() => setSheetOpen(false)}
@@ -100,30 +101,32 @@ export default function VenueStep({
       />
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (
-          <button
+          <Button
             type="button"
             onClick={onBack}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Back
-          </button>
+          </Button>
         )}
 
         <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <button
+          <Button
             type="button"
             onClick={onSaveDraft}
-            className="w-full sm:w-auto px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 transition min-h-[44px]"
+            variant="secondary"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             Save Draft
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onNext}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition min-h-[44px]"
+            className="w-full sm:w-auto min-h-[44px]"
           >
             {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { type ButtonHTMLAttributes } from 'react';
+import React, { forwardRef, type ButtonHTMLAttributes } from 'react';
 import clsx from 'clsx';
 import { buttonVariants, type ButtonVariant } from '@/styles/buttonVariants';
 
@@ -11,34 +11,41 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   fullWidth?: boolean;
 }
 
-export default function Button({
-  variant = 'primary',
-  isLoading = false,
-  fullWidth = false,
-  className,
-  children,
-  ...props
-}: ButtonProps) {
-  const base =
-    'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95';
-  const variantClass = buttonVariants[variant];
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = 'primary',
+      isLoading = false,
+      fullWidth = false,
+      className,
+      children,
+      ...props
+    }: ButtonProps,
+    ref,
+  ) => {
+    const base =
+      'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95';
+    const variantClass = buttonVariants[variant];
+    return (
+      <button
+        type={props.type ?? 'button'}
+        aria-busy={isLoading}
+        disabled={isLoading || props.disabled}
+        ref={ref}
+        {...props}
+        className={clsx(base, variantClass, fullWidth && 'w-full', className)}
+      >
+        {isLoading && (
+          <span
+            className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+            aria-hidden="true"
+          />
+        )}
+        <span className={clsx(isLoading && 'opacity-75')}>{children}</span>
+      </button>
+    );
+  },
+);
+Button.displayName = 'Button';
 
-  return (
-    <button
-      type={props.type ?? 'button'}
-      aria-busy={isLoading}
-      disabled={isLoading || props.disabled}
-      {...props}
-      className={clsx(base, variantClass, fullWidth && 'w-full', className)}
-    >
-      {isLoading && (
-        <span
-          className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-          aria-hidden="true"
-        />
-      )}
-      <span className={clsx(isLoading && 'opacity-75')}>{children}</span>
-    </button>
-  );
-}
-
+export default Button;

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -12,5 +12,9 @@ describe('buttonVariants', () => {
   it('provides classes for danger buttons', () => {
     expect(buttonVariants.danger).toMatch('bg-red-600');
   });
+
+  it('provides classes for link buttons', () => {
+    expect(buttonVariants.link).toMatch('text-indigo-600');
+  });
 });
 

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -3,6 +3,8 @@ export const buttonVariants = {
   secondary:
     'bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+  link:
+    'bg-transparent underline text-indigo-600 hover:text-indigo-700 focus:ring-indigo-600 px-0 py-0',
 } as const;
 
 export type ButtonVariant = keyof typeof buttonVariants;


### PR DESCRIPTION
## Summary
- add `link` variant to `buttonVariants`
- update booking steps to use the shared `Button` component
- forward refs in `Button` and support loading state
- document new button variant
- test the new variant

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685305d2ff08832e895599b4c6d9398b