### PR TITLE
Fix attachment link color in MessageThread

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -668,7 +668,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                             <a
                               href={msg.attachment_url}
                               target="_blank"
-                              className="block text-blue-600 underline mt-1 text-sm"
+                              className="block text-indigo-600 underline mt-1 text-sm"
                               rel="noopener noreferrer"
                             >
                               View attachment


### PR DESCRIPTION
## Summary
- adjust attachment link color to indigo variant
- run project tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854136d7d3c832ea45628ef0ab57914