### PR TITLE
Switch to TextInput for booking forms

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,6 +27,8 @@ Reusable style constants are defined in `src/styles`. Button variants come from
 variant provides a text-only style for inline actions. The Tailwind
 configuration includes this directory in its `content` array so these constant
 class names are preserved during production builds.
+All text inputs should use the `TextInput` component in `src/components/ui` so
+form fields share consistent spacing and focus styles.
 
 ### Loading Indicators
 

--- a/frontend/src/components/booking/PaymentModal.tsx
+++ b/frontend/src/components/booking/PaymentModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Button from '../ui/Button';
+import TextInput from '../ui/TextInput';
 import { createPayment } from '@/lib/api';
 import { formatCurrency } from '@/lib/utils';
 import { format } from 'date-fns';
@@ -121,22 +122,19 @@ const PaymentModal: React.FC<PaymentModalProps> = ({
       >
         <h2 className="text-lg font-medium mb-2">Pay Deposit</h2>
         <div className="space-y-2">
-          <label htmlFor="deposit-amount" className="flex flex-col text-sm">
-            Amount
-            <input
-              id="deposit-amount"
-              type="text"
-              className="w-full border rounded p-1"
-              placeholder="Amount"
-              value={amountInput}
-              onChange={(e) => {
-                const raw = e.target.value;
-                setAmountInput(raw);
-                const num = parseFloat(raw.replace(/[^0-9.]/g, ''));
-                if (!Number.isNaN(num)) setAmount(num);
-              }}
-            />
-          </label>
+          <TextInput
+            id="deposit-amount"
+            type="text"
+            label="Amount"
+            placeholder="Amount"
+            value={amountInput}
+            onChange={(e) => {
+              const raw = e.target.value;
+              setAmountInput(raw);
+              const num = parseFloat(raw.replace(/[^0-9.]/g, ''));
+              if (!Number.isNaN(num)) setAmount(num);
+            }}
+          />
           {depositDueBy && (
             <p className="text-sm text-gray-600">
               {formatCurrency(depositAmount ?? amount)} due by{' '}

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -2,7 +2,7 @@
 // Larger touch targets and contextual help improve usability on mobile.
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import useIsMobile from '@/hooks/useIsMobile';
-import { Button } from '../../ui';
+import { Button, TextInput } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -24,16 +24,16 @@ export default function GuestsStep({
   const isMobile = useIsMobile();
   return (
     <div className="space-y-4">
-      <label className="block text-sm font-medium">Number of guests</label>
       <p className="text-sm text-gray-600">How many people?</p>
       <Controller
         name="guests"
         control={control}
         render={({ field }) => (
-          <input
+          <TextInput
             type="number"
             min={1}
-            className="border p-3 rounded w-full text-lg min-h-[44px]"
+            label="Number of guests"
+            className="text-lg"
             {...field}
             autoFocus={!isMobile}
           />

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -13,7 +13,7 @@ const Marker = dynamic(
   { ssr: false },
 );
 import { useRef, useState, useEffect } from 'react';
-import { Button } from '../../ui';
+import { Button, TextInput } from '../../ui';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
 
 // Keeping the libraries array stable avoids unnecessary re-renders from
@@ -94,11 +94,11 @@ function AutocompleteInput({ value, onChange, onSelect, isLoaded }: Autocomplete
   }, [value]);
 
   return (
-    <input
+    <TextInput
       ref={inputRef}
-      className="border p-2 w-full min-h-[44px]"
       placeholder="Search address"
       onChange={(e) => onChange(e.target.value)}
+      className="min-h-[44px]"
       data-testid="autocomplete-input"
     />
   );

--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -1,5 +1,6 @@
 'use client';
 import type { InputHTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import clsx from 'clsx';
 
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -8,8 +9,8 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   loading?: boolean;
 }
 
-export default function TextInput({ label, id, error, loading = false, className, ...props }: TextInputProps) {
-  return (
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  ({ label, id, error, loading = false, className, ...props }, ref) => (
     <div className="w-full">
       {label && (
         <label htmlFor={id} className="block text-sm font-medium text-gray-700">
@@ -18,6 +19,7 @@ export default function TextInput({ label, id, error, loading = false, className
       )}
       <div className="mt-1 relative">
         <input
+          ref={ref}
           id={id}
           className={clsx(
             'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm',
@@ -33,5 +35,8 @@ export default function TextInput({ label, id, error, loading = false, className
       </div>
       {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
     </div>
-  );
-}
+  ),
+);
+TextInput.displayName = 'TextInput';
+
+export default TextInput;


### PR DESCRIPTION
## Summary
- use new TextInput component for payment modal
- replace inputs with TextInput in booking steps
- forward refs and add displayName in TextInput
- document TextInput usage in frontend README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68530b28ab5c832e91319f21b5342050