### PR TITLE
Add AlertBanner component and integrate into message thread

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl, formatCurrency } from '@/lib/utils';
 import HelpPrompt from '../ui/HelpPrompt';
+import AlertBanner from '../ui/AlertBanner';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Booking, Message, MessageCreate, QuoteV2 } from '@/types';
@@ -427,10 +428,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           )}
         </header>
         {bookingConfirmed && (
-          <div
-            className="rounded-lg bg-green-50 border border-green-200 p-4 text-sm text-green-800 mt-4"
-            data-testid="booking-confirmed-banner"
-          >
+          <AlertBanner variant="success" data-testid="booking-confirmed-banner" className="mt-4">
             🎉 Booking confirmed for {artistName}!{' '}
             {bookingDetails && (
               <>
@@ -442,7 +440,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                   : ' due.'}
               </>
             )}
-          </div>
+          </AlertBanner>
         )}
         {bookingConfirmed && (
           <>
@@ -492,10 +490,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           </>
         )}
         {paymentStatus && (
-          <div
-            className="rounded-lg bg-blue-50 border border-blue-200 p-4 text-sm text-blue-800 mt-2"
-            data-testid="payment-status-banner"
-          >
+          <AlertBanner variant="info" data-testid="payment-status-banner" className="mt-2">
             {paymentStatus === 'paid'
               ? 'Payment completed.'
               : `Deposit of ${formatCurrency(paymentAmount ?? depositAmount ?? 0)} received.`}
@@ -510,7 +505,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 View receipt
               </a>
             )}
-          </div>
+          </AlertBanner>
         )}
         {paymentError && (
           <p className="text-sm text-red-600" role="alert">{paymentError}</p>

--- a/frontend/src/components/ui/AlertBanner.tsx
+++ b/frontend/src/components/ui/AlertBanner.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+import clsx from 'clsx';
+
+export type AlertBannerVariant = 'success' | 'info' | 'error';
+
+export interface AlertBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: AlertBannerVariant;
+}
+
+export default function AlertBanner({
+  variant = 'info',
+  className,
+  children,
+  ...props
+}: AlertBannerProps) {
+  const variantClasses = {
+    success: 'bg-green-50 border border-green-200 text-green-800',
+    info: 'bg-blue-50 border border-blue-200 text-blue-800',
+    error: 'bg-red-50 border border-red-200 text-red-800',
+  }[variant];
+
+  return (
+    <div
+      {...props}
+      role="alert"
+      className={clsx('rounded-lg p-4 text-sm', variantClasses, className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/__tests__/AlertBanner.test.tsx
+++ b/frontend/src/components/ui/__tests__/AlertBanner.test.tsx
@@ -1,0 +1,41 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import AlertBanner from '../AlertBanner';
+
+describe('AlertBanner component', () => {
+  function renderBanner(variant?: 'success' | 'info' | 'error') {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<AlertBanner variant={variant}>Message</AlertBanner>);
+    });
+    return { container, root };
+  }
+
+  it('renders info variant by default', () => {
+    const { container, root } = renderBanner();
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('bg-blue-50');
+    expect(div.textContent).toBe('Message');
+    act(() => { root.unmount(); });
+    container.remove();
+  });
+
+  it('renders success variant', () => {
+    const { container, root } = renderBanner('success');
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('bg-green-50');
+    act(() => { root.unmount(); });
+    container.remove();
+  });
+
+  it('renders error variant', () => {
+    const { container, root } = renderBanner('error');
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('bg-red-50');
+    act(() => { root.unmount(); });
+    container.remove();
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -10,3 +10,4 @@ export { default as HelpPrompt } from './HelpPrompt';
 export { default as CollapsibleSection } from './CollapsibleSection';
 export { default as Spinner } from './Spinner';
 export { default as SkeletonList } from './SkeletonList';
+export { default as AlertBanner } from './AlertBanner';


### PR DESCRIPTION
## Summary
- implement `AlertBanner` UI component
- export it from `ui/index.ts`
- render `AlertBanner` in `MessageThread` for booking confirmation and payment status
- test `AlertBanner` component

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68530d852038832e9aae78f1a5635c3d