### PR TITLE
Replace modal buttons with Button component

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -784,8 +784,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             <Button
               type="submit"
               aria-label="Send message"
+              variant="primary"
+              className="rounded-full"
               disabled={uploading}
-              className="rounded-full bg-blue-600 text-white px-4 py-2 hover:bg-blue-700"
             >
               {uploading ? 'Uploading…' : 'Send'}
             </Button>

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useForm, SubmitHandler } from 'react-hook-form';
-import { Service } from '@/types';
-import { createService as apiCreateService } from '@/lib/api'; // Assuming this function exists
+import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useState } from 'react';
+import { Service } from '@/types';
+import { createService as apiCreateService } from '@/lib/api';
 import { DEFAULT_CURRENCY } from '@/lib/constants';
+import Button from '../ui/Button';
 
 interface AddServiceModalProps {
   isOpen: boolean;
@@ -135,20 +136,20 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
             {serverError && <p className="text-sm text-red-600">{serverError}</p>}
 
             <div className="items-center px-4 py-3 space-x-2">
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
-              >
+              <Button type="submit" disabled={isSubmitting}>
                 {isSubmitting ? 'Adding...' : 'Add Service'}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                onClick={() => { onClose(); reset(); setServerError(null); }}
-                className="px-4 py-2 bg-gray-200 text-gray-700 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500"
+                variant="secondary"
+                onClick={() => {
+                  onClose();
+                  reset();
+                  setServerError(null);
+                }}
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useForm, SubmitHandler } from "react-hook-form";
-import { Service } from "@/types";
-import { updateService as apiUpdateService } from "@/lib/api";
-import { useState } from "react";
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useState } from 'react';
+import { Service } from '@/types';
+import { updateService as apiUpdateService } from '@/lib/api';
 import { DEFAULT_CURRENCY } from '@/lib/constants';
+import Button from '../ui/Button';
 
 interface EditServiceModalProps {
   isOpen: boolean;
@@ -205,24 +206,20 @@ export default function EditServiceModal({
             )}
 
             <div className="items-center px-4 py-3 space-x-2">
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
-              >
-                {isSubmitting ? "Saving..." : "Save Changes"}
-              </button>
-              <button
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving...' : 'Save Changes'}
+              </Button>
+              <Button
                 type="button"
+                variant="secondary"
                 onClick={() => {
                   onClose();
                   reset();
                   setServerError(null);
                 }}
-                className="px-4 py-2 bg-gray-200 text-gray-700 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500"
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/frontend/src/components/dashboard/UpdateRequestModal.tsx
+++ b/frontend/src/components/dashboard/UpdateRequestModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { BookingRequest } from '@/types';
 import { updateBookingRequestArtist, postMessageToBookingRequest } from '@/lib/api';
+import Button from '../ui/Button';
 
 interface UpdateRequestModalProps {
   isOpen: boolean;
@@ -76,20 +77,12 @@ export default function UpdateRequestModal({
             </div>
             {error && <p className="text-sm text-red-600">{error}</p>}
             <div className="items-center px-4 py-3 space-x-2 text-right">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-4 py-2 bg-gray-200 text-gray-700 text-base font-medium rounded-md shadow-sm hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500"
-              >
+              <Button type="button" variant="secondary" onClick={onClose}>
                 Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={saving}
-                className="px-4 py-2 bg-brand text-white text-base font-medium rounded-md shadow-sm hover:bg-brand-dark focus:outline-none focus:ring-2 focus:ring-brand disabled:opacity-50"
-              >
+              </Button>
+              <Button type="submit" disabled={saving}>
                 {saving ? 'Saving...' : 'Save'}
-              </button>
+              </Button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- refactor AddServiceModal to use `<Button>` elements
- refactor EditServiceModal to use `<Button>` elements
- refactor UpdateRequestModal to use `<Button>` elements
- update MessageThread send button styling

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685315b2cecc832e810ea823b35ddb72