### PR TITLE
Add reviews migration

### DIFF
--- a/backend/alembic/versions/01dc14acc6a1_create_reviews_table.py
+++ b/backend/alembic/versions/01dc14acc6a1_create_reviews_table.py
@@ -1,0 +1,39 @@
+"""create reviews table
+
+Revision ID: 01dc14acc6a1
+Revises: c8f4f76b2a6b
+Create Date: 2025-06-19 08:27:33.012302
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '01dc14acc6a1'
+down_revision: Union[str, None] = 'c8f4f76b2a6b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'reviews',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('booking_id', sa.Integer(), nullable=False),
+        sa.Column('service_id', sa.Integer(), nullable=False),
+        sa.Column('artist_id', sa.Integer(), nullable=False),
+        sa.Column('rating', sa.Integer(), nullable=False),
+        sa.Column('comment', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['booking_id'], ['bookings.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['artist_id'], ['artist_profiles.user_id'], ondelete='CASCADE'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('reviews')

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -68,3 +68,9 @@ These sample commands demonstrate the basic booking flow using the API. Replace 
    curl -H "Authorization: Bearer CLIENT_TOKEN" \
      http://localhost:8000/api/v1/bookings/my-bookings
    ```
+
+8. **Run database migrations**
+   ```bash
+   alembic upgrade head
+   ```
+   This includes the new migration for creating the `reviews` table.


### PR DESCRIPTION
## Summary
- add migration for `reviews` table
- document running migrations in onboarding guide

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853c9a848a4832eba5a60c9af625f61