### PR TITLE
Add review request notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
 * Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `R50.00 due by Jan 1, 2025`.
 * Deposit due and new booking notifications now link to the full booking created from the accepted quote instead of the temporary record.
+* Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can quickly rate their experience.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.

--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -209,6 +209,7 @@ def update_booking_status(
             detail="Booking not found or you lack permission to update it.",
         )
 
+    prev_status = booking.status
     if status_update.status is not None:
         booking.status = status_update.status
 
@@ -225,6 +226,14 @@ def update_booking_status(
         .filter(Booking.id == booking.id)
         .first()
     )
+
+    if (
+        prev_status != BookingStatus.COMPLETED
+        and booking.status == BookingStatus.COMPLETED
+    ):
+        from ..utils.notifications import notify_review_request
+
+        notify_review_request(db, booking.client, booking.id)
     return reloaded
 
 

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -241,3 +241,27 @@ def notify_new_booking(db: Session, user: Optional[User], booking_id: int) -> No
     )
     logger.info("Notify %s: %s", user.email, message)
     _send_sms(user.phone_number, message)
+
+
+def notify_review_request(db: Session, user: Optional[User], booking_id: int) -> None:
+    """Notify a user to review a completed booking."""
+    if user is None:
+        logger.error(
+            "Failed to send review request notification: user missing for booking %s",
+            booking_id,
+        )
+        return
+
+    message = format_notification_message(
+        NotificationType.REVIEW_REQUEST,
+        booking_id=booking_id,
+    )
+    crud_notification.create_notification(
+        db,
+        user_id=user.id,
+        type=NotificationType.REVIEW_REQUEST,
+        message=message,
+        link=f"/dashboard/client/bookings/{booking_id}?review=1",
+    )
+    logger.info("Notify %s: %s", user.email, message)
+    _send_sms(user.phone_number, message)


### PR DESCRIPTION
## Summary
- add notify_review_request utility for sending review request notifications
- trigger the helper when bookings are marked completed
- document new notification type
- test that the notification is created with correct message and link

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853cb4668a0832eaeeccb8d81c38a09