### PR TITLE
Expose and use DEFAULT_CURRENCY via API

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 SQLALCHEMY_DATABASE_URL=sqlite:///./booking.db
 CORS_ORIGINS=["http://localhost:3000", "http://localhost:3002", "http://192.168.3.203:3000"]
 CORS_ALLOW_ALL=false
+DEFAULT_CURRENCY=ZAR

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/v1/google-calendar/callback
 FRONTEND_URL=http://localhost:3000
+DEFAULT_CURRENCY=ZAR

--- a/README.md
+++ b/README.md
@@ -838,6 +838,22 @@ formatCurrency(125); // => 'R 125,00'
 formatCurrency(99.5, 'USD', 'en-US'); // => 'US$99.50'
 ```
 
+### Customizing the currency
+
+Set `DEFAULT_CURRENCY` in your `.env` file to change the backend currency code.
+The value is exposed at `/api/v1/settings` so the frontend can fetch it. You can
+also override it on the client by setting `NEXT_PUBLIC_DEFAULT_CURRENCY` in
+`frontend/.env.local`.
+
+```env
+# backend/.env
+DEFAULT_CURRENCY=USD
+
+# optional frontend override
+NEXT_PUBLIC_DEFAULT_CURRENCY=EUR
+```
+
+
 ---
 
 ## Troubleshooting & Common Errors

--- a/backend/app/api/api_settings.py
+++ b/backend/app/api/api_settings.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+import logging
+from ..core.config import settings
+
+router = APIRouter(tags=["settings"])
+logger = logging.getLogger(__name__)
+
+
+@router.get("/settings")
+async def get_settings():
+    """Return selected public configuration values."""
+    logger.info("Serving DEFAULT_CURRENCY=%s", settings.DEFAULT_CURRENCY)
+    return {"default_currency": settings.DEFAULT_CURRENCY}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     # Base frontend URL used for OAuth redirects
     FRONTEND_URL: str = "http://localhost:3000"
 
+    # Default currency code used across the application
+    DEFAULT_CURRENCY: str = "ZAR"
+
     @field_validator("CORS_ORIGINS", mode="before")
     def split_origins(cls, v: Any) -> list[str]:
         """Parse comma-separated or JSON list of origins from environment."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from .api import (
     api_payment,
     api_calendar,
     api_quote_template,
+    api_settings,
 )
 
 # The “artist‐profiles” router lives under app/api/v1/
@@ -233,6 +234,13 @@ app.include_router(
     api_payment.router,
     prefix=f"{api_prefix}/payments",
     tags=["payments"],
+)
+
+# ─── SETTINGS ROUTES (under /api/v1) ─────────────────────────────────────────
+app.include_router(
+    api_settings.router,
+    prefix=f"{api_prefix}",
+    tags=["settings"],
 )
 
 

--- a/backend/tests/test_settings_endpoint.py
+++ b/backend/tests/test_settings_endpoint.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.core.config import settings
+
+client = TestClient(app)
+
+def test_settings_endpoint_returns_default_currency():
+    resp = client.get('/api/v1/settings')
+    assert resp.status_code == 200
+    assert resp.json() == {'default_currency': settings.DEFAULT_CURRENCY}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,4 +1,31 @@
 export const BOOKING_DETAILS_PREFIX = 'Booking details:';
 
-/** Default currency for all price displays */
-export const DEFAULT_CURRENCY = 'ZAR';
+/**
+ * Default currency for all price displays. The value is loaded from
+ * `NEXT_PUBLIC_DEFAULT_CURRENCY` when available. Otherwise `fetchDefaultCurrency`
+ * can retrieve it from the API at runtime.
+ */
+export let DEFAULT_CURRENCY =
+  process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || 'ZAR';
+
+/**
+ * Fetch the default currency from `/api/v1/settings` when not provided via
+ * environment variables. The resolved value updates `DEFAULT_CURRENCY` so
+ * subsequent calls use the fetched value.
+ */
+export async function fetchDefaultCurrency(): Promise<string> {
+  if (process.env.NEXT_PUBLIC_DEFAULT_CURRENCY) {
+    return DEFAULT_CURRENCY;
+  }
+  try {
+    const res = await fetch('/api/v1/settings');
+    if (res.ok) {
+      const data = await res.json();
+      DEFAULT_CURRENCY = data.default_currency || DEFAULT_CURRENCY;
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to load default currency', err);
+  }
+  return DEFAULT_CURRENCY;
+}


### PR DESCRIPTION
## Summary
- expose `DEFAULT_CURRENCY` in backend settings
- serve it via `/api/v1/settings`
- load currency from env or API in frontend constants
- test currency handling and new endpoint
- document currency configuration

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685661d92e38832e92d3950b9e5836b8