### PR TITLE
Update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder stage
-FROM python:3.12-slim AS builder
+FROM python:3.12.11-slim AS builder
 WORKDIR /app
 RUN apt-get update && apt-get install -y curl gnupg ca-certificates \
     libnss3 libatk1.0-0 libcups2 libdrm2 libgbm1 libgtk-3-0 libasound2 \
@@ -30,7 +30,7 @@ RUN npm ci --silent \
     && touch node_modules/.install_complete
 
 # final stage
-FROM python:3.12-slim
+FROM python:3.12.11-slim
 WORKDIR /app
 COPY --from=builder /app /app
 COPY setup.sh scripts/test-all.sh ./

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **FastAPI** 0.115.12 (requires Starlette 0.46+)
 - **Uvicorn** 0.34
 - **React** 18.3 and **Next.js** 14.2
-- **Python** 3.12
-- **Node.js** 22
+- **Python** 3.12.11
+- **Node.js** 22 (v22.16.0)
 - Minor fix: the artists listing now gracefully handles incomplete user data from the API.
 - Artists page adds a **Load More** button that fetches additional results using
   the API's pagination parameters.


### PR DESCRIPTION
## Summary
- bump base python to `python:3.12.11-slim`
- document updated versions

## Testing
- `./scripts/test-all.sh`
- `./scripts/docker-test.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592df3cbac832ea469edf681cf793a