### PR TITLE
Fix Gmail alias merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ new `POST /auth/confirm-email` endpoint marks the user as verified and removes
 the token from the `email_tokens` table.
 All email addresses are normalized to lowercase during registration and login so
 `User@Example.com` and `user@example.com` refer to the same account.
+Gmail addresses are further canonicalized: dots and `+tags` are ignored and
+`googlemail.com` maps to `gmail.com`. This prevents duplicate users when signing
+in with Google OAuth.
 
 Steps to confirm an email address:
 

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -12,5 +12,18 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 
 def normalize_email(email: str) -> str:
-    """Return a normalized email address for comparison and storage."""
-    return email.strip().lower()
+    """Return a normalized email address for comparison and storage.
+
+    Gmail addresses are canonicalized so aliases like "user+tag@googlemail.com"
+    and "u.s.e.r@gmail.com" resolve to the same account. This prevents duplicate
+    users when logging in via Google OAuth.
+    """
+
+    email = email.strip().lower()
+    local, _, domain = email.partition("@")
+
+    if domain in {"gmail.com", "googlemail.com"}:
+        domain = "gmail.com"
+        local = local.split("+", 1)[0].replace(".", "")
+
+    return f"{local}@{domain}"

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -307,6 +307,53 @@ def test_oauth_merges_case_insensitive_email(monkeypatch):
     app.dependency_overrides.pop(get_db, None)
 
 
+def test_oauth_merges_gmail_alias(monkeypatch):
+    """Gmail aliases should resolve to an existing user."""
+    Session = setup_app(monkeypatch)
+    db = Session()
+    user = User(
+        email='user@gmail.com',
+        password='x',
+        first_name='Us',
+        last_name='Er',
+        user_type=UserType.CLIENT,
+        is_verified=False,
+    )
+    db.add(user)
+    db.commit()
+    db.close()
+
+    async def fake_authorize_access_token(request):
+        return {'access_token': 'token'}
+
+    async def fake_parse_id_token(request, token):
+        return {
+            'email': 'u.ser+spam@googlemail.com',
+            'given_name': 'New',
+            'family_name': 'Name',
+        }
+
+    monkeypatch.setattr(
+        api_oauth.oauth,
+        'google',
+        types.SimpleNamespace(
+            authorize_access_token=fake_authorize_access_token,
+            parse_id_token=fake_parse_id_token,
+        ),
+        raising=False,
+    )
+    client = TestClient(app)
+    res = client.get('/auth/google/callback?code=x&state=/done', follow_redirects=False)
+    assert res.status_code == 307
+
+    db = Session()
+    users = db.query(User).filter(func.lower(User.email) == 'user@gmail.com').all()
+    assert len(users) == 1
+    db.close()
+
+    app.dependency_overrides.pop(get_db, None)
+
+
 def test_google_oauth_token_error(monkeypatch):
     Session = setup_app(monkeypatch)
 


### PR DESCRIPTION
## Summary
- canonicalize Gmail addresses in `normalize_email`
- document Gmail alias handling
- test Gmail alias merge in OAuth flow

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685827eebe0c832ea3caac993ecd8ffd