### PR TITLE
Implement pagination on artists page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **Python** 3.12
 - **Node.js** 22
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
+- Artists page adds a **Load More** button that fetches additional results using
+  the API's pagination parameters.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/src/app/artists/__tests__/page.test.tsx
+++ b/frontend/src/app/artists/__tests__/page.test.tsx
@@ -33,7 +33,13 @@ describe('Artists page filters', () => {
       catBtn.click();
       await Promise.resolve();
     });
-    expect(spy).toHaveBeenLastCalledWith({ category: 'Live Performance', location: undefined, sort: undefined });
+    expect(spy).toHaveBeenLastCalledWith({
+      category: 'Live Performance',
+      location: undefined,
+      sort: undefined,
+      page: 1,
+      limit: 20,
+    });
     act(() => root.unmount());
     container.remove();
   });
@@ -130,6 +136,53 @@ describe('Artists page filters', () => {
     container.remove();
   });
 
+  it('loads more artists when Load More clicked', async () => {
+    const firstPage = {
+      data: Array.from({ length: 20 }, (_, i) => ({
+        id: i + 1,
+        business_name: `Name${i + 1}`,
+        user: { first_name: 'A', last_name: 'B', is_verified: false },
+        user_id: i + 1,
+      })) as unknown as ArtistProfile[],
+    };
+    const secondPage = {
+      data: [
+        {
+          id: 21,
+          business_name: 'Name21',
+          user: { first_name: 'C', last_name: 'D', is_verified: false },
+          user_id: 21,
+        },
+      ] as unknown as ArtistProfile[],
+    };
+    const spy = jest
+      .spyOn(api, 'getArtists')
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(ArtistsPage));
+      await Promise.resolve();
+    });
+    const loadBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Load More',
+    ) as HTMLButtonElement;
+    expect(loadBtn).not.toBeNull();
+    await act(async () => {
+      loadBtn.click();
+      await Promise.resolve();
+    });
+    expect(spy).toHaveBeenLastCalledWith({
+      category: undefined,
+      location: undefined,
+      sort: undefined,
+      page: 2,
+      limit: 20,
+    });
+    act(() => root.unmount());
+    container.remove();
+  });
+
   it('clears all filters', async () => {
     const spy = jest.spyOn(api, 'getArtists').mockResolvedValue({ data: [] });
     const { container, root } = setup();
@@ -154,7 +207,13 @@ describe('Artists page filters', () => {
       button.click();
       await Promise.resolve();
     });
-    expect(spy).toHaveBeenLastCalledWith({ category: undefined, location: undefined, sort: undefined });
+    expect(spy).toHaveBeenLastCalledWith({
+      category: undefined,
+      location: undefined,
+      sort: undefined,
+      page: 1,
+      limit: 20,
+    });
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -133,6 +133,8 @@ export const getArtists = async (params?: {
   category?: string;
   location?: string;
   sort?: string;
+  page?: number;
+  limit?: number;
 }) => {
   const res = await api.get<ArtistProfile[]>(`${API_V1}/artist-profiles/`, {
     params,


### PR DESCRIPTION
## Summary
- allow `getArtists` API helper to accept `page` and `limit`
- paginate artists page with Load More button
- update artists page tests for pagination
- mention new pagination feature in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68592c7ea828832e899468788f4f8495