### PR TITLE
Fix social login redirect loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ fail.
 avoid hydration errors when rendering responsive components.
 
 Protected pages redirect unauthenticated visitors to `/login?next=<path>`. After
-sign in or sign up, the app automatically returns to the original URL.
+sign in or sign up, the app automatically returns to the original URL. The
+dashboard now waits for the authentication state to load before performing this
+redirect, preventing a loop after social login.
 
 API responses are now handled by a global interceptor which maps common HTTP
 status codes to human-friendly error messages and logs server errors to the

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -149,7 +149,7 @@ function ServiceCard({
 }
 
 export default function DashboardPage() {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -187,6 +187,7 @@ export default function DashboardPage() {
   const visibleBookings = bookings.slice(0, 5);
 
   useEffect(() => {
+    if (authLoading) return;
     if (!user) {
       router.push(`/login?next=${encodeURIComponent(pathname)}`);
       return;
@@ -231,7 +232,7 @@ export default function DashboardPage() {
     };
 
     fetchDashboardData();
-  }, [user, router, pathname]);
+  }, [user, authLoading, router, pathname]);
 
   const handleServiceAdded = (newService: Service) => {
     const processedService = normalizeService(newService);


### PR DESCRIPTION
## Summary
- avoid redirect loop on `/dashboard` by waiting for auth state
- document dashboard auth wait in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68580fe293b8832e90b36c3655e3513c