### PR TITLE
Add global HelpPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,10 +855,8 @@ instructions.
 ### Help Prompt
 
 The `HelpPrompt` component renders quick links to the FAQ and contact page. It
-appears beneath the booking confirmation banner in chat, on the booking details
-page, at the bottom of the client bookings page, and now on the client quotes
-page so users always know where
-to get assistance.
+is included once on every page via `MainLayout` so users always know where to
+get assistance.
 
 ### Support Pages
 

--- a/frontend/e2e/footer.spec.ts
+++ b/frontend/e2e/footer.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { stubCatchAllApi } from './stub-helpers';
+
+test.describe('Footer help prompt', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubCatchAllApi(page);
+  });
+
+  test('shows help links on the homepage', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('help-prompt')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'FAQ' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Contact support' })).toBeVisible();
+  });
+});

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import MainLayout from "@/components/layout/MainLayout";
 import PaymentModal from "@/components/booking/PaymentModal";
 import toast from "@/components/ui/Toast";
-import { HelpPrompt } from "@/components/ui";
 import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
 import type { Booking } from "@/types";
 import { formatCurrency } from "@/lib/utils";
@@ -157,7 +156,6 @@ export default function BookingDetailsPage() {
             Back to bookings
           </Link>
         </div>
-        <HelpPrompt />
       </div>
       <PaymentModal
         open={showPayment}

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -11,7 +11,7 @@ import { format } from "date-fns";
 import { formatCurrency } from "@/lib/utils";
 import Link from "next/link";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { HelpPrompt, Spinner } from "@/components/ui";
+import { Spinner } from "@/components/ui";
 
 interface BookingWithReview extends Booking {
   review?: Review | null;
@@ -315,7 +315,6 @@ export default function ClientBookingsPage() {
             />
           )}
         </section>
-        <HelpPrompt />
       </div>
       {reviewId && (
         <ReviewFormModal

--- a/frontend/src/app/dashboard/client/quotes/page.tsx
+++ b/frontend/src/app/dashboard/client/quotes/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import { getMyClientQuotes } from '@/lib/api';
-import { HelpPrompt, Spinner } from '@/components/ui';
+import { Spinner } from '@/components/ui';
 import type { Quote } from '@/types';
 
 export default function ClientQuotesPage() {
@@ -123,7 +123,6 @@ export default function ClientQuotesPage() {
             ))}
           </ul>
         )}
-        <HelpPrompt />
       </div>
     </MainLayout>
   );

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -14,7 +14,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl, formatCurrency } from '@/lib/utils';
-import HelpPrompt from '../ui/HelpPrompt';
 import AlertBanner from '../ui/AlertBanner';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
@@ -507,7 +506,6 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 Add to calendar
               </button>
             )}
-            <HelpPrompt />
           </>
         )}
         {paymentStatus && (

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -489,7 +489,7 @@ describe('MessageThread component', () => {
     );
     expect(dashboardLink).not.toBeNull();
     const help = container.querySelector('[data-testid="help-prompt"]');
-    expect(help).not.toBeNull();
+    expect(help).toBeNull();
   });
 
   it('loads booking details when an accepted quote is fetched', async () => {
@@ -605,7 +605,7 @@ describe('MessageThread component', () => {
     const calBtn = container.querySelector('[data-testid="add-calendar-button"]');
     expect(calBtn).not.toBeNull();
     const help = container.querySelector('[data-testid="help-prompt"]');
-    expect(help).not.toBeNull();
+    expect(help).toBeNull();
   });
 
   it('adds ring styles when deposit actions receive keyboard focus', async () => {

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -10,6 +10,7 @@ import NotificationBell from './NotificationBell';
 import BookingRequestIcon from './BookingRequestIcon';
 import MobileMenuDrawer from './MobileMenuDrawer';
 import MobileBottomNav from './MobileBottomNav';
+import { HelpPrompt } from '../ui';
 
 const baseNavigation = [
   { name: 'Home', href: '/' },
@@ -229,6 +230,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
           {children}
         </div>
+        <HelpPrompt className="mx-auto mt-10 max-w-7xl sm:px-6 lg:px-8" />
       </main>
       {user && <MobileBottomNav user={user} />}
     </div>


### PR DESCRIPTION
## Summary
- render HelpPrompt in MainLayout so each page has help links
- remove old HelpPrompt instances from dashboard and message thread
- adjust MessageThread tests for layout change
- test footer help prompt with Playwright
- document HelpPrompt behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68540660d51c832e8a740d45195899dd