### PR TITLE
Remove stray My Bookings links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists can mark bookings completed or cancelled and download confirmed bookings as calendar (.ics) files.
 - Clients can leave a star rating and comment once a booking is marked completed. Service detail pages now display these reviews.
 - A **Leave Review** button now appears in chat when a completed booking has no review.
-- After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, add it to a calendar, and jump to **My Bookings**.
+- After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -530,53 +530,6 @@ describe('DashboardPage quotes link', () => {
   });
 });
 
-describe('DashboardPage client bookings link', () => {
-  it('shows link for client users', async () => {
-    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
-    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
-    (api.getMyClientBookings as jest.Mock).mockResolvedValue({ data: [] });
-    (api.getMyBookingRequests as jest.Mock).mockResolvedValue({ data: [] });
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-    await act(async () => {
-      root.render(<DashboardPage />);
-    });
-    await act(async () => { await Promise.resolve(); });
-
-    const link = container.querySelector('a[href="/dashboard/client/bookings"]');
-    expect(link).toBeTruthy();
-    act(() => {
-      root.unmount();
-    });
-    container.remove();
-  });
-
-  it('hides link for artist users', async () => {
-    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
-    (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist', email: 'a@example.com' } });
-    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
-    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
-    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
-    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-    await act(async () => {
-      root.render(<DashboardPage />);
-    });
-    await act(async () => { await Promise.resolve(); });
-
-    const link = container.querySelector('a[href="/dashboard/client/bookings"]');
-    expect(link).toBeFalsy();
-    act(() => {
-      root.unmount();
-    });
-    container.remove();
-  });
-});
 
 describe('DashboardPage request updates', () => {
   it('updates request status when form submitted', async () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -391,16 +391,6 @@ export default function DashboardPage() {
               </Link>
             </div>
           )}
-          {user.user_type === 'client' && (
-            <div className="mt-2">
-              <Link
-                href="/dashboard/client/bookings"
-                className="text-brand-dark hover:underline text-sm"
-              >
-                My Bookings
-              </Link>
-            </div>
-          )}
         </div>
 
           {user.user_type === "artist" && activeTab === 'services' && (

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -493,18 +493,6 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             >
               View booking
             </Link>
-            <Link
-              href={
-                bookingDetails
-                  ? `/dashboard/client/bookings/${bookingDetails.id}`
-                  : '/dashboard/client/bookings'
-              }
-              aria-label="Go to My Bookings"
-              data-testid="my-bookings-link"
-              className="mt-2 ml-4 inline-block text-brand-dark hover:underline text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-            >
-              My Bookings
-            </Link>
             <button
               type="button"
               onClick={() =>

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -480,14 +480,10 @@ describe('MessageThread component', () => {
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
     expect(banner?.textContent).toContain('due by');
-    const viewLink = container.querySelector(
+    const dashboardLink = container.querySelectorAll(
       'a[href="/dashboard/client/bookings/1"]',
     );
-    expect(viewLink).not.toBeNull();
-    const dashboardLink = container.querySelector(
-      'a[href="/dashboard/client/bookings/1"]',
-    );
-    expect(dashboardLink).not.toBeNull();
+    expect(dashboardLink.length).toBe(1);
     const help = container.querySelector('[data-testid="help-prompt"]');
     expect(help).toBeNull();
   });
@@ -543,10 +539,10 @@ describe('MessageThread component', () => {
       await Promise.resolve();
     });
     expect(api.getBookingDetails).toHaveBeenCalledWith(42);
-    const dashboardLink = container.querySelector(
+    const dashboardLink = container.querySelectorAll(
       'a[href="/dashboard/client/bookings/42"]',
     );
-    expect(dashboardLink).not.toBeNull();
+    expect(dashboardLink.length).toBe(1);
   });
 
   it('opens payment modal after accepting quote', async () => {


### PR DESCRIPTION
## Summary
- remove obsolete **My Bookings** links from dashboard page and MessageThread
- update docs to reflect link removal
- adjust unit tests for updated UI

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68540dcf951c832ebf9d244a78bd7bfd