### PR TITLE
Add Redis shutdown hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Cache keys include page number and filter parameters so each combination is stored separately.
 * Default Redis URL: `redis://localhost:6379/0`.
 * Fallback to DB if Redis is unavailable.
+* Connections close cleanly on API shutdown.
 
 ### Artist Listing Filters
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,6 +54,7 @@ from .api import (
 from .api.v1 import api_artist
 
 from .core.config import settings
+from .utils.redis_cache import close_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -239,3 +240,10 @@ app.include_router(
 @app.get("/")
 async def root():
     return {"message": "Welcome to Artist Booking API"}
+
+
+@app.on_event("shutdown")
+def shutdown_redis_client() -> None:
+    """Close Redis connections when the application shuts down."""
+    logger.info("Closing Redis client")
+    close_redis_client()

--- a/backend/app/utils/redis_cache.py
+++ b/backend/app/utils/redis_cache.py
@@ -65,3 +65,15 @@ def cache_artist_list(
     except redis.exceptions.ConnectionError as exc:
         logging.warning("Could not cache artist list: %s", exc)
     return None
+
+
+def close_redis_client() -> None:
+    """Close the global Redis client if it exists."""
+    global _redis_client
+    if _redis_client is not None:
+        try:
+            _redis_client.close()
+        except redis.exceptions.ConnectionError as exc:  # pragma: no cover - best effort
+            logging.warning("Error closing Redis client: %s", exc)
+        finally:
+            _redis_client = None

--- a/backend/tests/test_redis_shutdown.py
+++ b/backend/tests/test_redis_shutdown.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.utils import redis_cache
+
+
+class DummyRedis:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_close_redis_client(monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(redis_cache, "_redis_client", dummy)
+    redis_cache.close_redis_client()
+    assert dummy.closed
+    assert redis_cache._redis_client is None
+
+
+def test_shutdown_event_closes_client(monkeypatch):
+    dummy = DummyRedis()
+    monkeypatch.setattr(redis_cache, "_redis_client", dummy)
+    monkeypatch.setattr(redis_cache, "get_redis_client", lambda: dummy)
+
+    with TestClient(app):
+        pass
+
+    assert dummy.closed
+    assert redis_cache._redis_client is None


### PR DESCRIPTION
## Summary
- implement `close_redis_client` in `redis_cache.py`
- call the close function from FastAPI shutdown event
- document clean Redis shutdown in README
- test Redis shutdown behaviour

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685660ae5748832eb2f35a1e5d92a323