### PR TITLE
Add SMTP config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ SMTP_FROM=no-reply@localhost
 If `SMTP_USERNAME` and `SMTP_PASSWORD` are provided, TLS is automatically used
 when sending email.
 
+These values correspond to `Settings.SMTP_HOST`, `Settings.SMTP_PORT`,
+`Settings.SMTP_USERNAME`, `Settings.SMTP_PASSWORD`, and `Settings.SMTP_FROM`
+defined in `backend/app/core/config.py`.
+
 ### Email confirmation
 
 Users registering via `/auth/register` receive a short-lived token in an email

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator, model_validator
 from typing import Any, ClassVar
 import json
@@ -44,6 +44,13 @@ class Settings(BaseSettings):
     # Default currency code used across the application
     DEFAULT_CURRENCY: str = "ZAR"
 
+    # SMTP email settings
+    SMTP_HOST: str = "localhost"
+    SMTP_PORT: int = 25
+    SMTP_USERNAME: str = ""
+    SMTP_PASSWORD: str = ""
+    SMTP_FROM: str = "no-reply@localhost"
+
     @field_validator("CORS_ORIGINS", mode="before")
     def split_origins(cls, v: Any) -> list[str]:
         """Parse comma-separated or JSON list of origins from environment."""
@@ -64,12 +71,13 @@ class Settings(BaseSettings):
             values.CORS_ORIGINS = ["*"]
         return values
 
-    class Config:
-        env_file = os.getenv(
-            "ENV_FILE",
-            str(Path(__file__).resolve().parents[3] / ".env"),
-        )
-        case_sensitive = True
+    model_config = SettingsConfigDict(
+        extra="forbid",
+        env_file=os.getenv(
+            "ENV_FILE", str(Path(__file__).resolve().parents[3] / ".env")
+        ),
+        case_sensitive=True,
+    )
 
 
 settings = Settings()

--- a/backend/app/utils/email.py
+++ b/backend/app/utils/email.py
@@ -1,17 +1,18 @@
-import os
 import asyncio
 import logging
 from email.message import EmailMessage
 
 import aiosmtplib
 
+from ..core.config import settings
+
 logger = logging.getLogger(__name__)
 
-SMTP_HOST = os.getenv("SMTP_HOST", "localhost")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "25"))
-SMTP_USERNAME = os.getenv("SMTP_USERNAME")
-SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
-SMTP_FROM = os.getenv("SMTP_FROM", "no-reply@localhost")
+SMTP_HOST = settings.SMTP_HOST
+SMTP_PORT = settings.SMTP_PORT
+SMTP_USERNAME = settings.SMTP_USERNAME
+SMTP_PASSWORD = settings.SMTP_PASSWORD
+SMTP_FROM = settings.SMTP_FROM
 
 
 async def _send_async(msg: EmailMessage) -> None:

--- a/backend/tests/test_settings_endpoint.py
+++ b/backend/tests/test_settings_endpoint.py
@@ -25,3 +25,19 @@ def test_env_file_override(tmp_path, monkeypatch):
     resp = override_client.get('/api/v1/settings')
     assert resp.status_code == 200
     assert resp.json() == {'default_currency': 'CHF'}
+
+
+def test_smtp_settings_from_env_file(tmp_path, monkeypatch):
+    env_file = tmp_path / 'smtp.env'
+    env_file.write_text(
+        'SMTP_HOST=mail.test\nSMTP_PORT=1025\nSMTP_USERNAME=user\nSMTP_PASSWORD=pass\nSMTP_FROM=from@test\n'
+    )
+    monkeypatch.setenv('ENV_FILE', str(env_file))
+    import app.core.config as config
+    import importlib
+    importlib.reload(config)
+    assert config.settings.SMTP_HOST == 'mail.test'
+    assert config.settings.SMTP_PORT == 1025
+    assert config.settings.SMTP_USERNAME == 'user'
+    assert config.settings.SMTP_PASSWORD == 'pass'
+    assert config.settings.SMTP_FROM == 'from@test'


### PR DESCRIPTION
## Summary
- load SMTP settings via Settings model
- document SMTP fields in README
- use settings in email utility
- test SMTP env file overrides

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857cb4904cc832e8513f7df4ffa8701