### PR TITLE
Fix booking request icon focus ring

### DIFF
--- a/frontend/src/components/layout/BookingRequestIcon.test.tsx
+++ b/frontend/src/components/layout/BookingRequestIcon.test.tsx
@@ -1,0 +1,43 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import BookingRequestIcon from './BookingRequestIcon';
+import useNotifications from '@/hooks/useNotifications';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => <a {...props} />,
+}));
+
+jest.mock('@/hooks/useNotifications');
+
+describe('BookingRequestIcon accessibility', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies ring styles when keyboard focused', () => {
+    (useNotifications as jest.Mock).mockReturnValue({ items: [] });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<BookingRequestIcon />);
+    });
+    const link = container.querySelector('a');
+    if (link) {
+      act(() => {
+        link.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+        (link as HTMLElement).focus();
+      });
+      expect(link.className).toContain('focus-visible:ring-2');
+      expect(link.className).toContain('focus-visible:ring-brand');
+    } else {
+      throw new Error('Link not found');
+    }
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/frontend/src/components/layout/BookingRequestIcon.tsx
+++ b/frontend/src/components/layout/BookingRequestIcon.tsx
@@ -23,7 +23,7 @@ export default function BookingRequestIcon() {
     <div className="relative ml-3" aria-live="polite">
       <Link
         href="/booking-requests"
-        className="flex text-gray-400 hover:text-gray-600 focus:outline-none"
+        className="flex text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <span className="sr-only">View booking requests</span>
         <ClipboardIcon className="h-6 w-6" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- add missing focus ring classes to BookingRequestIcon
- add test that checks keyboard focus ring styles

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68531e005380832e9b5825fdd3b5f519