### PR TITLE
Handle booking creation errors when accepting quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
   parameter when the related booking request was created without one.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
+* Accepting a quote may respond with **500 Internal Server Error** if booking creation fails.
 * Legacy quotes can still be accepted or rejected via `PUT /api/v1/quotes/{id}/client` when the newer `/accept` route is unavailable.
 * Artists can save **Quote Templates** via `/api/v1/quote-templates` and apply them when composing a quote.
 


### PR DESCRIPTION
## Summary
- rollback and return 500 when creating a booking fails
- test booking creation failure on quote accept
- mention quote accept 500 case in docs

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853fa304da4832e833ffe09192d2e65