### PR TITLE
Improve dashboard status labels

### DIFF
--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -11,6 +11,7 @@ import {
   getMyBookingRequests,
   getBookingRequestsForArtist,
 } from '@/lib/api';
+import { formatStatus } from '@/lib/utils';
 import type { BookingRequest } from '@/types';
 
 export default function BookingRequestsPage() {
@@ -25,18 +26,7 @@ export default function BookingRequestsPage() {
   const [error, setError] = useState<string | null>(null);
   const [openClients, setOpenClients] = useState<Record<number, boolean>>({});
 
-  const statusLabels: Record<string, string> = {
-    pending_quote: 'Pending Quote',
-    quote_provided: 'Quote Provided',
-    completed: 'Completed',
-  };
 
-  const formatStatus = (status: string) =>
-    statusLabels[status] ||
-    status
-      .split('_')
-      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-      .join(' ');
 
   useEffect(() => {
     const fetchRequests = async () => {

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -581,7 +581,7 @@ describe('DashboardPage request updates', () => {
     await act(async () => { await Promise.resolve(); });
 
     expect(api.updateBookingRequestArtist).toHaveBeenCalledWith(1, { status: 'request_declined' });
-    expect(container.textContent).toContain('request_declined');
+    expect(container.textContent).toContain('Request Declined');
 
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
@@ -99,7 +99,7 @@ describe('ArtistBookingsPage', () => {
     });
     await act(async () => { await Promise.resolve(); });
     expect(api.updateBookingStatus).toHaveBeenCalledWith(1, 'completed');
-    expect(div.textContent).toContain('completed');
+    expect(div.textContent).toContain('Completed');
 
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -12,7 +12,7 @@ import {
   downloadBookingIcs,
 } from '@/lib/api';
 import { Booking } from '@/types';
-import { formatCurrency } from '@/lib/utils';
+import { formatCurrency, formatStatus } from '@/lib/utils';
 import { Spinner } from '@/components/ui';
 
 export default function ArtistBookingsPage() {
@@ -137,7 +137,7 @@ export default function ArtistBookingsPage() {
                         : 'bg-yellow-100 text-yellow-800'
                     }`}
                   >
-                    {b.status}
+                    {formatStatus(b.status)}
                   </span>
                   <span className="text-sm text-gray-500">
                     {formatCurrency(Number(b.total_price))}

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -8,7 +8,7 @@ import PaymentModal from "@/components/booking/PaymentModal";
 import toast from "@/components/ui/Toast";
 import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
 import type { Booking } from "@/types";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, formatStatus } from "@/lib/utils";
 import { Spinner } from "@/components/ui";
 
 export default function BookingDetailsPage() {
@@ -97,7 +97,7 @@ export default function BookingDetailsPage() {
         {booking.deposit_amount !== undefined && (
           <p className="text-sm text-gray-700">
             Deposit: {formatCurrency(Number(booking.deposit_amount || 0))} (
-            {booking.payment_status})
+            {formatStatus(booking.payment_status)})
           </p>
         )}
         {booking.payment_status === "pending" && booking.deposit_due_by && (

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -8,7 +8,7 @@ import type { Booking, Review } from "@/types";
 import ReviewFormModal from "@/components/review/ReviewFormModal";
 import usePaymentModal from "@/hooks/usePaymentModal";
 import { format } from "date-fns";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, formatStatus } from "@/lib/utils";
 import Link from "next/link";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Spinner } from "@/components/ui";
@@ -51,7 +51,7 @@ function BookingList({
                         : "bg-yellow-100 text-yellow-800"
                 }`}
               >
-                {b.status}
+                {formatStatus(b.status)}
               </span>
               <span className="text-sm text-gray-500">
                 {formatCurrency(Number(b.total_price))}
@@ -60,7 +60,7 @@ function BookingList({
             {b.deposit_amount !== undefined && (
               <div className="text-sm text-gray-500 mt-1">
                 Deposit: {formatCurrency(Number(b.deposit_amount || 0))} (
-                {b.payment_status})
+                {formatStatus(b.payment_status)})
               </div>
             )}
             {b.payment_status === "pending" && b.deposit_due_by && (

--- a/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
+++ b/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
@@ -41,8 +41,8 @@ describe('ClientQuotesPage', () => {
 
     expect(getMyClientQuotes).toHaveBeenCalled();
     expect(div.textContent).toContain('My Quotes');
-    expect(div.textContent).toContain('pending_client_action');
-    expect(div.textContent).toContain('confirmed_by_artist');
+    expect(div.textContent).toContain('Pending Client Action');
+    expect(div.textContent).toContain('Confirmed by Artist');
 
     act(() => {
       root.unmount();
@@ -102,7 +102,7 @@ describe('ClientQuotesPage', () => {
     await act(async () => { await Promise.resolve(); });
 
     expect(getMyClientQuotes).toHaveBeenLastCalledWith({ status: 'accepted' });
-    expect(div.textContent).toContain('accepted_by_client');
+    expect(div.textContent).toContain('Accepted by Client');
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/dashboard/client/quotes/page.tsx
+++ b/frontend/src/app/dashboard/client/quotes/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import { getMyClientQuotes } from '@/lib/api';
+import { formatStatus } from '@/lib/utils';
 import { Spinner } from '@/components/ui';
 import type { Quote } from '@/types';
 
@@ -110,7 +111,7 @@ export default function ClientQuotesPage() {
                   <span
                     className={`inline-flex rounded-full px-2 text-xs font-semibold leading-5 ${badgeClasses(q.status)}`}
                   >
-                    {q.status}
+                    {formatStatus(q.status)}
                   </span>
                   <Link
                     href={`/quotes/${q.id}`}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ import {
   deleteService,
 } from "@/lib/api";
 import { format } from "date-fns";
-import { formatCurrency, normalizeService } from "@/lib/utils";
+import { formatCurrency, normalizeService, formatStatus } from "@/lib/utils";
 import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
 import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
@@ -435,7 +435,7 @@ export default function DashboardPage() {
                       {req.service?.title || '—'}
                     </div>
                     <div className="mt-2 flex justify-between text-sm text-gray-500">
-                      <span>{req.status}</span>
+                      <span>{formatStatus(req.status)}</span>
                       <span>{new Date(req.created_at).toLocaleDateString()}</span>
                     </div>
                     <Link
@@ -504,7 +504,7 @@ export default function DashboardPage() {
                           : 'bg-yellow-100 text-yellow-800'
                       }`}
                     >
-                      {booking.status}
+                      {formatStatus(booking.status)}
                     </span>
                     <span className="text-sm text-gray-500">
                       {formatCurrency(Number(booking.total_price))}

--- a/frontend/src/app/dashboard/quotes/page.tsx
+++ b/frontend/src/app/dashboard/quotes/page.tsx
@@ -9,6 +9,7 @@ import {
   updateQuoteAsArtist,
   confirmQuoteBooking,
 } from '@/lib/api';
+import { formatStatus } from '@/lib/utils';
 import type { Quote } from '@/types';
 import EditQuoteModal from '@/components/booking/EditQuoteModal';
 import { Spinner } from '@/components/ui';
@@ -127,7 +128,7 @@ export default function ArtistQuotesPage() {
             {quotes.map((q) => (
               <li key={q.id} className="bg-white p-4 shadow rounded-lg">
                 <div className="font-medium text-gray-900">{q.quote_details}</div>
-                <div className="text-sm text-gray-500">{q.status}</div>
+                <div className="text-sm text-gray-500">{formatStatus(q.status)}</div>
                 <div className="mt-2 flex space-x-4">
                   {q.status === 'pending_client_action' && (
                     <>

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getNextAvailableDates,
   getFullImageUrl,
   formatCurrency,
+  formatStatus,
 } from '../utils';
 import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
@@ -90,5 +91,15 @@ describe('formatCurrency', () => {
 
   it('accepts a custom locale', () => {
     expect(formatCurrency(100, DEFAULT_CURRENCY, 'en-US')).toBe('ZAR\u00A0100.00');
+  });
+});
+
+describe('formatStatus', () => {
+  it('uses predefined labels when available', () => {
+    expect(formatStatus('pending_quote')).toBe('Pending Quote');
+  });
+
+  it('humanises unknown values', () => {
+    expect(formatStatus('foo_bar')).toBe('Foo Bar');
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -97,3 +97,38 @@ export const getNextAvailableDates = (
   }
   return results;
 };
+
+/** Mapping of internal status codes to user-friendly labels. */
+export const STATUS_LABELS: Record<string, string> = {
+  pending_quote: 'Pending Quote',
+  quote_provided: 'Quote Provided',
+  pending_artist_confirmation: 'Pending Artist Confirmation',
+  request_confirmed: 'Request Confirmed',
+  request_completed: 'Request Completed',
+  request_declined: 'Request Declined',
+  request_withdrawn: 'Request Withdrawn',
+  quote_rejected: 'Quote Rejected',
+  pending_client_action: 'Pending Client Action',
+  accepted_by_client: 'Accepted by Client',
+  rejected_by_client: 'Rejected by Client',
+  confirmed_by_artist: 'Confirmed by Artist',
+  withdrawn_by_artist: 'Withdrawn by Artist',
+  expired: 'Expired',
+  pending: 'Pending',
+  confirmed: 'Confirmed',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+  deposit_paid: 'Deposit Paid',
+  paid: 'Paid',
+};
+
+const capitalize = (word: string): string =>
+  word.charAt(0).toUpperCase() + word.slice(1);
+
+/**
+ * Convert an internal status string like `pending_quote` to a human readable
+ * label ("Pending Quote"). Unknown statuses are humanised by splitting on
+ * underscores and capitalising each word.
+ */
+export const formatStatus = (status: string): string =>
+  STATUS_LABELS[status] || status.split('_').map(capitalize).join(' ');


### PR DESCRIPTION
## Summary
- add `formatStatus` helper and label map
- use `formatStatus` across dashboard views
- update unit tests for new label formatting

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68551b034ba8832e855075b92a3cef73