### PR TITLE
Use brand color for active step

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,7 @@ configuration includes this directory in its `content` array so these constant
 class names are preserved during production builds.
 All text inputs should use the `TextInput` component in `src/components/ui` so
 form fields share consistent spacing and focus styles.
+The `Stepper` progress bar highlights the active step with `bg-brand` and `text-brand-dark` to reinforce the brand palette.
 
 ### Loading Indicators
 

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -19,12 +19,14 @@ export default function Stepper({ steps, currentStep, maxStepCompleted, onStepCl
           <>
             <div
               className={`w-3 h-3 rounded-full ${
-                i === currentStep ? 'bg-black' : 'bg-gray-300'
+                i === currentStep ? 'bg-brand' : 'bg-gray-300'
               }`}
             />
             <span
               className={`mt-1 ${
-                i === currentStep ? 'font-medium text-black' : 'text-gray-400'
+                i === currentStep
+                  ? 'font-medium text-brand-dark'
+                  : 'text-gray-400'
               }`}
             >
               {label}


### PR DESCRIPTION
## Summary
- highlight the active step in Stepper using `bg-brand` and `text-brand-dark`
- document the new brand highlight in the UI Theme section

## Testing
- `./scripts/test-all.sh`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853ee6217ac832ebdcd8821ee6ab006