### PR TITLE
Add focus ring to MobileMenuDrawer close button

### DIFF
--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -62,7 +62,7 @@ export default function MobileMenuDrawer({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none"
+                  className="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                 >
                   <span className="sr-only">Close menu</span>
                   <XMarkIcon className="h-6 w-6" aria-hidden="true" />

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -51,6 +51,28 @@ describe('MobileMenuDrawer', () => {
     expect(bodyText).toContain('Quote Calculator');
   });
 
+  it('close button has focus ring classes', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          user: null,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const span = document.querySelector('span.sr-only');
+    const button = span?.parentElement as HTMLButtonElement | null;
+    expect(button?.className).toContain('focus-visible:ring-2');
+    expect(button?.className).toContain('focus-visible:ring-brand');
+  });
+
   it('shows artist links for artists', async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary
- add focus-visible ring styles to MobileMenuDrawer close button
- test presence of focus ring classes

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68531c763b18832ea0d5ccfc05747bf9