### PR TITLE
Add Google Calendar sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,13 @@ Set these variables in your `.env` file to enable syncing with Google Calendar:
 GOOGLE_CLIENT_ID=<your-client-id>
 GOOGLE_CLIENT_SECRET=<your-client-secret>
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/google-calendar/callback
+FRONTEND_URL=http://localhost:3000/calendar-sync
 ```
+
+Use `GET /api/v1/google-calendar/connect` to begin OAuth. After the Google
+callback completes, the API redirects to `FRONTEND_URL`. Artists can disconnect
+via `DELETE /api/v1/google-calendar` or check the connection status with
+`GET /api/v1/google-calendar/status`.
 
 After installing new dependencies, run `./scripts/test-all.sh` once to refresh the caches.
 

--- a/backend/app/api/api_calendar.py
+++ b/backend/app/api/api_calendar.py
@@ -16,6 +16,23 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["google-calendar"])
 
 
+@router.get("/google-calendar/status")
+def google_calendar_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return whether the user has a connected Google Calendar."""
+    account = (
+        db.query(CalendarAccount)
+        .filter(
+            CalendarAccount.user_id == current_user.id,
+            CalendarAccount.provider == CalendarProvider.GOOGLE,
+        )
+        .first()
+    )
+    return {"connected": account is not None}
+
+
 @router.get("/google-calendar/connect")
 def connect_google_calendar(
     db: Session = Depends(get_db),

--- a/frontend/src/app/calendar-sync/page.tsx
+++ b/frontend/src/app/calendar-sync/page.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '@/components/layout/MainLayout';
+
+export default function CalendarSyncPage() {
+  return (
+    <MainLayout>
+      <div className="prose mx-auto mt-10 text-center">
+        <h1>Google Calendar Connected</h1>
+        <p>You may now close this page.</p>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import EditArtistProfilePage from '../edit/page';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard/profile/edit'),
+}));
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MockMainLayout';
+  return Mock;
+});
+
+function setup() {
+  (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
+  (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: { user_id: 1 } });
+  (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: false } });
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  const root = createRoot(div);
+  return { div, root };
+}
+
+describe('Google Calendar connect/disconnect', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('calls connect and disconnect endpoints', async () => {
+    (api.connectGoogleCalendar as jest.Mock).mockResolvedValue({ data: { auth_url: 'http://auth' } });
+    (api.disconnectGoogleCalendar as jest.Mock).mockResolvedValue({});
+    const { div, root } = setup();
+    await act(async () => {
+      root.render(<EditArtistProfilePage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    const connectBtn = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Connect') as HTMLButtonElement;
+    await act(async () => {
+      connectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(api.connectGoogleCalendar).toHaveBeenCalled();
+
+    await act(async () => { await Promise.resolve(); });
+    act(() => { root.unmount(); });
+    const newRoot = createRoot(div);
+    (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: true } });
+    await act(async () => { newRoot.render(<EditArtistProfilePage />); });
+    await act(async () => { await Promise.resolve(); });
+    const disconnectBtn = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Disconnect') as HTMLButtonElement;
+    await act(async () => {
+      disconnectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(api.disconnectGoogleCalendar).toHaveBeenCalled();
+    act(() => { newRoot.unmount(); });
+    div.remove();
+  });
+
+  it('shows connection status', async () => {
+    const { div, root } = setup();
+    await act(async () => {
+      root.render(<EditArtistProfilePage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Status: Not connected');
+    act(() => { root.unmount(); });
+    const newRoot = createRoot(div);
+    (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: true } });
+    await act(async () => { newRoot.render(<EditArtistProfilePage />); });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Status: Connected');
+    act(() => { newRoot.unmount(); });
+    div.remove();
+  });
+});

--- a/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
@@ -22,6 +22,7 @@ function setup() {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
   (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: { user_id: 1, portfolio_image_urls: ['/img1.jpg', '/img2.jpg'] } });
+  (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: false } });
   const div = document.createElement('div');
   document.body.appendChild(div);
   const root = createRoot(div);

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -160,4 +160,24 @@ describe('BookingWizard flow', () => {
     const wrapper = container.querySelector('[aria-label="Progress"]')?.parentElement;
     expect(wrapper?.className).toContain('sticky');
   });
+
+  it('disables dates returned from Google Calendar', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    (api.getArtistAvailability as jest.Mock).mockResolvedValue({
+      data: { unavailable_dates: ['2025-01-02'] },
+    });
+    act(() => {
+      root.unmount();
+    });
+    container.innerHTML = '';
+    root = createRoot(container);
+    await act(async () => {
+      root.render(React.createElement(Wrapper));
+    });
+    await act(async () => {});
+    const disabledButtons = container.querySelectorAll('button[disabled]');
+    expect(disabledButtons.length).toBeGreaterThan(1);
+    jest.useRealTimers();
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -453,4 +453,14 @@ export const getMessageThreads = () =>
 export const markThreadRead = (bookingRequestId: number) =>
   api.put(`${API_V1}/notifications/message-threads/${bookingRequestId}/read`);
 
+// ─── GOOGLE CALENDAR ─────────────────────────────────────────────────────────
+export const getGoogleCalendarStatus = () =>
+  api.get<{ connected: boolean }>(`${API_V1}/google-calendar/status`);
+
+export const connectGoogleCalendar = () =>
+  api.get<{ auth_url: string }>(`${API_V1}/google-calendar/connect`);
+
+export const disconnectGoogleCalendar = () =>
+  api.delete(`${API_V1}/google-calendar`);
+
 export default api;


### PR DESCRIPTION
## Summary
- add calendar status route on backend
- hook up Google Calendar connect/disconnect in frontend
- document Google Calendar sync instructions
- test connect/disconnect functionality
- ensure booking wizard disables dates from calendar events

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685548ecfab0832e827e6d404d75c238