### PR TITLE
Add deposit fields to booking responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Python** 3.12
 - **Node.js** 21
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
-- Bookings now track `payment_status` and `deposit_amount` in `bookings_simple`.
-  The deposit amount defaults to half of the accepted quote total.
+- Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
+  `bookings_simple`. The deposit amount defaults to half of the accepted quote
+  total. Booking API responses now include these fields alongside
+  `deposit_due_by`.
 - A new `deposit_due_by` field records when the deposit is due, one week after a quote is accepted.
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
 - Booking cards now show deposit and payment status with a simple progress timeline.

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -38,6 +38,9 @@ class BookingResponse(BookingBase):
     created_at: datetime
     updated_at: datetime
     deposit_due_by: Optional[datetime] = None
+    deposit_amount: Optional[Decimal] = None
+    payment_status: Optional[str] = None
+    deposit_paid: Optional[bool] = None
 
     # Include nested details for frontend dashboard
     client: Optional[UserResponse] = None

--- a/backend/tests/test_booking_deposit_fields.py
+++ b/backend/tests/test_booking_deposit_fields.py
@@ -1,0 +1,133 @@
+import datetime
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import BaseModel
+from app.models import (
+    User,
+    UserType,
+    Service,
+    Booking,
+    BookingStatus,
+    BookingRequest,
+    QuoteV2,
+    QuoteStatusV2,
+    BookingSimple,
+)
+from app.api import api_booking
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def create_records(db):
+    client = User(
+        email="c@test.com",
+        password="x",
+        first_name="C",
+        last_name="L",
+        user_type=UserType.CLIENT,
+    )
+    artist = User(
+        email="a@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.ARTIST,
+    )
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title="Show",
+        price=Decimal("100"),
+        duration_minutes=60,
+        service_type="Live Performance",
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = QuoteV2(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[],
+        sound_fee=0,
+        travel_fee=0,
+        subtotal=Decimal("100"),
+        total=Decimal("100"),
+        status=QuoteStatusV2.ACCEPTED,
+    )
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+
+    booking = Booking(
+        artist_id=artist.id,
+        client_id=client.id,
+        service_id=service.id,
+        start_time=datetime.datetime(2030, 1, 1, 12, 0),
+        end_time=datetime.datetime(2030, 1, 1, 13, 0),
+        status=BookingStatus.CONFIRMED,
+        total_price=Decimal("100"),
+        quote_id=quote.id,
+    )
+    db.add(booking)
+    db.commit()
+    db.refresh(booking)
+
+    simple = BookingSimple(
+        quote_id=quote.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        confirmed=True,
+        payment_status="pending",
+        deposit_amount=Decimal("50"),
+        deposit_due_by=datetime.datetime(2029, 12, 25),
+        deposit_paid=False,
+    )
+    db.add(simple)
+    db.commit()
+    db.refresh(simple)
+
+    return client, booking
+
+
+def test_booking_endpoints_include_deposit_fields():
+    db = setup_db()
+    client, booking = create_records(db)
+
+    result = api_booking.read_my_bookings(db=db, current_client=client, status_filter=None)
+    assert result[0].deposit_amount == Decimal("50")
+    assert result[0].payment_status == "pending"
+    assert result[0].deposit_paid is False
+    assert result[0].deposit_due_by == datetime.datetime(2029, 12, 25)
+
+    detail = api_booking.read_booking_details(
+        db=db, booking_id=booking.id, current_user=client
+    )
+    assert detail.deposit_amount == Decimal("50")
+    assert detail.payment_status == "pending"
+    assert detail.deposit_paid is False
+    assert detail.deposit_due_by == datetime.datetime(2029, 12, 25)
+
+

--- a/backend/tests/test_client_bookings_status.py
+++ b/backend/tests/test_client_bookings_status.py
@@ -102,6 +102,9 @@ def test_filter_upcoming_and_past():
     assert len(data_upcoming) == 1
     assert data_upcoming[0]['status'] == 'confirmed'
     assert 'deposit_due_by' in data_upcoming[0]
+    assert 'deposit_amount' in data_upcoming[0]
+    assert 'payment_status' in data_upcoming[0]
+    assert 'deposit_paid' in data_upcoming[0]
 
     res_past = api_client.get('/api/v1/bookings/my-bookings?status=past')
     assert res_past.status_code == 200
@@ -109,6 +112,9 @@ def test_filter_upcoming_and_past():
     assert len(data_past) == 1
     assert data_past[0]['status'] == 'completed'
     assert 'deposit_due_by' in data_past[0]
+    assert 'deposit_amount' in data_past[0]
+    assert 'payment_status' in data_past[0]
+    assert 'deposit_paid' in data_past[0]
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- expose deposit_amount, payment_status and deposit_paid via BookingResponse
- include these fields when querying bookings
- ensure existing and new tests cover deposit fields
- document new booking fields

## Testing
- `./scripts/test-all.sh` *(fails: Unexpected any in frontend lint)*

------
https://chatgpt.com/codex/tasks/task_e_6853e698159c832eb399aa52853bb8f3