### PR TITLE
Add service_id support to acceptQuoteV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
 * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
   parameter when the related booking request was created without one.
+* Frontend helper `acceptQuoteV2(quoteId, serviceId?)` automatically appends
+  `?service_id={serviceId}` to this request when a service ID is provided.
 * The client quote detail page now uses this endpoint when clients click **Accept**.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
 * Accepting a quote may respond with **500 Internal Server Error** if booking creation fails.

--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -119,6 +119,7 @@ export default function BookingRequestDetailPage() {
         ) : (
           <MessageThread
             bookingRequestId={request.id}
+            serviceId={request.service_id ?? undefined}
             clientName={request.client?.first_name}
             artistName={artistName || request.artist?.user?.first_name}
             artistAvatarUrl={artistAvatar}

--- a/frontend/src/app/messages/thread/[threadId]/page.tsx
+++ b/frontend/src/app/messages/thread/[threadId]/page.tsx
@@ -79,6 +79,7 @@ export default function ThreadPage() {
       <div className="max-w-3xl mx-auto p-4">
         <MessageThread
           bookingRequestId={request.id}
+          serviceId={request.service_id ?? undefined}
           clientName={request.client?.first_name}
           artistName={
             request.artist?.business_name || request.artist?.user?.first_name

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -53,6 +53,8 @@ interface MessageThreadProps {
   onMessageSent?: () => void;
   /** Optional callback invoked after a quote is successfully sent */
   onQuoteSent?: () => void;
+  /** Service ID for accepting quotes when the request lacks one */
+  serviceId?: number;
   clientName?: string;
   artistName?: string;
   clientId?: number;
@@ -67,6 +69,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       bookingRequestId,
       onMessageSent,
       onQuoteSent,
+      serviceId,
       clientName = 'Client',
       artistName = 'Artist',
       clientId,
@@ -298,7 +301,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const handleAcceptQuote = useCallback(
     async (q: QuoteV2) => {
       try {
-        await acceptQuoteV2(q.id);
+        await acceptQuoteV2(q.id, serviceId);
       } catch (err) {
         console.error('acceptQuoteV2 failed', err);
         try {
@@ -324,7 +327,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
         console.error('Failed to finalize acceptance', err3);
       }
     },
-    [bookingRequestId, openPaymentModal],
+    [bookingRequestId, openPaymentModal, serviceId],
   );
 
   const handleDeclineQuote = useCallback(

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -74,7 +74,7 @@ describe('MessageThread component', () => {
 
   it('shows scroll-to-latest button when scrolled away from bottom', async () => {
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
     await new Promise((r) => setTimeout(r, 0));
     await act(async () => {
@@ -115,7 +115,7 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
     
     await act(async () => {
@@ -154,7 +154,7 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
 
     const messageBubbles = container.querySelectorAll('.whitespace-pre-wrap');
@@ -197,7 +197,7 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
 
     const groups = container.querySelectorAll('.text-xs.text-gray-400.mb-1');
@@ -229,7 +229,7 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
 
     const divider = container.querySelector('[data-testid="day-divider"]');
@@ -257,7 +257,7 @@ describe('MessageThread component', () => {
       data: [msg],
     });
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
 
     await act(async () => {
@@ -288,7 +288,7 @@ describe('MessageThread component', () => {
     );
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
     await act(async () => {
       await Promise.resolve();
@@ -578,7 +578,7 @@ it('opens payment modal after accepting quote', async () => {
     });
 
     await act(async () => {
-      root.render(<MessageThread bookingRequestId={1} />);
+      root.render(<MessageThread bookingRequestId={1} serviceId={4} />);
     });
     await act(async () => {
       await Promise.resolve();
@@ -589,7 +589,7 @@ it('opens payment modal after accepting quote', async () => {
     await act(async () => {
       acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(api.acceptQuoteV2).toHaveBeenCalledWith(7);
+    expect(api.acceptQuoteV2).toHaveBeenCalledWith(7, 4);
     await act(async () => {
       await Promise.resolve();
     });

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -8,6 +8,7 @@ import api, {
   updateQuoteAsArtist,
   updateQuoteAsClient,
   confirmQuoteBooking,
+  acceptQuoteV2,
   createReviewForBooking,
   getReview,
   getServiceReviews,
@@ -200,6 +201,29 @@ describe('confirmQuoteBooking', () => {
       .mockResolvedValue({ data: {} } as unknown as { data: unknown });
     await confirmQuoteBooking(3);
     expect(spy).toHaveBeenCalledWith('/api/v1/quotes/3/confirm-booking', {});
+    spy.mockRestore();
+  });
+});
+
+describe('acceptQuoteV2', () => {
+  it('posts to accept endpoint', async () => {
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await acceptQuoteV2(2);
+    expect(spy).toHaveBeenCalledWith('/api/v1/quotes/2/accept', {});
+    spy.mockRestore();
+  });
+
+  it('appends service_id when provided', async () => {
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await acceptQuoteV2(2, 5);
+    expect(spy).toHaveBeenCalledWith(
+      '/api/v1/quotes/2/accept?service_id=5',
+      {},
+    );
     spy.mockRestore();
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -312,8 +312,12 @@ export const createQuoteV2 = (data: QuoteV2Create) =>
 export const getQuoteV2 = (quoteId: number) =>
   api.get<QuoteV2>(`${API_V1}/quotes/${quoteId}`);
 
-export const acceptQuoteV2 = (quoteId: number) =>
-  api.post<BookingSimple>(`${API_V1}/quotes/${quoteId}/accept`, {});
+export const acceptQuoteV2 = (quoteId: number, serviceId?: number) => {
+  const url = serviceId
+    ? `${API_V1}/quotes/${quoteId}/accept?service_id=${serviceId}`
+    : `${API_V1}/quotes/${quoteId}/accept`;
+  return api.post<BookingSimple>(url, {});
+};
 
 export const getMyArtistQuotes = (params: { skip?: number; limit?: number } = {}) =>
   api.get<Quote[]>(`${API_V1}/quotes/me/artist`, { params });


### PR DESCRIPTION
## Summary
- make `acceptQuoteV2` accept optional serviceId
- use serviceId when accepting quotes from message thread
- document new helper behavior
- update unit tests for URL generation and message thread

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854e8fd0114832e9aa195c87e0121b9