### PR TITLE
Add deposit reminder formatter

### DIFF
--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -45,21 +45,21 @@ def format_notification_message(
     if ntype == NotificationType.DEPOSIT_DUE:
         amount = kwargs.get("deposit_amount")
         due_by = kwargs.get("deposit_due_by")
-        msg = "Booking confirmed"
+        msg = "Deposit"
         if amount is not None:
             try:
                 amt_str = f"R{float(amount):.2f}"
             except Exception:  # pragma: no cover - formatting should not fail
                 amt_str = f"R{amount}"
-            msg += f" \u2014 deposit {amt_str}"
-        else:
-            msg += " \u2014 deposit payment"
+            msg += f" {amt_str}"
         if due_by is not None:
             try:
                 date_str = due_by.strftime("%Y-%m-%d")
                 msg += f" due by {date_str}"
             except Exception:
-                pass
+                msg += " due"
+        else:
+            msg += " due"
         return msg
     if ntype == NotificationType.REVIEW_REQUEST:
         return f"Please review your booking #{kwargs.get('booking_id')}"

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -462,7 +462,7 @@ def test_format_notification_message_new_types():
     msg_booking = format_notification_message(
         NotificationType.NEW_BOOKING, booking_id=8
     )
-    assert msg_deposit == "Booking confirmed \u2014 deposit R50.00 due by 2025-01-01"
+    assert msg_deposit == "Deposit R50.00 due by 2025-01-01"
     assert msg_review == "Please review your booking #42"
     assert msg_quote == "Quote #7 accepted"
     assert msg_booking == "New booking #8"

--- a/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/[id]/page.tsx
@@ -8,7 +8,11 @@ import PaymentModal from "@/components/booking/PaymentModal";
 import toast from "@/components/ui/Toast";
 import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
 import type { Booking } from "@/types";
-import { formatCurrency, formatStatus } from "@/lib/utils";
+import {
+  formatCurrency,
+  formatStatus,
+  formatDepositReminder,
+} from "@/lib/utils";
 import { Spinner } from "@/components/ui";
 
 export default function BookingDetailsPage() {
@@ -104,8 +108,10 @@ export default function BookingDetailsPage() {
         )}
         {booking.payment_status === "pending" && booking.deposit_due_by && (
           <p className="text-sm text-gray-700">
-            Deposit due by{" "}
-            {new Date(booking.deposit_due_by).toLocaleDateString()}
+            {formatDepositReminder(
+              Number(booking.deposit_amount || 0),
+              booking.deposit_due_by,
+            )}
           </p>
         )}
         {booking.payment_id && (

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { format } from "date-fns";
 import BookingDetailsPage from "../[id]/page";
 import { getBookingDetails, downloadBookingIcs } from "@/lib/api";
+import { formatDepositReminder } from "@/lib/utils";
 import { useParams, useSearchParams } from "next/navigation";
 
 jest.mock("@/lib/api");
@@ -63,7 +64,9 @@ describe("BookingDetailsPage", () => {
 
     expect(getBookingDetails).toHaveBeenCalledWith(1);
     expect(div.textContent).toContain("Gig - Artist");
-    expect(div.textContent).toContain("Deposit due");
+    expect(div.textContent).toContain(
+      formatDepositReminder(50, new Date("2024-01-08")),
+    );
     const artistLink = div.querySelector('[data-testid="view-artist-link"]');
     expect(artistLink?.getAttribute("href")).toBe("/artists/2");
     const pay = div.querySelector('[data-testid="pay-deposit-button"]');

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -8,7 +8,11 @@ import type { Booking, Review } from "@/types";
 import ReviewFormModal from "@/components/review/ReviewFormModal";
 import usePaymentModal from "@/hooks/usePaymentModal";
 import { format } from "date-fns";
-import { formatCurrency, formatStatus } from "@/lib/utils";
+import {
+  formatCurrency,
+  formatStatus,
+  formatDepositReminder,
+} from "@/lib/utils";
 import Link from "next/link";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Spinner } from "@/components/ui";
@@ -67,8 +71,10 @@ function BookingList({
             )}
             {b.payment_status === "pending" && b.deposit_due_by && (
               <div className="text-sm text-gray-500 mt-1">
-                Deposit due by{" "}
-                {format(new Date(b.deposit_due_by), "MMM d, yyyy")}
+                {formatDepositReminder(
+                  Number(b.deposit_amount || 0),
+                  b.deposit_due_by,
+                )}
               </div>
             )}
             {b.payment_id && (

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -13,7 +13,11 @@ import { motion } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
 import TimeAgo from '../ui/TimeAgo';
-import { getFullImageUrl, formatCurrency } from '@/lib/utils';
+import {
+  getFullImageUrl,
+  formatCurrency,
+  formatDepositReminder,
+} from '@/lib/utils';
 import AlertBanner from '../ui/AlertBanner';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
 import { ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
@@ -467,11 +471,11 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             {bookingDetails && (
               <>
                 {bookingDetails.service?.title} on{' '}
-                {new Date(bookingDetails.start_time).toLocaleString()}. Deposit{' '}
-                {formatCurrency(depositAmount ?? bookingDetails.deposit_amount ?? 0)}
-                {bookingDetails.deposit_due_by
-                  ? ` due by ${new Date(bookingDetails.deposit_due_by).toLocaleDateString()}`
-                  : ' due.'}
+                {new Date(bookingDetails.start_time).toLocaleString()}.{' '}
+                {formatDepositReminder(
+                  depositAmount ?? bookingDetails.deposit_amount ?? 0,
+                  bookingDetails.deposit_due_by ?? undefined,
+                )}
               </>
             )}
           </AlertBanner>

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -48,7 +48,7 @@ describe('NotificationListItem', () => {
       type: 'deposit_due',
       timestamp: new Date().toISOString(),
       is_read: false,
-      content: 'Booking confirmed \u2014 deposit R200 due by 2025-12-31',
+      content: 'Deposit R200 due by 2025-12-31',
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Deposit Due');
@@ -60,7 +60,7 @@ describe('NotificationListItem', () => {
       type: 'deposit_due',
       timestamp: new Date().toISOString(),
       is_read: false,
-      content: 'Booking confirmed \u2014 deposit R50.00 due by 2025-01-01',
+      content: 'Deposit R50.00 due by 2025-01-01',
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.subtitle).toBe('R50.00 due by Jan 1, 2025');

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import api from './api';
 import { DEFAULT_CURRENCY } from './constants';
 import { Service } from '@/types';
-import { addDays } from 'date-fns';
+import { addDays, format } from 'date-fns';
 
 export const getFullImageUrl = (
   relativePath: string | undefined | null,
@@ -132,3 +132,24 @@ const capitalize = (word: string): string =>
  */
 export const formatStatus = (status: string): string =>
   STATUS_LABELS[status] || status.split('_').map(capitalize).join(' ');
+
+export const formatDepositReminder = (
+  amount?: number,
+  dueDate?: string | Date,
+): string => {
+  const parts: string[] = [];
+  const formattedAmount =
+    amount !== undefined ? formatCurrency(Number(amount)) : undefined;
+  if (formattedAmount) {
+    parts.push(`Deposit ${formattedAmount}`);
+  } else {
+    parts.push('Deposit');
+  }
+  if (dueDate) {
+    const d = typeof dueDate === 'string' ? new Date(dueDate) : dueDate;
+    parts.push(`due by ${format(d, 'MMM d, yyyy')}`);
+  } else {
+    parts.push('due');
+  }
+  return parts.join(' ');
+};


### PR DESCRIPTION
## Summary
- create `formatDepositReminder` helper in `utils.ts`
- use helper when showing deposit due text in booking thread and dashboard pages
- align deposit due email wording and adjust backend tests
- update notification parsing tests
- check booking details page uses the new formatted text

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685939a8936c832e8fe85aa751a1a30c