### PR TITLE
Fix quote acceptance for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
 * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
   parameter when the related booking request was created without one.
+* The client quote detail page now uses this endpoint when clients click **Accept**.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
 * Accepting a quote may respond with **500 Internal Server Error** if booking creation fails.
 * Legacy quotes can still be accepted or rejected via `PUT /api/v1/quotes/{id}/client` when the newer `/accept` route is unavailable.

--- a/frontend/src/app/quotes/[quoteId]/page.tsx
+++ b/frontend/src/app/quotes/[quoteId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import QuoteCard from '@/components/booking/QuoteCard';
 import { Spinner } from '@/components/ui';
-import { getQuoteV2, updateQuoteAsClient } from '@/lib/api';
+import { getQuoteV2, updateQuoteAsClient, acceptQuoteV2 } from '@/lib/api';
 import { QuoteV2 } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -71,7 +71,11 @@ export default function QuoteDetailPage() {
     if (!quote) return;
     setUpdating(true);
     try {
-      await updateQuoteAsClient(quote.id, { status });
+      if (status === 'accepted_by_client') {
+        await acceptQuoteV2(quote.id);
+      } else {
+        await updateQuoteAsClient(quote.id, { status });
+      }
       const res = await getQuoteV2(quote.id);
       setQuote(res.data);
     } catch (err) {

--- a/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
+++ b/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
@@ -58,4 +58,27 @@ describe('QuoteDetailPage', () => {
     });
     div.remove();
   });
+
+  it('accepts quote using new endpoint', async () => {
+    const { div, root } = setup();
+    (api.acceptQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+    await act(async () => {
+      root.render(<QuoteDetailPage />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const acceptBtn = Array.from(div.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Accept',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(api.acceptQuoteV2).toHaveBeenCalledWith(5);
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- allow clients to accept quotes using the v2 endpoint
- document new client behavior in README
- test quote detail page acceptance logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68543073e79c832eb714acc683c306f1