### PR TITLE
Add OAuth default redirect tests

### DIFF
--- a/frontend/src/components/auth/__tests__/SocialLoginButtons.test.tsx
+++ b/frontend/src/components/auth/__tests__/SocialLoginButtons.test.tsx
@@ -1,0 +1,58 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import SocialLoginButtons from '../SocialLoginButtons';
+
+describe('SocialLoginButtons redirect handling', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // jsdom location is read-only so redefine
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+    process.env.NEXT_PUBLIC_API_URL = 'http://api';
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    window.location = originalLocation;
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  it('defaults to /dashboard', () => {
+    act(() => {
+      root.render(<SocialLoginButtons />);
+    });
+    const googleBtn = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      googleBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(window.location.href).toBe(
+      'http://api/auth/google/login?next=%2Fdashboard',
+    );
+  });
+
+  it('accepts custom redirectPath', () => {
+    act(() => {
+      root.render(<SocialLoginButtons redirectPath="/profile" />);
+    });
+    const buttons = container.querySelectorAll('button');
+    const githubBtn = buttons[1] as HTMLButtonElement;
+    act(() => {
+      githubBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(window.location.href).toBe(
+      'http://api/auth/github/login?next=%2Fprofile',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add backend test confirming Google login without `next` redirects to dashboard
- create frontend tests for SocialLoginButtons redirect logic

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857ec13503c832e9a07564662f2ea24