### PR TITLE
Configure payment gateway URL in Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,4 @@ SMTP_FROM=no-reply@localhost
 # Login rate limiting
 MAX_LOGIN_ATTEMPTS=5
 LOGIN_ATTEMPT_WINDOW=300
+PAYMENT_GATEWAY_URL=https://example.com

--- a/README.md
+++ b/README.md
@@ -317,6 +317,16 @@ defined in `backend/app/core/config.py`. They are required for the email
 confirmation feature—missing values will cause the backend to exit during
 startup.
 
+### Payment gateway configuration
+
+Specify your payment provider base URL in `.env`:
+
+```env
+PAYMENT_GATEWAY_URL=https://pay.example.com
+```
+
+The default `https://example.com` is a placeholder. The API logs a warning on startup if this value isn't changed.
+
 ### Email confirmation
 
 Users registering via `/auth/register` receive a short-lived token in an email
@@ -912,6 +922,7 @@ The endpoint now verifies the booking belongs to the authenticated client and re
 Duplicate payments are rejected with **400 Bad Request** when the deposit is already paid.
 Payment processing now emits structured logs instead of printing to stdout so transactions can be traced in production.
 Set `PAYMENT_GATEWAY_FAKE=1` in the environment to bypass the real gateway during local testing. When enabled, `/api/v1/payments` returns a dummy `payment_id` and immediately marks the booking paid.
+Set `PAYMENT_GATEWAY_URL` to your payment provider's base URL. The default `https://example.com` triggers a startup warning so you don't accidentally hit a placeholder endpoint.
 
 When a client accepts a quote in the chat thread, the frontend now prompts them to pay a deposit via this endpoint. Successful payments update the booking's `payment_status` and display a confirmation banner.
 The payment modal automatically fills in half the quote total as the suggested deposit, but clients can adjust the amount before submitting.

--- a/backend/app/api/api_payment.py
+++ b/backend/app/api/api_payment.py
@@ -11,10 +11,10 @@ import uuid
 
 from ..models import User, BookingSimple, QuoteV2
 from .dependencies import get_db, get_current_active_client
+from ..core.config import settings
 
 logger = logging.getLogger(__name__)
 
-PAYMENT_GATEWAY_URL = os.getenv("PAYMENT_GATEWAY_URL", "https://example.com")
 PAYMENT_GATEWAY_FAKE = os.getenv("PAYMENT_GATEWAY_FAKE")
 
 router = APIRouter(tags=["payments"])
@@ -83,7 +83,7 @@ def create_payment(
     else:
         try:
             response = httpx.post(
-                f"{PAYMENT_GATEWAY_URL}/charges",
+                f"{settings.PAYMENT_GATEWAY_URL}/charges",
                 json={"amount": amount, "currency": "ZAR"},
                 timeout=10,
             )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     MAX_LOGIN_ATTEMPTS: int = 5
     LOGIN_ATTEMPT_WINDOW: int = 300  # seconds
 
+    # Payment gateway base URL
+    PAYMENT_GATEWAY_URL: str = "https://example.com"
+
     # SMTP email settings
     SMTP_HOST: str = "localhost"
     SMTP_PORT: int = 25

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -255,6 +255,16 @@ app.include_router(
 )
 
 
+# Warn if the payment gateway URL is not configured
+@app.on_event("startup")
+def check_payment_gateway_url() -> None:
+    """Log a warning when PAYMENT_GATEWAY_URL uses the default placeholder."""
+    if settings.PAYMENT_GATEWAY_URL == "https://example.com":
+        logger.warning(
+            "PAYMENT_GATEWAY_URL is set to the default placeholder; update .env to your gateway URL"
+        )
+
+
 # ─── A simple root check ─────────────────────────────────────────────────────────────
 @app.get("/")
 async def root():

--- a/backend/tests/test_gateway_url_warning.py
+++ b/backend/tests/test_gateway_url_warning.py
@@ -1,0 +1,15 @@
+import logging
+from fastapi.testclient import TestClient
+
+from app.main import app, logger, settings
+
+
+def test_warn_on_placeholder_gateway_url(monkeypatch, caplog):
+    monkeypatch.setattr(settings, "PAYMENT_GATEWAY_URL", "https://example.com", raising=False)
+    caplog.set_level("WARNING", logger=logger.name)
+    with TestClient(app):
+        pass
+    assert any(
+        "PAYMENT_GATEWAY_URL is set to the default placeholder" in r.getMessage()
+        for r in caplog.records
+    )

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -10,7 +10,7 @@ Enabling MFA greatly reduces the risk of unauthorized access. Keep your recovery
 
 ## Quickstart Booking Walkthrough
 
-These sample commands demonstrate the basic booking flow using the API. Replace `CLIENT_TOKEN`, `ARTIST_TOKEN`, `ARTIST_ID`, `SERVICE_ID`, `REQUEST_ID`, and `QUOTE_ID` with actual values from your environment. Set `PAYMENT_GATEWAY_FAKE=1` when testing locally so payments use the built-in fake gateway.
+These sample commands demonstrate the basic booking flow using the API. Replace `CLIENT_TOKEN`, `ARTIST_TOKEN`, `ARTIST_ID`, `SERVICE_ID`, `REQUEST_ID`, and `QUOTE_ID` with actual values from your environment. Set `PAYMENT_GATEWAY_FAKE=1` when testing locally so payments use the built-in fake gateway. Configure `PAYMENT_GATEWAY_URL` to point at your real payment processor; the default `https://example.com` only serves as a placeholder.
 
 1. **Create users**
    ```bash


### PR DESCRIPTION
## Summary
- add `PAYMENT_GATEWAY_URL` setting and use it in payment API
- warn on startup when the placeholder gateway URL is used
- document gateway configuration in README and onboarding guide
- add example variable to `.env.example`
- test warning when gateway URL isn't set

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685935b6da34832eb6bcfbe1e6974051