### PR TITLE
Fix google oauth userinfo endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ GITHUB_CLIENT_ID=<your-github-client-id>
 GITHUB_CLIENT_SECRET=<your-github-client-secret>
 ```
 
+The backend registers Google OAuth with
+`api_base_url` set to `https://openidconnect.googleapis.com/v1/`, ensuring the
+`userinfo` endpoint resolves correctly when exchanging the access token.
+
 OAuth routes store the provider state in a session cookie signed with
 `SECRET_KEY`. Ensure the same key is set in `.env` and `backend/.env`
 so logins work across environments.

--- a/backend/app/api/api_oauth.py
+++ b/backend/app/api/api_oauth.py
@@ -25,6 +25,7 @@ if settings.GOOGLE_OAUTH_CLIENT_ID:
         client_id=settings.GOOGLE_OAUTH_CLIENT_ID,
         client_secret=settings.GOOGLE_OAUTH_CLIENT_SECRET,
         server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+        api_base_url="https://openidconnect.googleapis.com/v1/",
         client_kwargs={"scope": "openid email profile"},
     )
 


### PR DESCRIPTION
## Summary
- register `api_base_url` for Google OAuth so userinfo calls have a full URL
- document the new Google OAuth base URL in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857d77b26d4832e827d8da32757d5d1