### PR TITLE
Switch UI blue shades to brand palette

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -76,7 +76,7 @@ export default function ArtistsPage() {
                 key={c}
                 type="button"
                 onClick={() => onCategory(c)}
-                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium bg-blue-50 text-gray-700 hover:bg-blue-100 transition${
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium bg-brand-light text-gray-700 hover:bg-brand-light/70 transition${
                   category === c ? ' bg-indigo-100 text-indigo-600 font-semibold' : ''
                 }`}
               >

--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -133,7 +133,7 @@ export default function ArtistBookingsPage() {
                         : b.status === 'cancelled'
                         ? 'bg-red-100 text-red-800'
                         : b.status === 'confirmed'
-                        ? 'bg-blue-100 text-blue-800'
+                        ? 'bg-brand-light text-brand-dark'
                         : 'bg-yellow-100 text-yellow-800'
                     }`}
                   >

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -47,7 +47,7 @@ function BookingList({
                     : b.status === 'cancelled'
                       ? 'bg-red-100 text-red-800'
                       : b.status === 'confirmed'
-                        ? 'bg-blue-100 text-blue-800'
+                        ? 'bg-brand-light text-brand-dark'
                         : 'bg-yellow-100 text-yellow-800'
                 }`}
               >

--- a/frontend/src/app/dashboard/client/quotes/page.tsx
+++ b/frontend/src/app/dashboard/client/quotes/page.tsx
@@ -71,7 +71,7 @@ export default function ClientQuotesPage() {
       case 'rejected_by_client':
         return 'bg-red-100 text-red-800';
       case 'confirmed_by_artist':
-        return 'bg-blue-100 text-blue-800';
+        return 'bg-brand-light text-brand-dark';
       case 'withdrawn_by_artist':
         return 'bg-gray-100 text-gray-800';
       default:

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -510,7 +510,7 @@ export default function DashboardPage() {
                           : booking.status === 'cancelled'
                           ? 'bg-red-100 text-red-800'
                           : booking.status === 'confirmed'
-                          ? 'bg-blue-100 text-blue-800'
+                          ? 'bg-brand-light text-brand-dark'
                           : 'bg-yellow-100 text-yellow-800'
                       }`}
                     >

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -153,7 +153,7 @@ export default function RegisterPage() {
                   <div className="mt-2 h-2 w-full rounded bg-gray-200">
                     <div
                       className={`h-full rounded ${
-                        ['bg-red-500', 'bg-yellow-500', 'bg-blue-500', 'bg-green-600'][Math.max(getPasswordStrength(password) - 1, 0)]
+                        ['bg-red-500', 'bg-yellow-500', 'bg-brand', 'bg-green-600'][Math.max(getPasswordStrength(password) - 1, 0)]
                       }`}
                       style={{ width: `${(getPasswordStrength(password) / 4) * 100}%` }}
                     />

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -108,7 +108,7 @@ export default function ArtistCard({
             {limitedTags.map((s) => (
               <span
                 key={`${id}-${s}`}
-                className="text-[10px] px-1.5 py-0.5 bg-blue-50 text-gray-700 rounded-full"
+                className="text-[10px] px-1.5 py-0.5 bg-brand-light text-gray-700 rounded-full"
               >
                 {s}
               </span>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -777,7 +777,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 aria-live="polite"
               >
                 <div className="w-16 bg-gray-200 rounded h-1">
-                  <div className="bg-blue-600 h-1 rounded" style={{ width: `${uploadProgress}%` }} />
+                  <div className="bg-brand h-1 rounded" style={{ width: `${uploadProgress}%` }} />
                 </div>
                 <span className="text-xs">{uploadProgress}%</span>
               </div>
@@ -786,7 +786,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               type="submit"
               aria-label="Send message"
               variant="primary"
-              className="rounded-full"
+              className="rounded-full bg-brand"
               disabled={uploading}
             >
               {uploading ? 'Uploading…' : 'Send'}

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -92,7 +92,7 @@ export default function NotesStep({
           aria-live="polite"
         >
           <div className="w-full bg-gray-200 rounded h-2">
-            <div className="bg-blue-600 h-2 rounded" style={{ width: `${progress}%` }} />
+            <div className="bg-brand h-2 rounded" style={{ width: `${progress}%` }} />
           </div>
           <span className="text-xs">{progress}%</span>
         </div>

--- a/frontend/src/components/ui/AlertBanner.tsx
+++ b/frontend/src/components/ui/AlertBanner.tsx
@@ -16,7 +16,7 @@ export default function AlertBanner({
 }: AlertBannerProps) {
   const variantClasses = {
     success: 'bg-green-50 border border-green-200 text-green-800',
-    info: 'bg-blue-50 border border-blue-200 text-blue-800',
+    info: 'bg-brand-light border border-brand-light text-brand-dark',
     error: 'bg-red-50 border border-red-200 text-red-800',
   }[variant];
 

--- a/frontend/src/components/ui/__tests__/AlertBanner.test.tsx
+++ b/frontend/src/components/ui/__tests__/AlertBanner.test.tsx
@@ -17,7 +17,7 @@ describe('AlertBanner component', () => {
   it('renders info variant by default', () => {
     const { container, root } = renderBanner();
     const div = container.firstChild as HTMLElement;
-    expect(div.className).toContain('bg-blue-50');
+    expect(div.className).toContain('bg-brand-light');
     expect(div.textContent).toBe('Message');
     act(() => { root.unmount(); });
     container.remove();


### PR DESCRIPTION
## Summary
- update NotesStep progress bar to use brand color
- color send button and upload progress bar in MessageThread with brand hues
- migrate AlertBanner info variant to brand palette and adjust tests
- replace remaining `bg-blue-*` classes with brand-light text pairing

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685320191c24832eb3df8b02e2b5494e