### PR TITLE
Use indigo brand color

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
 ### Brand Colors
 
 The frontend uses a small **brand** palette defined in `tailwind.config.js`. The
-primary hue is purple (`#7c3aed`), with `brand-dark` and `brand-light` variants.
+primary hue is indigo (`#6366f1`), with `brand-dark` and `brand-light` variants.
 Components reference these via utility classes such as `bg-brand` and
 `bg-brand-dark`.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,9 +46,9 @@ Brand colors are declared in `tailwind.config.js` and exposed as CSS variables i
 // tailwind.config.js
 colors: {
   brand: {
-    DEFAULT: '#7c3aed',
-    dark: '#6d28d9',
-    light: '#c084fc',
+    DEFAULT: '#6366f1',
+    dark: '#4f46e5',
+    light: '#a5b4fc',
   },
 }
 ```
@@ -56,9 +56,9 @@ colors: {
 ```css
 /* globals.css */
 :root {
-  --brand-color: #7c3aed;
-  --brand-color-dark: #6d28d9;
-  --brand-color-light: #c084fc;
+  --brand-color: #6366f1;
+  --brand-color-dark: #4f46e5;
+  --brand-color-light: #a5b4fc;
 }
 ```
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,9 +4,9 @@
 
 :root {
   --font-sans: var(--font-inter);
-  --brand-color: #7c3aed;
-  --brand-color-dark: #6d28d9;
-  --brand-color-light: #c084fc;
+  --brand-color: #6366f1;
+  --brand-color-dark: #4f46e5;
+  --brand-color-light: #a5b4fc;
 }
 
 @layer base {

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -134,7 +134,7 @@ export default function InboxPage() {
             onKeyPress={() => handleClick(t.booking_request_id)}
             className="flex items-center space-x-3 px-4 py-3 border-b cursor-pointer hover:bg-gray-50 active:bg-gray-100"
           >
-            <div className="w-10 h-10 rounded-full bg-purple-100 text-purple-700 flex items-center justify-center font-bold text-sm">
+            <div className="w-10 h-10 rounded-full bg-indigo-100 text-indigo-700 flex items-center justify-center font-bold text-sm">
               {initials}
             </div>
             <div className="flex-1 overflow-hidden">

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -550,7 +550,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
           const isSystem = firstMsg.message_type === 'system';
           const isSelf = !isSystem && firstMsg.sender_id === user?.id;
           const anyUnread = group.messages.some((m) => m.unread);
-          const groupClass = `${idx > 0 ? 'mt-1' : ''} ${anyUnread ? 'bg-purple-50' : ''}`;
+          const groupClass = `${idx > 0 ? 'mt-1' : ''} ${anyUnread ? 'bg-indigo-50' : ''}`;
 
           return (
             <div
@@ -579,7 +579,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               />
               {anyUnread && (
                 <span
-                  className="absolute right-0 top-1 w-2 h-2 bg-purple-600 rounded-full"
+                  className="absolute right-0 top-1 w-2 h-2 bg-indigo-600 rounded-full"
                   aria-label="Unread messages"
                 />
               )}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -121,7 +121,7 @@ describe('MessageThread component', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    const highlightedRow = container.querySelector('.bg-purple-50');
+    const highlightedRow = container.querySelector('.bg-indigo-50');
     const senderName = container.querySelector('span.font-semibold');
     const badge = container.querySelector('span[aria-label="Unread messages"]');
     expect(highlightedRow).not.toBeNull();

--- a/frontend/src/components/chat/StickyInputDemo.tsx
+++ b/frontend/src/components/chat/StickyInputDemo.tsx
@@ -45,7 +45,7 @@ export default function StickyInputDemo() {
         />
         <button
           type="submit"
-          className="bg-purple-600 text-white rounded px-4 py-2 text-sm"
+          className="bg-indigo-600 text-white rounded px-4 py-2 text-sm"
         >
           Send
         </button>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -14,9 +14,9 @@ module.exports = {
       },
       colors: {
         brand: {
-          DEFAULT: '#7c3aed',
-          dark: '#6d28d9',
-          light: '#c084fc',
+          DEFAULT: '#6366f1',
+          dark: '#4f46e5',
+          light: '#a5b4fc',
         },
       },
     },


### PR DESCRIPTION
## Summary
- switch brand palette to indigo hues
- update docs and globals for indigo color
- adjust components and tests to use indigo utilities

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853f667d75c832e89cd1208f36aaf7b