### PR TITLE
Adjust booking request buttons

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -434,9 +434,8 @@ export default function DashboardPage() {
                     <Link
                       href={`/booking-requests/${req.id}`}
                       className={clsx(
-                        'mt-2',
-                        'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition-transform active:scale-95',
-                        buttonVariants.secondary,
+                        'mt-2 inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition-transform active:scale-95',
+                        buttonVariants.primary,
                       )}
                     >
                       View Chat
@@ -445,7 +444,8 @@ export default function DashboardPage() {
                       <Button
                         type="button"
                         onClick={() => setRequestToUpdate(req)}
-                        variant="secondary"
+                        variant="primary"
+                        size="sm"
                         className="ml-4 mt-2"
                       >
                         Update

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
       </div>
       <button
         aria-busy="false"
-        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300 text-sm"
+        class="inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 px-4 py-2 text-sm bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300 text-sm"
         type="button"
       >
         <span
@@ -129,7 +129,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
     >
       <button
         aria-busy="false"
-        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300"
+        class="inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 px-4 py-2 text-sm bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300"
         type="button"
       >
         <span
@@ -140,7 +140,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
       </button>
       <button
         aria-busy="false"
-        class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 bg-brand hover:bg-brand-dark text-white focus:ring-brand-dark"
+        class="inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 px-4 py-2 text-sm bg-brand hover:bg-brand-dark text-white focus:ring-brand-dark"
         type="button"
       >
         <span

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -5,6 +5,8 @@ import { buttonVariants, type ButtonVariant } from '@/styles/buttonVariants';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
+  /** Small vs regular size */
+  size?: 'sm' | 'md';
   /** Show loading spinner and disable button */
   isLoading?: boolean;
   /** Stretch button to full width (useful on mobile) */
@@ -15,6 +17,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       variant = 'primary',
+      size = 'md',
       isLoading = false,
       fullWidth = false,
       className,
@@ -23,8 +26,12 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     }: ButtonProps,
     ref,
   ) => {
+    const sizeClass =
+      size === 'sm'
+        ? 'px-3 py-1.5 text-sm'
+        : 'px-4 py-2 text-sm';
     const base =
-      'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95';
+      'inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95';
     const variantClass = buttonVariants[variant];
     return (
       <button
@@ -33,7 +40,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isLoading || props.disabled}
         ref={ref}
         {...props}
-        className={clsx(base, variantClass, fullWidth && 'w-full', className)}
+        className={clsx(base, sizeClass, variantClass, fullWidth && 'w-full', className)}
       >
         {isLoading && (
           <span


### PR DESCRIPTION
## Summary
- add `size` prop to `Button` for smaller buttons
- update booking request buttons to use primary style
- refresh snapshot and tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855bfd2fb04832ebef4462cc133baba