### PR TITLE
Combine deposit notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,8 +562,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
-* Deposit due and new booking alerts show money and calendar icons so clients can easily spot payment reminders and confirmations. Deposit reminders now parse the amount and due date from the message so the drawer subtitle shows e.g. `R50.00 due by Jan 1, 2025`.
-* Deposit due and new booking notifications now link to the full booking created from the accepted quote instead of the temporary record.
+* Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" so clients immediately see the payment deadline. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
 * Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}` so clients can quickly rate their experience.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
@@ -770,8 +769,7 @@ When a client accepts a quote in the chat thread, the frontend now prompts them 
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.
 The amount field now displays this value formatted via `formatCurrency` and shows helper text indicating whether the deposit or full amount will be charged. Deposit due dates use the `PPP` format for brevity.
 The modal layout now adapts to narrow screens, trapping focus and scrolling internally so mobile users can submit using the keyboard's **Done** button.
-Accepting a quote also creates a **DEPOSIT_DUE** notification so the client receives a clear reminder to pay. The notification links to the dashboard at `/dashboard/client/bookings/{booking_id}?pay=1` where they can complete the deposit.
-The alert now displays the deposit amount and due date so clients know exactly what to pay and by when. The drawer also parses these values so the list shows `R50.00 due by Jan 1, 2025` under the title.
+Accepting a quote also creates a **DEPOSIT_DUE** notification formatted as `Booking confirmed – deposit R{amount} due by {date}`. The alert links to `/dashboard/client/bookings/{booking_id}?pay=1` so clients can pay immediately. The drawer parses the amount and date from this message and shows them as `R50.00 due by Jan 1, 2025` under the title.
 Clients can also pay outstanding deposits later from the bookings page. Each
 pending booking shows a **Pay deposit** button that fetches the latest deposit
 amount from the server before opening the payment modal.

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -192,7 +192,6 @@ def accept_quote(
     client = db_quote.client or db.query(models.User).get(db_quote.client_id)
     notify_quote_accepted(db, artist, db_quote.id, db_quote.booking_request_id)
     if db_booking is not None:
-        notify_new_booking(db, client, db_booking.id)
         notify_deposit_due(
             db,
             client,

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -45,21 +45,21 @@ def format_notification_message(
     if ntype == NotificationType.DEPOSIT_DUE:
         amount = kwargs.get("deposit_amount")
         due_by = kwargs.get("deposit_due_by")
-        booking_id = kwargs.get("booking_id")
-        msg = "Deposit payment due"
+        msg = "Booking confirmed"
         if amount is not None:
             try:
-                msg = f"Deposit of {float(amount):.2f} due"
+                amt_str = f"R{float(amount):.2f}"
             except Exception:  # pragma: no cover - formatting should not fail
-                msg = "Deposit payment due"
+                amt_str = f"R{amount}"
+            msg += f" \u2014 deposit {amt_str}"
+        else:
+            msg += " \u2014 deposit payment"
         if due_by is not None:
             try:
                 date_str = due_by.strftime("%Y-%m-%d")
-                msg += f" by {date_str}"
+                msg += f" due by {date_str}"
             except Exception:
                 pass
-        if booking_id is not None:
-            msg += f" for booking #{booking_id}"
         return msg
     if ntype == NotificationType.REVIEW_REQUEST:
         return f"Please review your booking #{kwargs.get('booking_id')}"

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -462,7 +462,7 @@ def test_format_notification_message_new_types():
     msg_booking = format_notification_message(
         NotificationType.NEW_BOOKING, booking_id=8
     )
-    assert msg_deposit == "Deposit of 50.00 due by 2025-01-01 for booking #42"
+    assert msg_deposit == "Booking confirmed \u2014 deposit R50.00 due by 2025-01-01"
     assert msg_review == "Please review your booking #42"
     assert msg_quote == "Quote #7 accepted"
     assert msg_booking == "New booking #8"

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -525,8 +525,8 @@ def test_accept_quote_creates_deposit_notification():
     from app.models import NotificationType
 
     notifs = crud_notification.get_notifications_for_user(db, client.id)
-    types = [n.type for n in notifs]
-    assert NotificationType.DEPOSIT_DUE in types
+    assert len(notifs) == 1
+    assert notifs[0].type == NotificationType.DEPOSIT_DUE
 
 
 def test_accept_quote_deposit_notification_link():
@@ -595,74 +595,6 @@ def test_accept_quote_deposit_notification_link():
     from app.models import Booking
     db_booking = db.query(Booking).filter(Booking.quote_id == quote.id).first()
     assert deposit.link == f"/dashboard/client/bookings/{db_booking.id}?pay=1"
-
-
-def test_accept_quote_new_booking_notification_link():
-    db = setup_db()
-    artist = User(
-        email="artist6@test.com",
-        password="x",
-        first_name="A",
-        last_name="R",
-        user_type=UserType.ARTIST,
-    )
-    client = User(
-        email="client6@test.com",
-        password="x",
-        first_name="C",
-        last_name="L",
-        user_type=UserType.CLIENT,
-    )
-    db.add_all([artist, client])
-    db.commit()
-    db.refresh(artist)
-    db.refresh(client)
-
-    service = Service(
-        artist_id=artist.id,
-        title="Show",
-        description="test",
-        price=Decimal("180"),
-        currency="ZAR",
-        duration_minutes=60,
-        service_type="Live Performance",
-    )
-    db.add(service)
-    db.commit()
-    db.refresh(service)
-
-    from datetime import datetime
-
-    br = BookingRequest(
-        client_id=client.id,
-        artist_id=artist.id,
-        service_id=service.id,
-        proposed_datetime_1=datetime(2033, 1, 1, 20, 0, 0),
-        status=BookingRequestStatus.PENDING_QUOTE,
-    )
-    db.add(br)
-    db.commit()
-    db.refresh(br)
-
-    quote_in = QuoteCreate(
-        booking_request_id=br.id,
-        artist_id=artist.id,
-        client_id=client.id,
-        services=[ServiceItem(description="Performance", price=Decimal("180"))],
-        sound_fee=Decimal("0"),
-        travel_fee=Decimal("0"),
-    )
-    quote = api_quote_v2.create_quote(quote_in, db)
-    booking = api_quote_v2.accept_quote(quote.id, db)
-
-    from app.crud import crud_notification
-    from app.models import NotificationType
-
-    notifs = crud_notification.get_notifications_for_user(db, client.id)
-    new_booking = next(n for n in notifs if n.type == NotificationType.NEW_BOOKING)
-    from app.models import Booking
-    db_booking = db.query(Booking).filter(Booking.quote_id == quote.id).first()
-    assert new_booking.link == f"/dashboard/client/bookings/{db_booking.id}"
 
 
 def test_accept_quote_supplies_missing_service_id():

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -100,12 +100,12 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
   if (/deposit.*due/i.test(n.content)) {
     let subtitle =
       n.content.length > 30 ? `${n.content.slice(0, 30)}...` : n.content;
-    const match = n.content.match(/Deposit of\s*([\d.,]+)\s*due(?:\s*by\s*(\d{4}-\d{2}-\d{2}))?/i);
+    const match = n.content.match(/deposit\s+(?:of\s*)?R?([\d.,]+)\s*due(?:\s*by\s*(\d{4}-\d{2}-\d{2}))?/i);
     if (match) {
       const [, amt, dateStr] = match;
       const parts: string[] = [];
       if (amt) {
-        parts.push(`${amt}`);
+        parts.push(`R${amt}`);
       }
       if (dateStr) {
         const formatted = format(new Date(dateStr), 'MMM d, yyyy');

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -48,7 +48,7 @@ describe('NotificationListItem', () => {
       type: 'deposit_due',
       timestamp: new Date().toISOString(),
       is_read: false,
-      content: 'Deposit payment due for booking #5',
+      content: 'Booking confirmed \u2014 deposit R200 due by 2025-12-31',
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Deposit Due');
@@ -60,24 +60,13 @@ describe('NotificationListItem', () => {
       type: 'deposit_due',
       timestamp: new Date().toISOString(),
       is_read: false,
-      content: 'Deposit of 50.00 due by 2025-01-01 for booking #42',
+      content: 'Booking confirmed \u2014 deposit R50.00 due by 2025-01-01',
     } as UnifiedNotification;
     const parsed = parseItem(n);
-    expect(parsed.subtitle).toBe('50.00 due by Jan 1, 2025');
+    expect(parsed.subtitle).toBe('R50.00 due by Jan 1, 2025');
     expect(parsed.icon).toBe('💰');
   });
 
-  it('parses new booking notifications', () => {
-    const n: UnifiedNotification = {
-      type: 'new_booking',
-      timestamp: new Date().toISOString(),
-      is_read: false,
-      content: 'New booking #5 confirmed',
-    } as UnifiedNotification;
-    const parsed = parseItem(n);
-    expect(parsed.title).toBe('Booking Confirmed');
-    expect(parsed.icon).toBe('📅');
-  });
 
   it('parses review request notifications', () => {
     const n: UnifiedNotification = {


### PR DESCRIPTION
## Summary
- send a single deposit notification when accepting a quote
- format deposit notifications as `Booking confirmed – deposit R{amount} due by {date}`
- adjust frontend parser to read new deposit message
- update tests for new notification flow
- document the new message format

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685404966f68832e8cde74c808070739