### PR TITLE
Add pagination limit to artist listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,17 +782,17 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 ### Redis Caching
 
 * Caches `/api/v1/artist-profiles/` GET responses.
-* Cache keys include page number and filter parameters so each combination is stored separately.
+* Cache keys include page number, limit, and filter parameters so each combination is stored separately.
 * Default Redis URL: `redis://localhost:6379/0`.
 * Fallback to DB if Redis is unavailable.
 * Connections close cleanly on API shutdown.
 
 ### Artist Listing Filters
 
-`GET /api/v1/artist-profiles/` supports optional query parameters:
+`GET /api/v1/artist-profiles/` supports pagination and optional filters:
 
 ```
-category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>
+page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>
 ```
 
 Profiles include `rating`, `rating_count`, and `is_available` fields. A new

--- a/backend/tests/test_artist_filters.py
+++ b/backend/tests/test_artist_filters.py
@@ -76,10 +76,23 @@ def test_filters_and_sorting(monkeypatch):
     create_artist(db, 'Alpha', 'New York', ServiceType.LIVE_PERFORMANCE, rating=4, bookings=2)
     create_artist(db, 'Beta', 'San Francisco', ServiceType.OTHER, rating=5, bookings=5)
 
-    monkeypatch.setattr('app.utils.redis_cache.get_cached_artist_list', lambda: None)
-    monkeypatch.setattr('app.utils.redis_cache.cache_artist_list', lambda data: None)
+    monkeypatch.setattr(
+        'app.utils.redis_cache.get_cached_artist_list',
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        'app.utils.redis_cache.cache_artist_list',
+        lambda *args, **kwargs: None,
+    )
 
-    results = read_all_artist_profiles(category=ServiceType.OTHER, location='San', sort='most_booked', db=db, page=1)
+    results = read_all_artist_profiles(
+        category=ServiceType.OTHER,
+        location='San',
+        sort='most_booked',
+        db=db,
+        page=1,
+        limit=20,
+    )
     assert len(results) == 1
     assert results[0].business_name == 'Beta'
     assert results[0].rating == 5

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -18,12 +18,34 @@ def test_cache_artist_list_page_specific(monkeypatch):
     monkeypatch.setattr(redis_cache, "get_redis_client", lambda: fake)
 
     data = [{"id": 2, "business_name": "Another"}]
-    redis_cache.cache_artist_list(data, page=2, category="A", location="NY", sort="newest")
+    redis_cache.cache_artist_list(
+        data,
+        page=2,
+        limit=15,
+        category="A",
+        location="NY",
+        sort="newest",
+    )
     assert (
-        redis_cache.get_cached_artist_list(page=2, category="A", location="NY", sort="newest")
+        redis_cache.get_cached_artist_list(
+            page=2,
+            limit=15,
+            category="A",
+            location="NY",
+            sort="newest",
+        )
         == data
     )
-    assert redis_cache.get_cached_artist_list(page=1, category="A", location="NY", sort="newest") is None
+    assert (
+        redis_cache.get_cached_artist_list(
+            page=1,
+            limit=15,
+            category="A",
+            location="NY",
+            sort="newest",
+        )
+        is None
+    )
 
 
 from types import SimpleNamespace
@@ -115,11 +137,25 @@ def test_read_all_artist_profiles_uses_cache(monkeypatch):
     db.add(profile)
     db.commit()
 
-    first = api_artist.read_all_artist_profiles(db=db, category=None, location=None, sort=None, page=1)
+    first = api_artist.read_all_artist_profiles(
+        db=db,
+        category=None,
+        location=None,
+        sort=None,
+        page=1,
+        limit=20,
+    )
     assert len(first) == 1
 
     # Use failing DB to ensure cache is consulted on second call
-    second = api_artist.read_all_artist_profiles(db=FailingDB([]), category=None, location=None, sort=None, page=1)
+    second = api_artist.read_all_artist_profiles(
+        db=FailingDB([]),
+        category=None,
+        location=None,
+        sort=None,
+        page=1,
+        limit=20,
+    )
     assert second == first
 
 
@@ -143,5 +179,12 @@ def test_fallback_when_redis_unavailable(monkeypatch):
     db.add(profile)
     db.commit()
 
-    result = api_artist.read_all_artist_profiles(db=db, category=None, location=None, sort=None, page=1)
+    result = api_artist.read_all_artist_profiles(
+        db=db,
+        category=None,
+        location=None,
+        sort=None,
+        page=1,
+        limit=20,
+    )
     assert len(result) == 1


### PR DESCRIPTION
## Summary
- allow artist listings to specify a `limit` query parameter
- cache artist list results using limit value in the key
- support pagination limit when reading from cache
- update tests for pagination limit and cache keys
- document the new pagination parameters in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68592b2ab8e0832e83b322200d87e2bf