### PR TITLE
Fix quote creation when booking request missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   circular references.
 * POST `/api/v1/booking-requests/{id}/quotes` now returns a Quote with
   `booking_request` set to `null` to prevent serialization cycles.
+* `POST /api/v1/quotes` returns **404 Not Found** when the
+  `booking_request_id` does not match an existing request.
 * Accepting a Quote V2 now also creates a formal booking visible on the artist dashboard.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
 * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query

--- a/backend/app/api/api_quote_v2.py
+++ b/backend/app/api/api_quote_v2.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 import logging
@@ -34,6 +34,8 @@ def create_quote(quote_in: schemas.QuoteV2Create, db: Session = Depends(get_db))
             attachment_url=None,
         )
         return quote
+    except HTTPException:
+        raise
     except Exception as exc:  # pragma: no cover - generic failure path
         logger.error(
             "Failed to create quote; artist_id=%s client_id=%s request_id=%s error=%s",

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -37,6 +37,12 @@ def create_quote(db: Session, quote_in: schemas.QuoteV2Create) -> models.QuoteV2
         .filter(models.BookingRequest.id == quote_in.booking_request_id)
         .first()
     )
+    if booking_request is None:
+        raise error_response(
+            "Booking request not found",
+            {"booking_request_id": "not_found"},
+            status.HTTP_404_NOT_FOUND,
+        )
     db_quote = models.QuoteV2(
         booking_request_id=quote_in.booking_request_id,
         artist_id=quote_in.artist_id,


### PR DESCRIPTION
## Summary
- raise 404 error when creating a quote for a nonexistent booking request
- propagate HTTPException from `create_quote`
- test missing request case in `test_quote_v2`
- document the new 404 behavior in the README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852be75a00c832eaef4a5ff9e3e021d