### PR TITLE
Fix OAuth redirect to frontend

### DIFF
--- a/backend/app/api/api_oauth.py
+++ b/backend/app/api/api_oauth.py
@@ -55,6 +55,8 @@ async def google_callback(request: Request, db: Session = Depends(get_db)):
     if not hasattr(oauth, 'google'):
         raise HTTPException(500, "Google OAuth not configured")
     next_url = request.query_params.get("state") or settings.FRONTEND_URL
+    if next_url.startswith("/"):
+        next_url = settings.FRONTEND_URL.rstrip("/") + next_url
     token = await oauth.google.authorize_access_token(request)
     profile = None
     try:
@@ -114,6 +116,8 @@ async def github_callback(request: Request, db: Session = Depends(get_db)):
     if not hasattr(oauth, 'github'):
         raise HTTPException(500, "GitHub OAuth not configured")
     next_url = request.query_params.get("state") or settings.FRONTEND_URL
+    if next_url.startswith("/"):
+        next_url = settings.FRONTEND_URL.rstrip("/") + next_url
     token = await oauth.github.authorize_access_token(request)
     resp = await oauth.github.get("user", token=token)
     profile = resp.json()

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -69,7 +69,7 @@ def test_google_oauth_creates_user(monkeypatch):
     client = TestClient(app)
     res = client.get('/auth/google/callback?code=x&state=/done', follow_redirects=False)
     assert res.status_code == 307
-    assert res.headers['location'].startswith('/done?token=')
+    assert res.headers['location'].startswith('http://localhost:3000/done?token=')
     token = res.headers['location'].split('token=')[1]
     payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
     assert payload['sub'] == 'new@example.com'
@@ -117,7 +117,7 @@ def test_github_oauth_updates_user(monkeypatch):
     client = TestClient(app)
     res = client.get('/auth/github/callback?code=x&state=/next', follow_redirects=False)
     assert res.status_code == 307
-    assert res.headers['location'].startswith('/next?token=')
+    assert res.headers['location'].startswith('http://localhost:3000/next?token=')
     token = res.headers['location'].split('token=')[1]
     payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
     assert payload['sub'] == 'gh@example.com'


### PR DESCRIPTION
## Summary
- prefix state path with `FRONTEND_URL` when redirecting after OAuth
- update OAuth tests for absolute redirects

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857df3a3390832ea8f68abf7d6b66a3