### PR TITLE
Add View Artist links to bookings pages

### DIFF
--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -1,21 +1,21 @@
-'use client';
+"use client";
 
-import { useEffect, useState, useCallback } from 'react';
-import { useParams, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
-import MainLayout from '@/components/layout/MainLayout';
-import PaymentModal from '@/components/booking/PaymentModal';
-import toast from '@/components/ui/Toast';
-import { HelpPrompt } from '@/components/ui';
-import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
-import type { Booking } from '@/types';
-import { formatCurrency } from '@/lib/utils';
-import { Spinner } from '@/components/ui';
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import MainLayout from "@/components/layout/MainLayout";
+import PaymentModal from "@/components/booking/PaymentModal";
+import toast from "@/components/ui/Toast";
+import { HelpPrompt } from "@/components/ui";
+import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
+import type { Booking } from "@/types";
+import { formatCurrency } from "@/lib/utils";
+import { Spinner } from "@/components/ui";
 
 export default function BookingDetailsPage() {
   const params = useParams();
   const searchParams = useSearchParams();
-  const pay = searchParams.get('pay');
+  const pay = searchParams.get("pay");
   const id = Number(params.id);
 
   const [booking, setBooking] = useState<Booking | null>(null);
@@ -29,12 +29,12 @@ export default function BookingDetailsPage() {
       try {
         const res = await getBookingDetails(id);
         setBooking(res.data);
-        if (pay === '1' && res.data.payment_status === 'pending') {
+        if (pay === "1" && res.data.payment_status === "pending") {
           setShowPayment(true);
         }
       } catch (err) {
-        console.error('Failed to load booking', err);
-        setError('Failed to load booking');
+        console.error("Failed to load booking", err);
+        setError("Failed to load booking");
       } finally {
         setLoading(false);
       }
@@ -46,9 +46,9 @@ export default function BookingDetailsPage() {
     if (!booking) return;
     try {
       const res = await downloadBookingIcs(booking.id);
-      const blob = new Blob([res.data], { type: 'text/calendar' });
+      const blob = new Blob([res.data], { type: "text/calendar" });
       const url = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.href = url;
       link.download = `booking-${booking.id}.ics`;
       document.body.appendChild(link);
@@ -56,9 +56,9 @@ export default function BookingDetailsPage() {
       link.remove();
       window.URL.revokeObjectURL(url);
     } catch (err) {
-      console.error('Calendar download error', err);
+      console.error("Calendar download error", err);
       toast.error(
-        err instanceof Error ? err.message : 'Failed to download calendar',
+        err instanceof Error ? err.message : "Failed to download calendar",
       );
     }
   }, [booking]);
@@ -66,7 +66,9 @@ export default function BookingDetailsPage() {
   if (loading) {
     return (
       <MainLayout>
-        <div className="p-8"><Spinner /></div>
+        <div className="p-8">
+          <Spinner />
+        </div>
       </MainLayout>
     );
   }
@@ -74,7 +76,7 @@ export default function BookingDetailsPage() {
   if (error || !booking) {
     return (
       <MainLayout>
-        <div className="p-8 text-red-600">{error || 'Booking not found'}</div>
+        <div className="p-8 text-red-600">{error || "Booking not found"}</div>
       </MainLayout>
     );
   }
@@ -86,6 +88,13 @@ export default function BookingDetailsPage() {
         <p className="text-sm text-gray-700">
           {new Date(booking.start_time).toLocaleString()}
         </p>
+        <Link
+          href={`/artists/${booking.artist_id}`}
+          className="text-indigo-600 underline text-sm"
+          data-testid="view-artist-link"
+        >
+          View Artist
+        </Link>
         {booking.deposit_amount !== undefined && (
           <p className="text-sm text-gray-700">
             Deposit: {formatCurrency(Number(booking.deposit_amount || 0))} (
@@ -94,7 +103,8 @@ export default function BookingDetailsPage() {
         )}
         {booking.deposit_due_by && (
           <p className="text-sm text-gray-700">
-            Deposit due by {new Date(booking.deposit_due_by).toLocaleDateString()}
+            Deposit due by{" "}
+            {new Date(booking.deposit_due_by).toLocaleDateString()}
           </p>
         )}
         {booking.payment_id && (
@@ -111,7 +121,7 @@ export default function BookingDetailsPage() {
           </p>
         )}
         <div className="mt-2 space-x-4">
-          {booking.payment_status === 'pending' && (
+          {booking.payment_status === "pending" && (
             <button
               type="button"
               onClick={() => setShowPayment(true)}
@@ -121,7 +131,7 @@ export default function BookingDetailsPage() {
               Pay deposit
             </button>
           )}
-          {booking.status === 'confirmed' && (
+          {booking.status === "confirmed" && (
             <button
               type="button"
               onClick={handleDownload}
@@ -152,13 +162,15 @@ export default function BookingDetailsPage() {
       <PaymentModal
         open={showPayment}
         onClose={() => setShowPayment(false)}
-        bookingRequestId={booking.source_quote?.booking_request_id || booking.id}
+        bookingRequestId={
+          booking.source_quote?.booking_request_id || booking.id
+        }
         depositAmount={booking.deposit_amount}
         depositDueBy={booking.deposit_due_by ?? undefined}
         onSuccess={({ paymentId }) => {
           setBooking({
             ...booking,
-            payment_status: 'deposit_paid',
+            payment_status: "deposit_paid",
             payment_id: paymentId ?? booking.payment_id,
           });
           setShowPayment(false);

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -1,24 +1,27 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { act } from 'react';
-import BookingDetailsPage from '../[id]/page';
-import { getBookingDetails, downloadBookingIcs } from '@/lib/api';
-import { useParams, useSearchParams } from 'next/navigation';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import BookingDetailsPage from "../[id]/page";
+import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
+import { useParams, useSearchParams } from "next/navigation";
 
-jest.mock('@/lib/api');
-jest.mock('next/navigation', () => ({
+jest.mock("@/lib/api");
+jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useSearchParams: jest.fn(),
-  usePathname: jest.fn(() => '/dashboard/client/bookings/1'),
+  usePathname: jest.fn(() => "/dashboard/client/bookings/1"),
 }));
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
-jest.mock('next/link', () => {
-  const React = require('react');
-  return { __esModule: true, default: (props: any) => React.createElement('a', props) };
+jest.mock("next/link", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: (props: any) => React.createElement("a", props),
+  };
 });
 /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 
-describe('BookingDetailsPage', () => {
+describe("BookingDetailsPage", () => {
   beforeEach(() => {
     (useSearchParams as jest.Mock).mockReturnValue({ get: () => null });
   });
@@ -26,8 +29,8 @@ describe('BookingDetailsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('renders booking details and shows pay button when pending', async () => {
-    (useParams as jest.Mock).mockReturnValue({ id: '1' });
+  it("renders booking details and shows pay button when pending", async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: "1" });
     (getBookingDetails as jest.Mock).mockResolvedValue({
       data: {
         id: 1,
@@ -36,37 +39,43 @@ describe('BookingDetailsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 100,
-        notes: '',
+        notes: "",
         deposit_amount: 50,
-        deposit_due_by: new Date('2024-01-08').toISOString(),
-        payment_status: 'pending',
-        service: { title: 'Gig' },
+        deposit_due_by: new Date("2024-01-08").toISOString(),
+        payment_status: "pending",
+        service: { title: "Gig" },
         client: { id: 3 },
       },
     });
     (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     const root = createRoot(div);
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(getBookingDetails).toHaveBeenCalledWith(1);
-    expect(div.textContent).toContain('Gig');
-    expect(div.textContent).toContain('Deposit due');
+    expect(div.textContent).toContain("Gig");
+    expect(div.textContent).toContain("Deposit due");
+    const artistLink = div.querySelector('[data-testid="view-artist-link"]');
+    expect(artistLink?.getAttribute("href")).toBe("/artists/2");
     const pay = div.querySelector('[data-testid="pay-deposit-button"]');
     expect(pay).not.toBeNull();
 
-    act(() => { root.unmount(); });
+    act(() => {
+      root.unmount();
+    });
     div.remove();
   });
 
-  it('shows receipt link when payment_id is present', async () => {
-    (useParams as jest.Mock).mockReturnValue({ id: '2' });
+  it("shows receipt link when payment_id is present", async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: "2" });
     (getBookingDetails as jest.Mock).mockResolvedValue({
       data: {
         id: 2,
@@ -75,36 +84,40 @@ describe('BookingDetailsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 100,
-        notes: '',
+        notes: "",
         deposit_amount: 50,
-        deposit_due_by: new Date('2024-01-08').toISOString(),
-        payment_status: 'deposit_paid',
-        payment_id: 'pay_123',
-        service: { title: 'Gig' },
+        deposit_due_by: new Date("2024-01-08").toISOString(),
+        payment_status: "deposit_paid",
+        payment_id: "pay_123",
+        service: { title: "Gig" },
         client: { id: 3 },
       },
     });
     (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     const root = createRoot(div);
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const link = div.querySelector('[data-testid="booking-receipt-link"]');
     expect(link).not.toBeNull();
-    expect(link?.getAttribute('href')).toBe('/api/v1/payments/pay_123/receipt');
+    expect(link?.getAttribute("href")).toBe("/api/v1/payments/pay_123/receipt");
 
-    act(() => { root.unmount(); });
+    act(() => {
+      root.unmount();
+    });
     div.remove();
   });
 
-  it('renders the help prompt', async () => {
-    (useParams as jest.Mock).mockReturnValue({ id: '3' });
+  it("renders the help prompt", async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: "3" });
     (getBookingDetails as jest.Mock).mockResolvedValue({
       data: {
         id: 3,
@@ -113,34 +126,38 @@ describe('BookingDetailsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 100,
-        notes: '',
+        notes: "",
         deposit_amount: 50,
-        deposit_due_by: new Date('2024-01-08').toISOString(),
-        payment_status: 'pending',
-        service: { title: 'Gig' },
+        deposit_due_by: new Date("2024-01-08").toISOString(),
+        payment_status: "pending",
+        service: { title: "Gig" },
         client: { id: 3 },
       },
     });
     (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     const root = createRoot(div);
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const help = div.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();
 
-    act(() => { root.unmount(); });
+    act(() => {
+      root.unmount();
+    });
     div.remove();
   });
 
-  it('shows a link to message the artist', async () => {
-    (useParams as jest.Mock).mockReturnValue({ id: '4' });
+  it("shows a link to message the artist", async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: "4" });
     (getBookingDetails as jest.Mock).mockResolvedValue({
       data: {
         id: 4,
@@ -149,31 +166,36 @@ describe('BookingDetailsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 100,
-        notes: '',
+        notes: "",
         deposit_amount: 50,
-        deposit_due_by: new Date('2024-01-08').toISOString(),
-        payment_status: 'deposit_paid',
-        service: { title: 'Gig' },
+        deposit_due_by: new Date("2024-01-08").toISOString(),
+        payment_status: "deposit_paid",
+        service: { title: "Gig" },
         client: { id: 3 },
         source_quote: { booking_request_id: 7 },
       },
     });
     (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     const root = createRoot(div);
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
-    await act(async () => { await Promise.resolve(); });
-    
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const msg = div.querySelector('[data-testid="message-artist-link"]');
     expect(msg).not.toBeNull();
-    expect(msg?.getAttribute('href')).toBe('/booking-requests/7');
+    expect(msg?.getAttribute("href")).toBe("/booking-requests/7");
+    const artistLink = div.querySelector('[data-testid="view-artist-link"]');
+    expect(artistLink?.getAttribute("href")).toBe("/artists/2");
 
     act(() => {
       root.unmount();
@@ -181,10 +203,10 @@ describe('BookingDetailsPage', () => {
     div.remove();
   });
 
-  it('opens the payment modal when ?pay=1 and payment pending', async () => {
-    (useParams as jest.Mock).mockReturnValue({ id: '5' });
+  it("opens the payment modal when ?pay=1 and payment pending", async () => {
+    (useParams as jest.Mock).mockReturnValue({ id: "5" });
     (useSearchParams as jest.Mock).mockReturnValue({
-      get: (key: string) => (key === 'pay' ? '1' : null),
+      get: (key: string) => (key === "pay" ? "1" : null),
     });
     (getBookingDetails as jest.Mock).mockResolvedValue({
       data: {
@@ -194,19 +216,19 @@ describe('BookingDetailsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 100,
-        notes: '',
+        notes: "",
         deposit_amount: 50,
-        deposit_due_by: new Date('2024-01-08').toISOString(),
-        payment_status: 'pending',
-        service: { title: 'Gig' },
+        deposit_due_by: new Date("2024-01-08").toISOString(),
+        payment_status: "pending",
+        service: { title: "Gig" },
         client: { id: 3 },
       },
     });
     (downloadBookingIcs as jest.Mock).mockResolvedValue({ data: new Blob() });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     const root = createRoot(div);
     await act(async () => {
       root.render(<BookingDetailsPage />);
@@ -215,8 +237,8 @@ describe('BookingDetailsPage', () => {
       await Promise.resolve();
     });
 
-    const modalHeading = div.querySelector('h2');
-    expect(modalHeading?.textContent).toBe('Pay Deposit');
+    const modalHeading = div.querySelector("h2");
+    expect(modalHeading?.textContent).toBe("Pay Deposit");
 
     act(() => {
       root.unmount();
@@ -224,4 +246,3 @@ describe('BookingDetailsPage', () => {
     div.remove();
   });
 });
-

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -1,34 +1,42 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { act } from 'react';
-import ClientBookingsPage from '../page';
-import { getMyClientBookings, getBookingDetails } from '@/lib/api';
-import { formatCurrency } from '@/lib/utils';
-import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'next/navigation';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import ClientBookingsPage from "../page";
+import { getMyClientBookings, getBookingDetails } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter } from "next/navigation";
 
-jest.mock('@/lib/api');
-jest.mock('@/contexts/AuthContext');
-jest.mock('next/navigation', () => ({
+jest.mock("@/lib/api");
+jest.mock("@/contexts/AuthContext");
+jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
-  usePathname: jest.fn(() => '/dashboard/client/bookings'),
+  usePathname: jest.fn(() => "/dashboard/client/bookings"),
 }));
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
-jest.mock('next/link', () => {
-  const React = require('react');
-  return { __esModule: true, default: (props: any) => React.createElement('a', props) };
+jest.mock("next/link", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: (props: any) => React.createElement("a", props),
+  };
 });
 /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 
-describe('ClientBookingsPage', () => {
+describe("ClientBookingsPage", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders upcoming and past bookings with deposit info', async () => {
+  it("renders upcoming and past bookings with deposit info", async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
-      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+      user: {
+        id: 1,
+        user_type: "client",
+        email: "c@example.com",
+        first_name: "C",
+      },
     });
     (getMyClientBookings as jest.Mock)
       .mockResolvedValueOnce({
@@ -40,14 +48,14 @@ describe('ClientBookingsPage', () => {
             service_id: 4,
             start_time: new Date().toISOString(),
             end_time: new Date().toISOString(),
-            status: 'confirmed',
+            status: "confirmed",
             total_price: 100,
-            notes: '',
+            notes: "",
             deposit_amount: 50,
-            deposit_due_by: new Date('2024-01-08').toISOString(),
-            payment_status: 'deposit_paid',
-            payment_id: 'pay_upcoming',
-            service: { title: 'Gig' },
+            deposit_due_by: new Date("2024-01-08").toISOString(),
+            payment_status: "deposit_paid",
+            payment_id: "pay_upcoming",
+            service: { title: "Gig" },
             client: { id: 1 },
           },
         ],
@@ -61,18 +69,18 @@ describe('ClientBookingsPage', () => {
             service_id: 4,
             start_time: new Date().toISOString(),
             end_time: new Date().toISOString(),
-            status: 'completed',
+            status: "completed",
             total_price: 200,
-            notes: '',
+            notes: "",
             deposit_amount: 100,
-            payment_status: 'paid',
-            service: { title: 'Gig' },
+            payment_status: "paid",
+            service: { title: "Gig" },
             client: { id: 1 },
           },
         ],
       });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     document.body.appendChild(div);
     const root = createRoot(div);
 
@@ -83,20 +91,22 @@ describe('ClientBookingsPage', () => {
       await Promise.resolve();
     });
 
-    expect(getMyClientBookings).toHaveBeenCalledWith({ status: 'upcoming' });
-    expect(getMyClientBookings).toHaveBeenCalledWith({ status: 'past' });
-    expect(div.textContent).toContain('Upcoming Bookings');
-    expect(div.textContent).toContain('Past Bookings');
-    expect(div.textContent).toContain('Deposit:');
-    expect(div.textContent).toContain('Deposit Paid');
-    expect(div.textContent).toContain('Deposit due by');
-    expect(div.textContent).toContain('Requested');
-    expect(div.textContent).toContain('Completed');
+    expect(getMyClientBookings).toHaveBeenCalledWith({ status: "upcoming" });
+    expect(getMyClientBookings).toHaveBeenCalledWith({ status: "past" });
+    expect(div.textContent).toContain("Upcoming Bookings");
+    expect(div.textContent).toContain("Past Bookings");
+    expect(div.textContent).toContain("Deposit:");
+    expect(div.textContent).toContain("Deposit Paid");
+    expect(div.textContent).toContain("Deposit due by");
+    expect(div.textContent).toContain("Requested");
+    expect(div.textContent).toContain("Completed");
     const link = div.querySelector('a[data-booking-id="1"]');
-    expect(link?.getAttribute('href')).toBe('/dashboard/client/bookings/1');
+    expect(link?.getAttribute("href")).toBe("/dashboard/client/bookings/1");
+    const artistLink = div.querySelector('[data-testid="view-artist-link"]');
+    expect(artistLink?.getAttribute("href")).toBe("/artists/2");
     const receipt = div.querySelector('[data-testid="booking-receipt-link"]');
-    expect(receipt?.getAttribute('href')).toBe(
-      '/api/v1/payments/pay_upcoming/receipt',
+    expect(receipt?.getAttribute("href")).toBe(
+      "/api/v1/payments/pay_upcoming/receipt",
     );
     const help = div.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();
@@ -107,10 +117,15 @@ describe('ClientBookingsPage', () => {
     div.remove();
   });
 
-  it('shows review button for completed bookings', async () => {
+  it("shows review button for completed bookings", async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
-      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+      user: {
+        id: 1,
+        user_type: "client",
+        email: "c@example.com",
+        first_name: "C",
+      },
     });
     (getMyClientBookings as jest.Mock)
       .mockResolvedValueOnce({ data: [] })
@@ -123,27 +138,29 @@ describe('ClientBookingsPage', () => {
             service_id: 4,
             start_time: new Date().toISOString(),
             end_time: new Date().toISOString(),
-            status: 'completed',
+            status: "completed",
             total_price: 100,
-            notes: '',
+            notes: "",
             deposit_amount: 50,
-            payment_status: 'deposit_paid',
-            service: { title: 'Gig' },
+            payment_status: "deposit_paid",
+            service: { title: "Gig" },
             client: { id: 1 },
           },
         ],
       });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     document.body.appendChild(div);
     const root = createRoot(div);
 
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
-    expect(div.textContent).toContain('Leave review');
+    expect(div.textContent).toContain("Leave review");
     const help = div.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();
 
@@ -153,10 +170,15 @@ describe('ClientBookingsPage', () => {
     div.remove();
   });
 
-  it('opens payment modal with deposit amount when clicking pay button', async () => {
+  it("opens payment modal with deposit amount when clicking pay button", async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
-      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+      user: {
+        id: 1,
+        user_type: "client",
+        email: "c@example.com",
+        first_name: "C",
+      },
     });
     (getMyClientBookings as jest.Mock)
       .mockResolvedValueOnce({
@@ -168,12 +190,12 @@ describe('ClientBookingsPage', () => {
             service_id: 4,
             start_time: new Date().toISOString(),
             end_time: new Date().toISOString(),
-            status: 'confirmed',
+            status: "confirmed",
             total_price: 120,
-            notes: '',
+            notes: "",
             deposit_amount: 60,
-            payment_status: 'pending',
-            service: { title: 'Gig' },
+            payment_status: "pending",
+            service: { title: "Gig" },
             client: { id: 1 },
           },
         ],
@@ -187,33 +209,39 @@ describe('ClientBookingsPage', () => {
         service_id: 4,
         start_time: new Date().toISOString(),
         end_time: new Date().toISOString(),
-        status: 'confirmed',
+        status: "confirmed",
         total_price: 120,
-        notes: '',
+        notes: "",
         deposit_amount: 80,
-        payment_status: 'pending',
-        service: { title: 'Gig' },
+        payment_status: "pending",
+        service: { title: "Gig" },
         client: { id: 1 },
         source_quote: { booking_request_id: 5 },
       },
     });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     document.body.appendChild(div);
     const root = createRoot(div);
 
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
-    const payBtn = div.querySelector('[data-testid="pay-deposit-button"]') as HTMLButtonElement;
+    const payBtn = div.querySelector(
+      '[data-testid="pay-deposit-button"]',
+    ) as HTMLButtonElement;
     expect(payBtn).not.toBeNull();
 
     await act(async () => {
-      payBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      payBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(getBookingDetails).toHaveBeenCalledWith(5);
     const input = div.querySelector('input[type="text"]') as HTMLInputElement;
@@ -225,10 +253,15 @@ describe('ClientBookingsPage', () => {
     div.remove();
   });
 
-  it('links each booking card to the booking request', async () => {
+  it("links each booking card to the booking request", async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
-      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+      user: {
+        id: 1,
+        user_type: "client",
+        email: "c@example.com",
+        first_name: "C",
+      },
     });
     (getMyClientBookings as jest.Mock)
       .mockResolvedValueOnce({
@@ -240,12 +273,12 @@ describe('ClientBookingsPage', () => {
             service_id: 4,
             start_time: new Date().toISOString(),
             end_time: new Date().toISOString(),
-            status: 'confirmed',
+            status: "confirmed",
             total_price: 150,
-            notes: '',
+            notes: "",
             deposit_amount: 50,
-            payment_status: 'deposit_paid',
-            service: { title: 'Gig' },
+            payment_status: "deposit_paid",
+            service: { title: "Gig" },
             client: { id: 1 },
             source_quote: { booking_request_id: 12 },
           },
@@ -253,18 +286,22 @@ describe('ClientBookingsPage', () => {
       })
       .mockResolvedValueOnce({ data: [] });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     document.body.appendChild(div);
     const root = createRoot(div);
 
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const msgLink = div.querySelector('[data-testid="message-artist-link"]');
     expect(msgLink).not.toBeNull();
-    expect(msgLink?.getAttribute('href')).toBe('/booking-requests/12');
+    expect(msgLink?.getAttribute("href")).toBe("/booking-requests/12");
+    const artistLink = div.querySelector('[data-testid="view-artist-link"]');
+    expect(artistLink?.getAttribute("href")).toBe("/artists/2");
 
     act(() => {
       root.unmount();
@@ -272,10 +309,15 @@ describe('ClientBookingsPage', () => {
     div.remove();
   });
 
-  it('shows alert when there are pending deposits', async () => {
+  it("shows alert when there are pending deposits", async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({
-      user: { id: 1, user_type: 'client', email: 'c@example.com', first_name: 'C' },
+      user: {
+        id: 1,
+        user_type: "client",
+        email: "c@example.com",
+        first_name: "C",
+      },
     });
     (getMyClientBookings as jest.Mock)
       .mockResolvedValueOnce({
@@ -285,33 +327,35 @@ describe('ClientBookingsPage', () => {
             artist_id: 2,
             client_id: 1,
             service_id: 4,
-            start_time: new Date('2023-01-01').toISOString(),
-            end_time: new Date('2023-01-01').toISOString(),
-            status: 'confirmed',
+            start_time: new Date("2023-01-01").toISOString(),
+            end_time: new Date("2023-01-01").toISOString(),
+            status: "confirmed",
             total_price: 100,
-            notes: '',
+            notes: "",
             deposit_amount: 50,
-            payment_status: 'pending',
-            service: { title: 'Gig' },
+            payment_status: "pending",
+            service: { title: "Gig" },
             client: { id: 1 },
           },
         ],
       })
       .mockResolvedValueOnce({ data: [] });
 
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     document.body.appendChild(div);
     const root = createRoot(div);
 
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const alert = div.querySelector('[data-testid="pending-payment-alert"]');
     expect(alert).not.toBeNull();
-    const link = alert?.querySelector('a');
-    expect(link?.getAttribute('href')).toBe('/dashboard/client/bookings/1');
+    const link = alert?.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/dashboard/client/bookings/1");
 
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -1,17 +1,17 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import MainLayout from '@/components/layout/MainLayout';
-import { useAuth } from '@/contexts/AuthContext';
-import { getMyClientBookings, getBookingDetails } from '@/lib/api';
-import type { Booking, Review } from '@/types';
-import ReviewFormModal from '@/components/review/ReviewFormModal';
-import PaymentModal from '@/components/booking/PaymentModal';
-import { format } from 'date-fns';
-import { formatCurrency } from '@/lib/utils';
-import Link from 'next/link';
-import { XMarkIcon } from '@heroicons/react/24/outline';
-import { HelpPrompt, Spinner } from '@/components/ui';
+import { useEffect, useState } from "react";
+import MainLayout from "@/components/layout/MainLayout";
+import { useAuth } from "@/contexts/AuthContext";
+import { getMyClientBookings, getBookingDetails } from "@/lib/api";
+import type { Booking, Review } from "@/types";
+import ReviewFormModal from "@/components/review/ReviewFormModal";
+import PaymentModal from "@/components/booking/PaymentModal";
+import { format } from "date-fns";
+import { formatCurrency } from "@/lib/utils";
+import Link from "next/link";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { HelpPrompt, Spinner } from "@/components/ui";
 
 interface BookingWithReview extends Booking {
   review?: Review | null;
@@ -37,18 +37,18 @@ function BookingList({
           >
             <div className="font-medium text-gray-900">{b.service.title}</div>
             <div className="text-sm text-gray-500">
-              {format(new Date(b.start_time), 'MMM d, yyyy h:mm a')}
+              {format(new Date(b.start_time), "MMM d, yyyy h:mm a")}
             </div>
             <div className="mt-2 flex justify-between items-center">
               <span
                 className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${
-                  b.status === 'completed'
-                    ? 'bg-green-100 text-green-800'
-                    : b.status === 'cancelled'
-                      ? 'bg-red-100 text-red-800'
-                      : b.status === 'confirmed'
-                        ? 'bg-brand-light text-brand-dark'
-                        : 'bg-yellow-100 text-yellow-800'
+                  b.status === "completed"
+                    ? "bg-green-100 text-green-800"
+                    : b.status === "cancelled"
+                      ? "bg-red-100 text-red-800"
+                      : b.status === "confirmed"
+                        ? "bg-brand-light text-brand-dark"
+                        : "bg-yellow-100 text-yellow-800"
                 }`}
               >
                 {b.status}
@@ -63,49 +63,55 @@ function BookingList({
                 {b.payment_status})
               </div>
             )}
-          {b.deposit_due_by && (
-            <div className="text-sm text-gray-500 mt-1">
-              Deposit due by {format(new Date(b.deposit_due_by), 'MMM d, yyyy')}
-            </div>
-          )}
-          {b.payment_id && (
-            <a
-              href={`/api/v1/payments/${b.payment_id}/receipt`}
-              target="_blank"
-              rel="noopener"
-              className="mt-2 text-indigo-600 hover:underline text-sm"
-              data-testid="booking-receipt-link"
-            >
-              View receipt
-            </a>
-          )}
-          <div className="flex justify-between text-xs text-gray-500 mt-2">
-            {['Requested', 'Confirmed', 'Deposit Paid',
-              b.status === 'cancelled' ? 'Cancelled' : 'Completed'].map(
-                (step, idx) => {
-                  const activeIdx =
-                    b.status === 'pending'
-                      ? 0
-                      : b.status === 'confirmed'
-                        ? b.payment_status === 'deposit_paid' || b.payment_status === 'paid'
-                          ? 2
-                          : 1
-                        : 3;
-                  return (
-                    <span
-                      key={step}
-                      className={
-                        idx <= activeIdx ? 'font-semibold text-indigo-600 flex-1 text-center' : 'flex-1 text-center'
-                      }
-                    >
-                      {step}
-                    </span>
-                  );
-                },
-              )}
+            {b.deposit_due_by && (
+              <div className="text-sm text-gray-500 mt-1">
+                Deposit due by{" "}
+                {format(new Date(b.deposit_due_by), "MMM d, yyyy")}
+              </div>
+            )}
+            {b.payment_id && (
+              <a
+                href={`/api/v1/payments/${b.payment_id}/receipt`}
+                target="_blank"
+                rel="noopener"
+                className="mt-2 text-indigo-600 hover:underline text-sm"
+                data-testid="booking-receipt-link"
+              >
+                View receipt
+              </a>
+            )}
+            <div className="flex justify-between text-xs text-gray-500 mt-2">
+              {[
+                "Requested",
+                "Confirmed",
+                "Deposit Paid",
+                b.status === "cancelled" ? "Cancelled" : "Completed",
+              ].map((step, idx) => {
+                const activeIdx =
+                  b.status === "pending"
+                    ? 0
+                    : b.status === "confirmed"
+                      ? b.payment_status === "deposit_paid" ||
+                        b.payment_status === "paid"
+                        ? 2
+                        : 1
+                      : 3;
+                return (
+                  <span
+                    key={step}
+                    className={
+                      idx <= activeIdx
+                        ? "font-semibold text-indigo-600 flex-1 text-center"
+                        : "flex-1 text-center"
+                    }
+                  >
+                    {step}
+                  </span>
+                );
+              })}
             </div>
           </Link>
-          {b.payment_status === 'pending' && (
+          {b.payment_status === "pending" && (
             <button
               type="button"
               onClick={() => onPayDeposit(b.id)}
@@ -115,7 +121,7 @@ function BookingList({
               Pay deposit
             </button>
           )}
-          {b.status === 'completed' && !b.review && (
+          {b.status === "completed" && !b.review && (
             <button
               type="button"
               onClick={() => onReview(b.id)}
@@ -138,6 +144,13 @@ function BookingList({
               Message Artist
             </Link>
           )}
+          <Link
+            href={`/artists/${b.artist_id}`}
+            className="mt-2 text-indigo-600 hover:underline text-sm"
+            data-testid="view-artist-link"
+          >
+            View Artist
+          </Link>
         </li>
       ))}
     </ul>
@@ -150,10 +163,11 @@ export default function ClientBookingsPage() {
   const [past, setPast] = useState<BookingWithReview[]>([]);
   const [reviewId, setReviewId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
   const [showPayment, setShowPayment] = useState(false);
-  const [paymentBookingRequestId, setPaymentBookingRequestId] =
-    useState<number | null>(null);
+  const [paymentBookingRequestId, setPaymentBookingRequestId] = useState<
+    number | null
+  >(null);
   const [paymentDeposit, setPaymentDeposit] = useState<number | undefined>();
   const [paymentBookingId, setPaymentBookingId] = useState<number | null>(null);
   const [showPendingAlert, setShowPendingAlert] = useState(true);
@@ -164,24 +178,24 @@ export default function ClientBookingsPage() {
     const fetchData = async () => {
       try {
         const [upRes, pastRes] = await Promise.all([
-          getMyClientBookings({ status: 'upcoming' }),
-          getMyClientBookings({ status: 'past' }),
+          getMyClientBookings({ status: "upcoming" }),
+          getMyClientBookings({ status: "past" }),
         ]);
         setUpcoming(upRes.data);
         setPast(pastRes.data);
       } catch (err) {
-        console.error('Failed to load client bookings', err);
-        setError('Failed to load bookings');
+        console.error("Failed to load client bookings", err);
+        setError("Failed to load bookings");
       } finally {
         setLoading(false);
       }
     };
 
-    if (user.user_type === 'client') {
+    if (user.user_type === "client") {
       fetchData();
     } else {
       setLoading(false);
-      setError('Access denied');
+      setError("Access denied");
     }
   }, [user]);
 
@@ -199,8 +213,8 @@ export default function ClientBookingsPage() {
       setPaymentBookingId(id);
       setShowPayment(true);
     } catch (err) {
-      console.error('Failed to load booking details for payment', err);
-      setError('Failed to load payment details');
+      console.error("Failed to load booking details for payment", err);
+      setError("Failed to load payment details");
     }
   };
 
@@ -211,7 +225,7 @@ export default function ClientBookingsPage() {
   };
 
   const pendingBookings = [...upcoming, ...past].filter(
-    (b) => b.payment_status === 'pending',
+    (b) => b.payment_status === "pending",
   );
   const oldestPending = pendingBookings
     .slice()
@@ -258,7 +272,7 @@ export default function ClientBookingsPage() {
             <div className="flex items-start justify-between">
               <p className="text-sm text-yellow-700">
                 You have {pendingBookings.length} pending deposit
-                {pendingBookings.length > 1 ? 's' : ''}.{' '}
+                {pendingBookings.length > 1 ? "s" : ""}.{" "}
                 <Link
                   href={`/dashboard/client/bookings/${oldestPending.id}`}
                   className="font-medium underline"
@@ -318,11 +332,12 @@ export default function ClientBookingsPage() {
           depositAmount={
             paymentDeposit !== undefined
               ? paymentDeposit
-              : [...upcoming, ...past].find((b) => b.id === paymentBookingId)?.deposit_amount
+              : [...upcoming, ...past].find((b) => b.id === paymentBookingId)
+                  ?.deposit_amount
           }
           depositDueBy={
-            [...upcoming, ...past].find((b) => b.id === paymentBookingId)?.deposit_due_by ??
-            undefined
+            [...upcoming, ...past].find((b) => b.id === paymentBookingId)
+              ?.deposit_due_by ?? undefined
           }
           onClose={() => setShowPayment(false)}
           onSuccess={(result) => {


### PR DESCRIPTION
## Summary
- link each booking card to the artist profile
- show the same artist link on booking details page
- verify artist links in dashboard booking tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853c4d03030832eaf721a50888e45f5