### PR TITLE
Add FRONTEND_URL config and callback handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+SECRET_KEY=your_super_secret_key
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+SQLALCHEMY_DATABASE_URL=sqlite:///./booking.db
+CORS_ORIGINS=["http://localhost:3000", "http://localhost:3002"]
+CORS_ALLOW_ALL=false
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/google-calendar/callback
+FRONTEND_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -176,12 +176,14 @@ Set these variables in your `.env` file to enable syncing with Google Calendar:
 GOOGLE_CLIENT_ID=<your-client-id>
 GOOGLE_CLIENT_SECRET=<your-client-secret>
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/google-calendar/callback
-FRONTEND_URL=http://localhost:3000/calendar-sync
+FRONTEND_URL=http://localhost:3000
 ```
 
 Use `GET /api/v1/google-calendar/connect` to begin OAuth. After the Google
-callback completes, the API redirects to `FRONTEND_URL`. Artists can disconnect
-via `DELETE /api/v1/google-calendar` or check the connection status with
+callback completes, the API redirects to
+`FRONTEND_URL/dashboard/profile/edit?calendarSync=success` on success or
+`calendarSync=error` when the exchange fails. Artists can disconnect via
+`DELETE /api/v1/google-calendar` or check the connection status with
 `GET /api/v1/google-calendar/status`.
 
 After installing new dependencies, run `./scripts/test-all.sh` once to refresh the caches.

--- a/backend/app/api/api_calendar.py
+++ b/backend/app/api/api_calendar.py
@@ -49,8 +49,17 @@ def google_calendar_callback(
     db: Session = Depends(get_db),
 ):
     user_id = int(state)
-    calendar_service.exchange_code(user_id, code, settings.GOOGLE_REDIRECT_URI, db)
-    redirect_target = getattr(settings, "FRONTEND_URL", "/")
+    status = "success"
+    try:
+        calendar_service.exchange_code(
+            user_id, code, settings.GOOGLE_REDIRECT_URI, db
+        )
+    except Exception as exc:  # noqa: BLE001
+        status = "error"
+        logger.error(
+            "Failed to exchange Google Calendar auth code: %s", exc, exc_info=True
+        )
+    redirect_target = f"{settings.FRONTEND_URL}/dashboard/profile/edit?calendarSync={status}"
     return RedirectResponse(url=redirect_target)
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     GOOGLE_CLIENT_SECRET: str = ""
     GOOGLE_REDIRECT_URI: str = "http://localhost:8000/api/v1/google-calendar/callback"
 
+    # Base frontend URL used for OAuth redirects
+    FRONTEND_URL: str = "http://localhost:3000"
+
     @field_validator("CORS_ORIGINS", mode="before")
     def split_origins(cls, v: Any) -> list[str]:
         """Parse comma-separated or JSON list of origins from environment."""

--- a/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
@@ -4,12 +4,13 @@ import { createRoot } from 'react-dom/client';
 import EditArtistProfilePage from '../edit/page';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
   usePathname: jest.fn(() => '/dashboard/profile/edit'),
 }));
 jest.mock('@/components/layout/MainLayout', () => {
@@ -18,11 +19,14 @@ jest.mock('@/components/layout/MainLayout', () => {
   return Mock;
 });
 
-function setup() {
+function setup(calendarParam: string | null = null, status = false) {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  (useSearchParams as jest.Mock).mockReturnValue({
+    get: (key: string) => (key === 'calendarSync' ? calendarParam : null),
+  });
   (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: { user_id: 1 } });
-  (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: false } });
+  (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: status } });
   const div = document.createElement('div');
   document.body.appendChild(div);
   const root = createRoot(div);
@@ -78,6 +82,30 @@ describe('Google Calendar connect/disconnect', () => {
     await act(async () => { await Promise.resolve(); });
     expect(div.textContent).toContain('Status: Connected');
     act(() => { newRoot.unmount(); });
+    div.remove();
+  });
+
+  it('displays success message from query param', async () => {
+    const { div, root } = setup('success', true);
+    await act(async () => {
+      root.render(<EditArtistProfilePage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Google Calendar connected successfully!');
+    expect(div.textContent).toContain('Status: Connected');
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+
+  it('displays error message from query param', async () => {
+    const { div, root } = setup('error');
+    await act(async () => {
+      root.render(<EditArtistProfilePage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(div.textContent).toContain('Failed to connect Google Calendar.');
+    expect(div.textContent).toContain('Status: Not connected');
+    act(() => { root.unmount(); });
     div.remove();
   });
 });

--- a/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
@@ -4,12 +4,13 @@ import { createRoot } from 'react-dom/client';
 import EditArtistProfilePage from '../edit/page';
 import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
   usePathname: jest.fn(() => '/dashboard/profile/edit'),
 }));
 jest.mock('@/components/layout/MainLayout', () => {
@@ -21,6 +22,7 @@ jest.mock('@/components/layout/MainLayout', () => {
 function setup() {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  (useSearchParams as jest.Mock).mockReturnValue({ get: () => null });
   (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: { user_id: 1, portfolio_image_urls: ['/img1.jpg', '/img2.jpg'] } });
   (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({ data: { connected: false } });
   const div = document.createElement('div');

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import NextImage from 'next/image';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MobileSaveBar from '@/components/dashboard/MobileSaveBar';
 import { useAuth } from '@/contexts/AuthContext';
@@ -156,6 +156,8 @@ export default function EditArtistProfilePage(): JSX.Element {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [calendarConnected, setCalendarConnected] = useState(false);
 
+  const searchParams = useSearchParams();
+
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
@@ -203,11 +205,19 @@ export default function EditArtistProfilePage(): JSX.Element {
       }
     };
 
+    const syncStatus = searchParams.get('calendarSync');
+    if (syncStatus === 'success') {
+      setSuccessMessage('Google Calendar connected successfully!');
+      setCalendarConnected(true);
+    } else if (syncStatus === 'error') {
+      setError('Failed to connect Google Calendar.');
+    }
+
     fetchProfile();
     getGoogleCalendarStatus()
       .then((res) => setCalendarConnected(res.data.connected))
       .catch(() => setCalendarConnected(false));
-  }, [user, authLoading, router, pathname]);
+  }, [user, authLoading, router, pathname, searchParams]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add `FRONTEND_URL` to backend settings
- redirect calendar callback to dashboard with status parameter
- handle `calendarSync` query parameter on profile page
- extend google calendar tests for new logic
- document new env var and redirect behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68555bf87698832e81f7f78712bf8ce7