### PR TITLE
Improve error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `?service_id={serviceId}` to this request when a service ID is provided.
 * The client quote detail page now uses this endpoint when clients click **Accept**.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
+* Backend helper `error_response` now logs its message and field errors before raising an exception.
 * Accepting a quote may respond with **500 Internal Server Error** if booking creation fails.
 * Legacy quotes can still be accepted or rejected via `PUT /api/v1/quotes/{id}/client` when the newer `/accept` route is unavailable.
 * Artists can save **Quote Templates** via `/api/v1/quote-templates` and apply them when composing a quote.

--- a/backend/app/utils/errors.py
+++ b/backend/app/utils/errors.py
@@ -1,9 +1,17 @@
 from typing import Dict
 from fastapi import HTTPException, status
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-def error_response(message: str, field_errors: Dict[str, str], code: int = status.HTTP_422_UNPROCESSABLE_ENTITY) -> HTTPException:
-    """Return an HTTPException with a consistent structure."""
+def error_response(
+    message: str,
+    field_errors: Dict[str, str],
+    code: int = status.HTTP_422_UNPROCESSABLE_ENTITY,
+) -> HTTPException:
+    """Return an HTTPException with a consistent structure and log details."""
+    logger.error("%s %s", message, field_errors)
     detail = {"message": message, "field_errors": field_errors}
     return HTTPException(status_code=code, detail=detail)
 

--- a/backend/tests/test_error_response.py
+++ b/backend/tests/test_error_response.py
@@ -1,0 +1,16 @@
+import logging
+import pytest
+from fastapi import HTTPException
+
+from app.utils.errors import error_response
+
+
+def test_error_response_logs(caplog):
+    caplog.set_level(logging.ERROR, logger="app.utils.errors")
+    with pytest.raises(HTTPException):
+        raise error_response("Invalid", {"field": "bad"})
+    assert any(
+        "Invalid" in r.getMessage() and "'field': 'bad'" in r.getMessage()
+        for r in caplog.records
+    )
+


### PR DESCRIPTION
## Summary
- log message and fields in `error_response`
- document improved helper logging in README
- test `error_response` logging

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855cb2fe8fc832e80bb105c79f56aaa