### PR TITLE
Add leave review action in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Each booking item in this list now includes a `deposit_due_by` field when the booking was created from a quote.
 - Artists can mark bookings completed or cancelled and download confirmed bookings as calendar (.ics) files.
 - Clients can leave a star rating and comment once a booking is marked completed. Service detail pages now display these reviews.
+- A **Leave Review** button now appears in chat when a completed booking has no review.
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, add it to a calendar, and jump to **My Bookings**.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -37,6 +37,7 @@ import SendQuoteModal from './SendQuoteModal';
 import PaymentModal from './PaymentModal';
 import QuoteCard from './QuoteCard';
 import useWebSocket from '@/hooks/useWebSocket';
+import ReviewFormModal from '../review/ReviewFormModal';
 
 const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const wsBase =
@@ -85,6 +86,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [showQuoteModal, setShowQuoteModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
+  const [showReviewModal, setShowReviewModal] = useState(false);
   const [depositAmount, setDepositAmount] = useState<number | undefined>(
     undefined,
   );
@@ -849,6 +851,27 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               setPaymentError(null);
             }}
             onError={(msg) => setPaymentError(msg)}
+          />
+          {bookingDetails &&
+            bookingDetails.status === 'completed' &&
+            !(bookingDetails as any).review && (
+              <Button
+                type="button"
+                onClick={() => setShowReviewModal(true)}
+                className="mt-2 text-sm text-indigo-600 underline"
+              >
+                Leave Review
+              </Button>
+            )}
+          <ReviewFormModal
+            isOpen={showReviewModal}
+            bookingId={bookingDetails?.id ?? 0}
+            onClose={() => setShowReviewModal(false)}
+            onSubmitted={(rev) =>
+              setBookingDetails((prev) =>
+                prev ? { ...prev, review: rev } : prev,
+              )
+            }
           />
         </>
       )}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -855,6 +855,65 @@ describe('MessageThread component', () => {
     expect(link).not.toBeNull();
   });
 
+  it('shows Leave Review button for completed booking', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Quote',
+          message_type: 'quote',
+          quote_id: 12,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 12,
+        status: 'accepted',
+        booking_id: 3,
+        services: [],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 0,
+        total: 0,
+        artist_id: 2,
+        client_id: 1,
+        booking_request_id: 1,
+        created_at: '',
+        updated_at: '',
+      },
+    });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({
+      data: {
+        id: 3,
+        status: 'completed',
+        service: { title: 'Gig' },
+        start_time: '2024-01-01T00:00:00Z',
+        deposit_amount: 0,
+        review: null,
+      },
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const reviewBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Leave Review',
+    );
+    expect(reviewBtn).not.toBeUndefined();
+  });
+
   it('links the avatar to the artist profile when artistId is provided', async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary
- show a Leave Review button in MessageThread when a completed booking lacks a review
- open ReviewFormModal from that button and store the submitted review
- test for Leave Review button rendering when booking is completed
- document new chat feature in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853ceaf28bc832ebe159491480dd85a