### PR TITLE
Add login rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,14 @@ codes. Subsequent logins require the verification step provided by
 `POST /auth/verify-mfa`. The login page automatically prompts for this
 verification code whenever a login response includes `mfa_required`.
 
+### Login rate limiting
+
+Failed login attempts are tracked per user and IP using Redis. After
+`MAX_LOGIN_ATTEMPTS` failures within `LOGIN_ATTEMPT_WINDOW` seconds,
+`POST /auth/login` responds with **429 Too Many Requests**. A successful
+login resets these counters. Configure the limits via environment variables
+if the defaults are too strict.
+
 ---
 
 ## Development

--- a/backend/tests/test_login_lockout.py
+++ b/backend/tests/test_login_lockout.py
@@ -1,0 +1,83 @@
+import time
+import fakeredis
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models import User, UserType
+from app.models.base import BaseModel
+from app.api.auth import get_db
+from app.api import auth as auth_module
+from app.utils.auth import get_password_hash
+from app.utils import redis_cache
+
+
+def setup_app(monkeypatch):
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    fake = fakeredis.FakeStrictRedis()
+    monkeypatch.setattr(redis_cache, 'get_redis_client', lambda: fake)
+    monkeypatch.setattr(auth_module, 'get_redis_client', lambda: fake)
+
+    app.dependency_overrides[get_db] = override_db
+    return Session, fake
+
+
+def create_user(Session):
+    db = Session()
+    user = User(
+        email='lock@test.com',
+        password=get_password_hash('secret'),
+        first_name='T',
+        last_name='User',
+        user_type=UserType.CLIENT,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.close()
+    return user
+
+
+def test_lockout_and_reset(monkeypatch):
+    Session, fake = setup_app(monkeypatch)
+    user = create_user(Session)
+    client = TestClient(app)
+
+    monkeypatch.setattr(auth_module, 'MAX_LOGIN_ATTEMPTS', 3)
+    monkeypatch.setattr(auth_module, 'LOGIN_ATTEMPT_WINDOW', 1)
+
+    for _ in range(3):
+        res = client.post('/auth/login', data={'username': user.email, 'password': 'bad'})
+        assert res.status_code == 401
+
+    res = client.post('/auth/login', data={'username': user.email, 'password': 'bad'})
+    assert res.status_code == 429
+
+    time.sleep(1.1)
+    res = client.post('/auth/login', data={'username': user.email, 'password': 'secret'})
+    assert res.status_code == 200
+
+    for _ in range(3):
+        res = client.post('/auth/login', data={'username': user.email, 'password': 'wrong'})
+        assert res.status_code == 401
+
+    res = client.post('/auth/login', data={'username': user.email, 'password': 'wrong'})
+    assert res.status_code == 429
+
+    app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary
- lock out repeated failed login attempts with Redis
- document login rate limiting environment variables
- test lockout and reset logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855c6e48410832e9e26598c7be4fce7