### PR TITLE
Fix quote acceptance error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,10 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Accepted quotes now include a `booking_id` when retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
 * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
   parameter when the related booking request was created without one.
+* If a booking request lacks a `proposed_datetime_1`, the accept endpoint now
+  returns `422` with the message "Booking request is missing a proposed
+  date/time." This ensures personalized video requests surface a clear error
+  before a booking is created.
 * Frontend helper `acceptQuoteV2(quoteId, serviceId?)` automatically appends
   `?service_id={serviceId}` to this request when a service ID is provided.
 * The client quote detail page now uses this endpoint when clients click **Accept**.

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -99,15 +99,15 @@ def accept_quote(
     booking_request = db_quote.booking_request
     if not booking_request or not booking_request.proposed_datetime_1:
         logger.error(
-            "Booking request %s missing service_id or proposed_datetime_1 when accepting quote %s; artist_id=%s client_id=%s",
+            "Booking request %s missing proposed_datetime_1 when accepting quote %s; artist_id=%s client_id=%s",
             getattr(booking_request, "id", None),
             quote_id,
             db_quote.artist_id,
             db_quote.client_id,
         )
         raise error_response(
-            "Booking request missing service_id or proposed_datetime_1",
-            {"booking_request_id": "invalid"},
+            "Booking request is missing a proposed date/time. Please update the request before accepting this quote.",
+            {"proposed_datetime_1": "missing"},
             status.HTTP_422_UNPROCESSABLE_ENTITY,
         )
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -302,21 +302,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const handleAcceptQuote = useCallback(
     async (q: QuoteV2) => {
       setAcceptingQuoteId(q.id);
-      let accepted = false;
       try {
         await acceptQuoteV2(q.id, serviceId);
-        accepted = true;
       } catch (err) {
         console.error('acceptQuoteV2 failed', err);
-        try {
-          await updateQuoteAsClient(q.id, { status: 'accepted_by_client' });
-          accepted = true;
-        } catch (err2) {
-          console.error('Failed legacy accept', err2);
-        }
-      }
-      if (!accepted) {
-        setErrorMsg('Failed to accept quote. Please refresh and try again.');
+        setErrorMsg((err as Error).message);
         setAcceptingQuoteId(null);
         return;
       }

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -759,7 +759,7 @@ it.skip('adds ring styles when deposit actions receive keyboard focus', async ()
     expect(calBtn.className).toContain('focus-visible:ring-brand');
   });
 
-it('falls back to legacy endpoint when accept fails', async () => {
+it('shows an error when acceptQuoteV2 fails', async () => {
     (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
       data: [
         {
@@ -790,8 +790,8 @@ it('falls back to legacy endpoint when accept fails', async () => {
         updated_at: '',
       },
     });
-    (api.acceptQuoteV2 as jest.Mock).mockRejectedValue(new Error('fail'));
-    (api.updateQuoteAsClient as jest.Mock).mockResolvedValue({ data: {} });
+  (api.acceptQuoteV2 as jest.Mock).mockRejectedValue(new Error('fail'));
+  (api.updateQuoteAsClient as jest.Mock).mockResolvedValue({ data: {} });
 
     await act(async () => {
       root.render(<MessageThread bookingRequestId={1} />);
@@ -806,9 +806,9 @@ it('falls back to legacy endpoint when accept fails', async () => {
     await act(async () => {
       acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-  expect(api.updateQuoteAsClient).toHaveBeenCalledWith(8, {
-    status: 'accepted_by_client',
-  });
+  const alert = container.querySelector('p[role="alert"]');
+  expect(alert?.textContent).toContain('fail');
+  expect(api.updateQuoteAsClient).not.toHaveBeenCalled();
 });
 
 it('shows an error when quote acceptance fails', async () => {
@@ -860,9 +860,10 @@ it('shows an error when quote acceptance fails', async () => {
   });
 
   const alert = container.querySelector('p[role="alert"]');
-  expect(alert?.textContent).toContain('Failed to accept quote');
+  expect(alert?.textContent).toContain('nope');
   const modalHeading = container.querySelector('h2');
   expect(modalHeading).toBeNull();
+  expect(api.updateQuoteAsClient).not.toHaveBeenCalled();
 });
 
 it('declines quote using legacy endpoint', async () => {

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -116,11 +116,11 @@ describe('response interceptor', () => {
   };
   const rejected = typedApi.interceptors.response.handlers[0].rejected;
 
-  it('maps HTTP status to user message', async () => {
+  it('maps HTTP status to user message when detail is missing', async () => {
     expect.assertions(1);
     const err: unknown = {
       isAxiosError: true,
-      response: { status: 401, data: { detail: 'unauth' } },
+      response: { status: 401, data: { detail: null } },
     };
     await rejected(err).catch((e: Error) => {
       expect(e.message).toBe('Authentication required. Please log in.');
@@ -139,6 +139,17 @@ describe('response interceptor', () => {
     });
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it('uses server detail when provided for 422', async () => {
+    expect.assertions(1);
+    const err: unknown = {
+      isAxiosError: true,
+      response: { status: 422, data: { detail: 'missing date' } },
+    };
+    await rejected(err).catch((e: Error) => {
+      expect(e.message).toBe('missing date');
+    });
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,7 +67,9 @@ api.interceptors.response.use(
           422: 'Validation failed. Please check your input.',
           500: 'Server error. Please try again later.',
         };
-        message = map[status] || message;
+        if (message === 'An unexpected error occurred.') {
+          message = map[status] || message;
+        }
       } else {
         message = 'Network error. Please check your connection.';
       }


### PR DESCRIPTION
## Summary
- return clearer message when booking request lacks date/time
- preserve API error detail in frontend interceptor
- display backend error on quote acceptance failure
- update related unit tests
- document new accept behavior in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68550d5fbf1c832ebee3f8ce9abf03e1