### PR TITLE
Add focus-visible ring classes to notification buttons

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -85,15 +85,15 @@ export default function FullScreenNotificationModal({
               <button
                 type="button"
                 onClick={() => setShowUnread((prev) => !prev)}
-                className="text-sm text-gray-600 hover:underline"
+                className="text-sm text-gray-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                 data-testid="toggle-unread"
               >
                 {showUnread ? 'Show All' : 'Unread Only'}
               </button>
-              <button type="button" onClick={markAllRead} className="text-sm text-indigo-600">
+              <button type="button" onClick={markAllRead} className="text-sm text-indigo-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
                 Mark All as Read
               </button>
-              <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-600">
+              <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand">
                 <span className="sr-only">Close panel</span>
                 <XMarkIcon className="h-6 w-6" aria-hidden="true" />
               </button>
@@ -141,7 +141,7 @@ export default function FullScreenNotificationModal({
                         type="button"
                         aria-label="Load more notifications"
                         onClick={loadMore}
-                        className="text-sm text-indigo-600 hover:underline focus:outline-none"
+                        className="text-sm text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                       >
                         Load more
                       </button>

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -77,7 +77,7 @@ export default function NotificationBell(): JSX.Element {
         onClick={() => setOpen(true)}
         onMouseEnter={prefetchNotifications}
         onFocus={prefetchNotifications}
-        className="flex text-gray-400 hover:text-gray-600 focus:outline-none"
+        className="flex text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <span className="sr-only">View notifications</span>
         <BellIcon className="h-6 w-6" aria-hidden="true" />

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -83,7 +83,7 @@ export default function NotificationDrawer({
                       <button
                         type="button"
                         onClick={() => setShowUnread((prev) => !prev)}
-                        className="text-sm text-gray-600 hover:underline"
+                        className="text-sm text-gray-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                         data-testid="toggle-unread"
                       >
                         {showUnread ? 'Show All' : 'Unread Only'}
@@ -91,13 +91,13 @@ export default function NotificationDrawer({
                       <button
                         type="button"
                         onClick={markAllRead}
-                        className="text-sm text-indigo-600 hover:underline"
+                        className="text-sm text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                       >
                         Mark All as Read
                       </button>
                       <button
                         type="button"
-                        className="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none"
+                        className="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                         onClick={onClose}
                       >
                         <span className="sr-only">Close panel</span>
@@ -145,7 +145,7 @@ export default function NotificationDrawer({
                                 type="button"
                                 aria-label="Load more notifications"
                                 onClick={loadMore}
-                                className="text-sm text-indigo-600 hover:underline focus:outline-none"
+                                className="text-sm text-indigo-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                               >
                                 Load more
                               </button>

--- a/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
@@ -1,0 +1,49 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import NotificationBell from '../NotificationBell';
+import useNotifications from '@/hooks/useNotifications';
+import useIsMobile from '@/hooks/useIsMobile';
+
+jest.mock('@/hooks/useNotifications');
+jest.mock('@/hooks/useIsMobile');
+
+function setup() {
+  (useNotifications as jest.Mock).mockReturnValue({
+    items: [],
+    unreadCount: 0,
+    markItem: jest.fn(),
+    markAll: jest.fn(),
+    loadMore: jest.fn(),
+    hasMore: false,
+  });
+  (useIsMobile as jest.Mock).mockReturnValue(false);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('NotificationBell accessibility', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies ring styles when keyboard focused', () => {
+    const { container, root } = setup();
+    act(() => {
+      root.render(React.createElement(NotificationBell));
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+      button.focus();
+    });
+    expect(button.className).toContain('focus-visible:ring-2');
+    expect(button.className).toContain('focus-visible:ring-brand');
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- improve NotificationBell accessibility with focus-visible ring classes
- add same ring styles to NotificationDrawer and FullScreenNotificationModal buttons
- test NotificationBell keyboard focus styling

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685307b530e0832ea536108675aa4891