### PR TITLE
Fix CollapsibleSection arrow

### DIFF
--- a/frontend/src/components/ui/CollapsibleSection.tsx
+++ b/frontend/src/components/ui/CollapsibleSection.tsx
@@ -36,7 +36,7 @@ export default function CollapsibleSection({
             aria-hidden="true"
             className={clsx('ml-2 transition-transform', open ? 'rotate-180' : 'rotate-0')}
           >
-            \u203a
+            {'›'}
           </span>
         </button>
       </h3>


### PR DESCRIPTION
## Summary
- render the arrow icon in `CollapsibleSection` using the actual `›` character

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68553a4232e4832ea019ccc5075a0e6d