### PR TITLE
Refactor payment modal logic and update tests

### DIFF
--- a/frontend/e2e/full-booking.spec.ts
+++ b/frontend/e2e/full-booking.spec.ts
@@ -34,10 +34,18 @@ test.describe('Signup to deposit flow', () => {
     await page.getByTestId('date-next-button').click();
     await expect(page.getByTestId('step-heading')).toHaveText(/Location/);
 
-    await page.goto('/dashboard/client/bookings/5?pay=1');
-    const responsePromise = page.waitForResponse('**/api/v1/payments');
+    await page.goto('/booking-requests/42');
+    await page.getByRole('button', { name: 'Accept' }).click();
+    let responsePromise = page.waitForResponse('**/api/v1/payments');
     await page.getByRole('button', { name: 'Pay' }).click();
-    const response = await responsePromise;
+    let response = await responsePromise;
+    expect(response.status()).toBe(200);
+    await expect(page.getByRole('dialog')).not.toBeVisible();
+
+    await page.goto('/dashboard/client/bookings');
+    responsePromise = page.waitForResponse('**/api/v1/payments');
+    await page.getByTestId('pay-deposit-button').first().click();
+    response = await responsePromise;
     expect(response.status()).toBe(200);
     await expect(page.getByRole('dialog')).not.toBeVisible();
   });

--- a/frontend/src/hooks/usePaymentModal.tsx
+++ b/frontend/src/hooks/usePaymentModal.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState, useCallback } from 'react';
+import PaymentModal from '@/components/booking/PaymentModal';
+
+export interface PaymentSuccess {
+  status: string;
+  amount: number;
+  receiptUrl?: string;
+  paymentId?: string;
+}
+
+interface OpenArgs {
+  bookingRequestId: number;
+  depositAmount?: number;
+  depositDueBy?: string;
+}
+
+export default function usePaymentModal(
+  onSuccess: (res: PaymentSuccess) => void,
+  onError: (msg: string) => void,
+) {
+  const [open, setOpen] = useState(false);
+  const [args, setArgs] = useState<OpenArgs | null>(null);
+
+  const openPaymentModal = useCallback((opts: OpenArgs) => {
+    setArgs(opts);
+    setOpen(true);
+  }, []);
+
+  const modal = args ? (
+    <PaymentModal
+      open={open}
+      bookingRequestId={args.bookingRequestId}
+      depositAmount={args.depositAmount}
+      depositDueBy={args.depositDueBy}
+      onClose={() => setOpen(false)}
+      onSuccess={(result) => {
+        setOpen(false);
+        onSuccess(result);
+      }}
+      onError={(msg) => {
+        setOpen(false);
+        onError(msg);
+      }}
+    />
+  ) : null;
+
+  return { openPaymentModal, paymentModal: modal };
+}


### PR DESCRIPTION
## Summary
- add `usePaymentModal` hook for reusable payment modal logic
- switch `MessageThread` and client bookings to use the new hook
- remove extra payment button logic and streamline open/close handlers
- expand e2e helpers and update full-booking flow test

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68540868b288832e8608f42ad05f10ab