### PR TITLE
Add openid scope for Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ GOOGLE_CLIENT_SECRET=<your-client-secret>
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/google-calendar/callback
 FRONTEND_URL=http://localhost:3000
 ```
+Your OAuth consent screen should also request the scopes
+`https://www.googleapis.com/auth/calendar.readonly`,
+`https://www.googleapis.com/auth/userinfo.email`, and `openid`.
 
 Use `GET /api/v1/google-calendar/connect` to begin OAuth. After the Google
 callback completes, the API redirects to

--- a/backend/app/services/calendar_service.py
+++ b/backend/app/services/calendar_service.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 SCOPES = [
     "https://www.googleapis.com/auth/calendar.readonly",
     "https://www.googleapis.com/auth/userinfo.email",
+    "openid",
 ]
 
 

--- a/backend/tests/test_google_calendar.py
+++ b/backend/tests/test_google_calendar.py
@@ -118,6 +118,23 @@ def test_unavailable_dates_include_calendar(monkeypatch):
     assert resp['unavailable_dates'] == ['2025-01-01', '2025-01-02']
 
 
+def test_flow_includes_openid_scope(monkeypatch):
+    captured = {}
+
+    def dummy_from_client_config(config, scopes=None, redirect_uri=None):
+        captured['scopes'] = scopes
+
+        class DummyFlow:
+            def authorization_url(self, *args, **kwargs):
+                return 'http://auth', None
+
+        return DummyFlow()
+
+    monkeypatch.setattr(calendar_service.Flow, 'from_client_config', dummy_from_client_config)
+    calendar_service.get_auth_url(1, 'http://localhost')
+    assert 'openid' in captured['scopes']
+
+
 def test_calendar_status_endpoint():
     db = setup_db()
     user = User(


### PR DESCRIPTION
## Summary
- add `openid` to calendar OAuth scopes
- test that OAuth flow includes new scope
- document Google OAuth scopes in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685567317e5c832eb2d8c9c08060056a