### PR TITLE
Implement OAuth login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ API responses are now handled by a global interceptor which maps common HTTP
 status codes to human-friendly error messages and logs server errors to the
 console. Hooks and components no longer need to parse Axios errors manually.
 
+### Google & GitHub OAuth login
+
+Set these variables in `.env` to enable social sign-in:
+
+```env
+GOOGLE_OAUTH_CLIENT_ID=<your-google-client-id>
+GOOGLE_OAUTH_CLIENT_SECRET=<your-google-client-secret>
+GITHUB_CLIENT_ID=<your-github-client-id>
+GITHUB_CLIENT_SECRET=<your-github-client-secret>
+```
+
+Users are redirected to `/auth/google/login` or `/auth/github/login` with a
+`next` query parameter. After the provider grants access, the API exchanges the
+code for profile information, creates or updates the user record with
+`is_verified` set to `true`, issues a JWT, and finally redirects the browser to
+`next` with `?token=<jwt>` appended.
+
+
 ### Multi-factor authentication
 
 Run `POST /auth/setup-mfa` while authenticated to generate a TOTP secret.

--- a/backend/app/api/api_oauth.py
+++ b/backend/app/api/api_oauth.py
@@ -1,0 +1,144 @@
+from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+from datetime import timedelta
+import secrets
+import logging
+
+from authlib.integrations.starlette_client import OAuth
+
+from app.core.config import settings
+from app.database import get_db
+from app.models import User, UserType
+from app.api.auth import create_access_token, ACCESS_TOKEN_EXPIRE_MINUTES
+from app.utils.auth import get_password_hash
+
+router = APIRouter()
+
+logger = logging.getLogger(__name__)
+
+oauth = OAuth()
+
+if settings.GOOGLE_OAUTH_CLIENT_ID:
+    oauth.register(
+        name="google",
+        client_id=settings.GOOGLE_OAUTH_CLIENT_ID,
+        client_secret=settings.GOOGLE_OAUTH_CLIENT_SECRET,
+        server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+        client_kwargs={"scope": "openid email profile"},
+    )
+
+if settings.GITHUB_CLIENT_ID:
+    oauth.register(
+        name="github",
+        client_id=settings.GITHUB_CLIENT_ID,
+        client_secret=settings.GITHUB_CLIENT_SECRET,
+        access_token_url="https://github.com/login/oauth/access_token",
+        authorize_url="https://github.com/login/oauth/authorize",
+        api_base_url="https://api.github.com/",
+        client_kwargs={"scope": "user:email"},
+    )
+
+
+@router.get("/google/login")
+async def google_login(request: Request, next: str = settings.FRONTEND_URL):
+    """Start Google OAuth flow."""
+    if not hasattr(oauth, 'google'):
+        raise HTTPException(500, "Google OAuth not configured")
+    redirect_uri = request.url_for("google_callback")
+    return await oauth.google.authorize_redirect(request, redirect_uri, state=next)
+
+
+@router.get("/google/callback")
+async def google_callback(request: Request, db: Session = Depends(get_db)):
+    if not hasattr(oauth, 'google'):
+        raise HTTPException(500, "Google OAuth not configured")
+    next_url = request.query_params.get("state") or settings.FRONTEND_URL
+    token = await oauth.google.authorize_access_token(request)
+    profile = await oauth.google.parse_id_token(request, token)
+    if profile is None:
+        raise HTTPException(400, "Failed to fetch Google profile")
+    email = profile.get("email")
+    if not email:
+        raise HTTPException(400, "Email not available from Google")
+    first_name = profile.get("given_name") or ""
+    last_name = profile.get("family_name") or ""
+
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        user = User(
+            email=email,
+            password=get_password_hash(secrets.token_hex(8)),
+            first_name=first_name or email.split("@")[0],
+            last_name=last_name,
+            user_type=UserType.CLIENT,
+            is_verified=True,
+        )
+        db.add(user)
+    else:
+        user.first_name = user.first_name or first_name
+        user.last_name = user.last_name or last_name
+        user.is_verified = True
+    db.commit()
+    db.refresh(user)
+
+    expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    jwt_token = create_access_token({"sub": user.email}, expires)
+    redirect = f"{next_url}?token={jwt_token}"
+    return RedirectResponse(url=redirect)
+
+
+@router.get("/github/login")
+async def github_login(request: Request, next: str = settings.FRONTEND_URL):
+    """Start GitHub OAuth flow."""
+    if not hasattr(oauth, 'github'):
+        raise HTTPException(500, "GitHub OAuth not configured")
+    redirect_uri = request.url_for("github_callback")
+    return await oauth.github.authorize_redirect(request, redirect_uri, state=next)
+
+
+@router.get("/github/callback")
+async def github_callback(request: Request, db: Session = Depends(get_db)):
+    if not hasattr(oauth, 'github'):
+        raise HTTPException(500, "GitHub OAuth not configured")
+    next_url = request.query_params.get("state") or settings.FRONTEND_URL
+    token = await oauth.github.authorize_access_token(request)
+    resp = await oauth.github.get("user", token=token)
+    profile = resp.json()
+    email = profile.get("email")
+    if not email:
+        r = await oauth.github.get("user/emails", token=token)
+        for entry in r.json():
+            if entry.get("primary"):
+                email = entry.get("email")
+                break
+        if not email and r.json():
+            email = r.json()[0].get("email")
+    if not email:
+        raise HTTPException(400, "Email not available from GitHub")
+    name = profile.get("name") or profile.get("login")
+    parts = name.split()
+    first_name = parts[0]
+    last_name = "".join(parts[1:]) if len(parts) > 1 else ""
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        user = User(
+            email=email,
+            password=get_password_hash(secrets.token_hex(8)),
+            first_name=first_name,
+            last_name=last_name,
+            user_type=UserType.CLIENT,
+            is_verified=True,
+        )
+        db.add(user)
+    else:
+        user.first_name = user.first_name or first_name
+        user.last_name = user.last_name or last_name
+        user.is_verified = True
+    db.commit()
+    db.refresh(user)
+
+    expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    jwt_token = create_access_token({"sub": user.email}, expires)
+    redirect = f"{next_url}?token={jwt_token}"
+    return RedirectResponse(url=redirect)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,6 +31,12 @@ class Settings(BaseSettings):
     GOOGLE_CLIENT_SECRET: str = ""
     GOOGLE_REDIRECT_URI: str = "http://localhost:8000/api/v1/google-calendar/callback"
 
+    # Social login OAuth credentials
+    GOOGLE_OAUTH_CLIENT_ID: str = ""
+    GOOGLE_OAUTH_CLIENT_SECRET: str = ""
+    GITHUB_CLIENT_ID: str = ""
+    GITHUB_CLIENT_SECRET: str = ""
+
     # Base frontend URL used for OAuth redirects
     FRONTEND_URL: str = "http://localhost:3000"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from .models.notification import Notification
 
 # Routers under app/api/
 from .api import auth
+from .api import api_oauth
 from .api import (
     api_service,
     api_booking,
@@ -156,6 +157,7 @@ api_prefix = settings.API_V1_STR  # usually something like "/api/v1"
 # ─── AUTH ROUTES (no version prefix) ────────────────────────────────────────────────
 # Clients will POST to /auth/register and /auth/login
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
+app.include_router(api_oauth.router, prefix="/auth", tags=["auth"])
 
 
 # ─── ARTIST‐PROFILE ROUTES (under /api/v1/artist-profiles) ──────────────────────────

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ pyotp==2.9.0
 google-auth-oauthlib==1.2.0
 google-api-python-client==2.127.0
 ics==0.7.2
+authlib==1.3.0

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -1,0 +1,123 @@
+import types
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models import User, UserType
+from app.models.base import BaseModel
+from app.api.dependencies import get_db
+from app.api import api_oauth
+
+
+def setup_app(monkeypatch):
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+async def fake_authorize_access_token(request):
+    return {'access_token': 'token'}
+
+
+async def fake_parse_id_token(request, token):
+    return {
+        'email': 'new@example.com',
+        'given_name': 'New',
+        'family_name': 'User',
+    }
+
+
+def test_google_oauth_creates_user(monkeypatch):
+    Session = setup_app(monkeypatch)
+    monkeypatch.setattr(
+        api_oauth.oauth,
+        'google',
+        types.SimpleNamespace(
+            authorize_access_token=fake_authorize_access_token,
+            parse_id_token=fake_parse_id_token,
+        ),
+        raising=False,
+    )
+
+    client = TestClient(app)
+    res = client.get('/auth/google/callback?code=x&state=/done', follow_redirects=False)
+    assert res.status_code == 307
+    assert res.headers['location'].startswith('/done?token=')
+
+    db = Session()
+    user = db.query(User).filter(User.email == 'new@example.com').first()
+    assert user is not None
+    assert user.is_verified is True
+    db.close()
+
+    app.dependency_overrides.pop(get_db, None)
+
+
+async def fake_github_get(endpoint, token=None):
+    if endpoint == 'user':
+        return DummyResponse({'login': 'gh', 'name': 'GH User', 'email': 'gh@example.com'})
+    return DummyResponse([{'email': 'gh@example.com', 'primary': True}])
+
+
+def test_github_oauth_updates_user(monkeypatch):
+    Session = setup_app(monkeypatch)
+    db = Session()
+    user = User(
+        email='gh@example.com',
+        password='x',
+        first_name='Existing',
+        last_name='User',
+        user_type=UserType.CLIENT,
+        is_verified=False,
+    )
+    db.add(user)
+    db.commit()
+    db.close()
+
+    monkeypatch.setattr(
+        api_oauth.oauth,
+        'github',
+        types.SimpleNamespace(
+            authorize_access_token=fake_authorize_access_token,
+            get=fake_github_get,
+        ),
+        raising=False,
+    )
+
+    client = TestClient(app)
+    res = client.get('/auth/github/callback?code=x&state=/next', follow_redirects=False)
+    assert res.status_code == 307
+    assert res.headers['location'].startswith('/next?token=')
+
+    db = Session()
+    updated = db.query(User).filter(User.email == 'gh@example.com').first()
+    assert updated is not None
+    assert updated.is_verified is True
+    assert updated.first_name == 'Existing'
+    db.close()
+
+    app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary
- add Google/GitHub OAuth endpoints
- wire OAuth router into application
- configure OAuth client settings
- document social login setup
- include Authlib dependency
- add unit tests for OAuth callback logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68567c96ae54832eba8a6cdec21209c3