### PR TITLE
Add accessible labels to SendQuoteModal

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,7 +82,7 @@ Passing `service_id` skips the service selection step when a user clicks "Book N
 
 ## Dashboard
 
-The artist dashboard includes a quotes page for managing offers. The `EditQuoteModal` allows artists to modify quote details and price inline without leaving the list. It opens when clicking the "Edit" button next to a pending quote and mirrors the style of `SendQuoteModal`.
+The artist dashboard includes a quotes page for managing offers. The `EditQuoteModal` allows artists to modify quote details and price inline without leaving the list. It opens when clicking the "Edit" button next to a pending quote and mirrors the style of `SendQuoteModal`. Both modals now wrap the sound fee, travel fee, discount, accommodation, and expiry fields in accessible labels so screen readers announce each input.
 
 ### Artist Listing
 

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -130,45 +130,61 @@ const SendQuoteModal: React.FC<Props> = ({
           <Button type="button" onClick={addService} className="text-sm" variant="secondary">
             Add Item
           </Button>
-          <input
-            type="number"
-            className="w-full border rounded p-1"
-            placeholder="Sound fee"
-            value={soundFee}
-            onChange={(e) => setSoundFee(Number(e.target.value))}
-          />
-          <input
-            type="number"
-            className="w-full border rounded p-1"
-            placeholder="Travel fee"
-            value={travelFee}
-            onChange={(e) => setTravelFee(Number(e.target.value))}
-          />
-          <textarea
-            className="w-full border rounded p-1"
-            placeholder="Accommodation (optional)"
-            value={accommodation}
-            onChange={(e) => setAccommodation(e.target.value)}
-          />
-          <input
-            type="number"
-            className="w-full border rounded p-1"
-            placeholder="Discount (optional)"
-            value={discount}
-            onChange={(e) => setDiscount(Number(e.target.value))}
-          />
-          <select
-            className="w-full border rounded p-1"
-            value={expiresHours ?? ''}
-            onChange={(e) => setExpiresHours(e.target.value ? Number(e.target.value) : null)}
-          >
-            <option value="">No expiry</option>
-            {expiryOptions.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
+          <label htmlFor="sound-fee" className="flex flex-col text-sm">
+            Sound fee
+            <input
+              id="sound-fee"
+              type="number"
+              className="w-full border rounded p-1"
+              value={soundFee}
+              onChange={(e) => setSoundFee(Number(e.target.value))}
+            />
+          </label>
+          <label htmlFor="travel-fee" className="flex flex-col text-sm">
+            Travel fee
+            <input
+              id="travel-fee"
+              type="number"
+              className="w-full border rounded p-1"
+              value={travelFee}
+              onChange={(e) => setTravelFee(Number(e.target.value))}
+            />
+          </label>
+          <label htmlFor="accommodation" className="flex flex-col text-sm">
+            Accommodation (optional)
+            <textarea
+              id="accommodation"
+              className="w-full border rounded p-1"
+              value={accommodation}
+              onChange={(e) => setAccommodation(e.target.value)}
+            />
+          </label>
+          <label htmlFor="discount" className="flex flex-col text-sm">
+            Discount (optional)
+            <input
+              id="discount"
+              type="number"
+              className="w-full border rounded p-1"
+              value={discount}
+              onChange={(e) => setDiscount(Number(e.target.value))}
+            />
+          </label>
+          <label htmlFor="expires-hours" className="flex flex-col text-sm">
+            Expires in
+            <select
+              id="expires-hours"
+              className="w-full border rounded p-1"
+              value={expiresHours ?? ''}
+              onChange={(e) => setExpiresHours(e.target.value ? Number(e.target.value) : null)}
+            >
+              <option value="">No expiry</option>
+              {expiryOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <div className="text-sm mt-2">
             Subtotal: {formatCurrency(subtotal)}
             <br />

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -49,6 +49,16 @@ describe('SendQuoteModal', () => {
     expect(inputs[0].value).toBe('5');
     expect(inputs[1].value).toBe('1');
     expect(inputs[2].value).toBe('2');
+    const soundLabel = div.querySelector('label[for="sound-fee"]');
+    const travelLabel = div.querySelector('label[for="travel-fee"]');
+    const discountLabel = div.querySelector('label[for="discount"]');
+    const accommodationLabel = div.querySelector('label[for="accommodation"]');
+    const expiryLabel = div.querySelector('label[for="expires-hours"]');
+    expect(soundLabel?.textContent).toContain('Sound fee');
+    expect(travelLabel?.textContent).toContain('Travel fee');
+    expect(discountLabel?.textContent).toContain('Discount');
+    expect(accommodationLabel?.textContent).toContain('Accommodation');
+    expect(expiryLabel?.textContent).toContain('Expires in');
     root.unmount();
   });
 
@@ -90,6 +100,26 @@ describe('SendQuoteModal', () => {
     });
     const summary = div.querySelector('div.text-sm.mt-2') as HTMLDivElement;
     expect(summary.textContent).toContain(formatCurrency(8));
+    root.unmount();
+  });
+
+  it('matches snapshot', async () => {
+    (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <SendQuoteModal
+          open
+          onClose={() => {}}
+          onSubmit={() => {}}
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+        />,
+      );
+    });
+    expect(div.firstChild).toMatchSnapshot();
     root.unmount();
   });
 });

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SendQuoteModal matches snapshot 1`] = `
+<div
+  class="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+>
+  <div
+    class="bg-white rounded-lg shadow-lg w-full max-w-md p-4"
+  >
+    <h2
+      class="text-lg font-medium mb-2"
+    >
+      Send Quote
+    </h2>
+    <div
+      class="space-y-2 max-h-[60vh] overflow-y-auto"
+    >
+      <div
+        class="flex gap-2 items-center"
+      >
+        <input
+          class="flex-1 border rounded p-1"
+          placeholder="Description"
+          type="text"
+          value=""
+        />
+        <input
+          class="w-24 border rounded p-1"
+          placeholder="Price"
+          type="number"
+          value="0"
+        />
+      </div>
+      <button
+        aria-busy="false"
+        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300 text-sm"
+        type="button"
+      >
+        <span
+          class=""
+        >
+          Add Item
+        </span>
+      </button>
+      <label
+        class="flex flex-col text-sm"
+        for="sound-fee"
+      >
+        Sound fee
+        <input
+          class="w-full border rounded p-1"
+          id="sound-fee"
+          type="number"
+          value="0"
+        />
+      </label>
+      <label
+        class="flex flex-col text-sm"
+        for="travel-fee"
+      >
+        Travel fee
+        <input
+          class="w-full border rounded p-1"
+          id="travel-fee"
+          type="number"
+          value="0"
+        />
+      </label>
+      <label
+        class="flex flex-col text-sm"
+        for="accommodation"
+      >
+        Accommodation (optional)
+        <textarea
+          class="w-full border rounded p-1"
+          id="accommodation"
+        />
+      </label>
+      <label
+        class="flex flex-col text-sm"
+        for="discount"
+      >
+        Discount (optional)
+        <input
+          class="w-full border rounded p-1"
+          id="discount"
+          type="number"
+          value="0"
+        />
+      </label>
+      <label
+        class="flex flex-col text-sm"
+        for="expires-hours"
+      >
+        Expires in
+        <select
+          class="w-full border rounded p-1"
+          id="expires-hours"
+        >
+          <option
+            value=""
+          >
+            No expiry
+          </option>
+          <option
+            value="24"
+          >
+            24h
+          </option>
+          <option
+            value="72"
+          >
+            3 days
+          </option>
+        </select>
+      </label>
+      <div
+        class="text-sm mt-2"
+      >
+        Subtotal: 
+        R 0,00
+        <br />
+        Total: 
+        R 0,00
+      </div>
+    </div>
+    <div
+      class="flex justify-end gap-2 mt-4"
+    >
+      <button
+        aria-busy="false"
+        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300"
+        type="button"
+      >
+        <span
+          class=""
+        >
+          Cancel
+        </span>
+      </button>
+      <button
+        aria-busy="false"
+        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-brand hover:bg-brand-dark text-white focus:ring-brand-dark"
+        type="button"
+      >
+        <span
+          class=""
+        >
+          Send
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- wrap quote amount fields in label elements in SendQuoteModal
- update SendQuoteModal tests with label queries and snapshot
- document quote modal labels in frontend README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853bc991fe8832e9c15c1adc0214799