### PR TITLE
Handle review request notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
 * Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `R50.00 due by Jan 1, 2025`.
 * Deposit due and new booking notifications now link to the full booking created from the accepted quote instead of the temporary record.
-* Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can quickly rate their experience.
+* Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}` so clients can quickly rate their experience.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -57,6 +57,10 @@ export default function FullScreenNotificationModal({
     await onItemClick(itemId);
     if (item.type === 'message' && item.booking_request_id) {
       router.push(`/messages/thread/${item.booking_request_id}`);
+    } else if (item.type === 'review_request' && item.link) {
+      const match = item.link.match(/bookings\/(\d+)/);
+      const bid = match ? match[1] : '';
+      router.push(`/dashboard/client/bookings/${bid}`);
     } else if (item.link) {
       router.push(item.link);
     }

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -58,6 +58,10 @@ export default function NotificationBell(): JSX.Element {
     setOpen(false);
     if (item.type === 'message' && item.booking_request_id) {
       router.push(`/messages/thread/${item.booking_request_id}`);
+    } else if (item.type === 'review_request' && item.link) {
+      const match = item.link.match(/bookings\/(\d+)/);
+      const bid = match ? match[1] : '';
+      router.push(`/dashboard/client/bookings/${bid}`);
     } else if (item.link) {
       router.push(item.link);
     } else {

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -91,6 +91,12 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       metadata,
     };
   }
+  if (n.type === 'review_request') {
+    const title = 'Review Request';
+    const subtitle =
+      n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;
+    return { title, subtitle, icon: '🔔' };
+  }
   if (/deposit.*due/i.test(n.content)) {
     let subtitle =
       n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -78,4 +78,37 @@ describe('NotificationListItem', () => {
     expect(parsed.title).toBe('Booking Confirmed');
     expect(parsed.icon).toBe('📅');
   });
+
+  it('parses review request notifications', () => {
+    const n: UnifiedNotification = {
+      type: 'review_request',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Please review your booking #7',
+      link: '/dashboard/client/bookings/7?review=1',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.title).toBe('Review Request');
+    expect(parsed.icon).toBe('🔔');
+  });
+
+  it('sets title attribute for review request', () => {
+    const n: UnifiedNotification = {
+      type: 'review_request',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Please review your booking #8',
+      link: '/dashboard/client/bookings/8?review=1',
+    } as UnifiedNotification;
+    act(() => {
+      root.render(
+        React.createElement(NotificationListItem, {
+          n,
+          onClick: () => {},
+        }),
+      );
+    });
+    const span = container.querySelector('span[title]');
+    expect(span?.getAttribute('title')).toBe('Review Request');
+  });
 });


### PR DESCRIPTION
## Summary
- support `review_request` in NotificationListItem
- open bookings page on review request clicks
- document new review request link
- test review request parsing

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853ccb654e4832ea780bc629f30138b