### PR TITLE
Remove toast on confirm booking

### DIFF
--- a/frontend/src/app/dashboard/quotes/__tests__/ArtistQuotesPage.test.tsx
+++ b/frontend/src/app/dashboard/quotes/__tests__/ArtistQuotesPage.test.tsx
@@ -5,9 +5,14 @@ import ArtistQuotesPage from '../page';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from 'next/navigation';
+import toast from '@/components/ui/Toast';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
+jest.mock('@/components/ui/Toast', () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
   usePathname: jest.fn(() => '/dashboard/quotes'),
@@ -52,6 +57,11 @@ describe('ArtistQuotesPage', () => {
       confirmBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(api.confirmQuoteBooking).toHaveBeenCalledWith(2);
+    expect(
+      (toast.success as jest.Mock).mock.calls.some(
+        (c) => c[0] === 'Booking confirmed',
+      ),
+    ).toBe(false);
 
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/quotes/page.tsx
+++ b/frontend/src/app/dashboard/quotes/page.tsx
@@ -84,7 +84,6 @@ export default function ArtistQuotesPage() {
           q.id === id ? { ...q, status: 'confirmed_by_artist' } : q,
         ),
       );
-      toast.success('Booking confirmed');
     } catch (err) {
       console.error('Confirm booking error', err);
       toast.error(err instanceof Error ? err.message : 'Failed to confirm');


### PR DESCRIPTION
## Summary
- drop success toast from artist quotes page
- mock toast in ArtistQuotesPage test and verify no success toast when confirming

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68540c14b260832e97cce8e96893edcb