### PR TITLE
Add account export and deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   `deposit_due_by`.
 - A new `deposit_due_by` field records when the deposit is due, one week after a quote is accepted.
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
+- Users can download all account data via `/api/v1/users/me/export` and permanently delete their account with `DELETE /api/v1/users/me`.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.

--- a/backend/app/api/api_user.py
+++ b/backend/app/api/api_user.py
@@ -1,0 +1,110 @@
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session, selectinload
+from pydantic import BaseModel
+
+from ..database import get_db
+from ..models import (
+    User,
+    Booking,
+    BookingSimple,
+    Message,
+    BookingRequest,
+)
+from ..schemas.user import UserResponse
+from ..schemas.booking import BookingResponse
+from ..schemas.quote_v2 import BookingSimpleRead
+from ..schemas.message import MessageResponse
+from .dependencies import get_current_user
+from ..utils.auth import verify_password
+from ..utils.email import send_email
+
+router = APIRouter(tags=["users"])
+logger = logging.getLogger(__name__)
+
+
+@router.get("/users/me/export")
+def export_me(
+    *, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
+) -> Any:
+    """Return all user related data as JSON."""
+    bookings = (
+        db.query(Booking)
+        .outerjoin(BookingSimple, Booking.quote_id == BookingSimple.quote_id)
+        .options(
+            selectinload(Booking.service),
+            selectinload(Booking.client),
+            selectinload(Booking.source_quote),
+        )
+        .filter((Booking.client_id == current_user.id) | (Booking.artist_id == current_user.id))
+        .all()
+    )
+
+    booking_data = []
+    for b in bookings:
+        simple = (
+            db.query(BookingSimple)
+            .filter(BookingSimple.quote_id == b.quote_id)
+            .first()
+        )
+        data = BookingResponse.model_validate(b).model_dump()
+        if simple:
+            simple_data = BookingSimpleRead.model_validate(simple).model_dump()
+            data.update(simple_data)
+        booking_data.append(data)
+
+    messages = (
+        db.query(Message)
+        .join(BookingRequest, Message.booking_request_id == BookingRequest.id)
+        .filter(
+            (BookingRequest.client_id == current_user.id)
+            | (BookingRequest.artist_id == current_user.id)
+        )
+        .order_by(Message.timestamp)
+        .all()
+    )
+    message_data = [MessageResponse.model_validate(m).model_dump() for m in messages]
+
+    payments = (
+        db.query(BookingSimple)
+        .filter(
+            (BookingSimple.client_id == current_user.id)
+            | (BookingSimple.artist_id == current_user.id)
+        )
+        .all()
+    )
+    payment_data = [BookingSimpleRead.model_validate(p).model_dump() for p in payments]
+
+    return {
+        "user": UserResponse.model_validate(current_user).model_dump(),
+        "bookings": booking_data,
+        "payments": payment_data,
+        "messages": message_data,
+    }
+
+
+class DeleteMeRequest(BaseModel):
+    password: str
+
+
+@router.delete("/users/me", status_code=status.HTTP_204_NO_CONTENT)
+def delete_me(
+    payload: DeleteMeRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """Delete the current user's account after password confirmation."""
+    if not verify_password(payload.password, current_user.password):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Incorrect password")
+
+    email = current_user.email
+    db.delete(current_user)
+    db.commit()
+    try:
+        send_email(email, "Account deleted", "Your account has been permanently deleted.")
+    except Exception as exc:  # pragma: no cover - email failure shouldn't block
+        logger.error("Failed to send deletion email: %s", exc)
+    return None
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from .api import (
     api_message,
     api_notification,
     api_payment,
+    api_user,
     api_calendar,
     api_quote_template,
     api_settings,
@@ -245,6 +246,13 @@ app.include_router(
     api_payment.router,
     prefix=f"{api_prefix}/payments",
     tags=["payments"],
+)
+
+# ─── USER ROUTES (under /api/v1/users) ─────────────────────────────────────
+app.include_router(
+    api_user.router,
+    prefix=f"{api_prefix}",
+    tags=["users"],
 )
 
 # ─── SETTINGS ROUTES (under /api/v1) ─────────────────────────────────────────

--- a/backend/tests/test_user_export_delete.py
+++ b/backend/tests/test_user_export_delete.py
@@ -1,0 +1,182 @@
+from datetime import datetime
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.models.base import BaseModel
+from app.models import (
+    User,
+    UserType,
+    Service,
+    Booking,
+    BookingStatus,
+    BookingRequest,
+    QuoteV2,
+    QuoteStatusV2,
+    BookingSimple,
+    Message,
+    SenderType,
+    MessageType,
+)
+from app.api.dependencies import get_db
+from app.api.auth import get_password_hash, create_access_token
+import app.api.api_user as api_user
+
+
+def setup_app():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    client = User(
+        email='client@test.com',
+        password=get_password_hash('pw'),
+        first_name='C',
+        last_name='L',
+        user_type=UserType.CLIENT,
+    )
+    artist = User(
+        email='artist@test.com',
+        password='x',
+        first_name='A',
+        last_name='R',
+        user_type=UserType.ARTIST,
+    )
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title='Gig',
+        price=Decimal('100'),
+        duration_minutes=60,
+        service_type='Live Performance',
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id)
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = QuoteV2(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[],
+        sound_fee=0,
+        travel_fee=0,
+        subtotal=Decimal('100'),
+        total=Decimal('100'),
+        status=QuoteStatusV2.ACCEPTED,
+    )
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+
+    booking = Booking(
+        artist_id=artist.id,
+        client_id=client.id,
+        service_id=service.id,
+        start_time=datetime(2030, 1, 1, 12, 0, 0),
+        end_time=datetime(2030, 1, 1, 13, 0, 0),
+        status=BookingStatus.CONFIRMED,
+        total_price=Decimal('100'),
+        quote_id=quote.id,
+    )
+    db.add(booking)
+    db.commit()
+    db.refresh(booking)
+
+    simple = BookingSimple(
+        quote_id=quote.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        confirmed=True,
+        payment_status='deposit_paid',
+        deposit_amount=Decimal('50'),
+        deposit_paid=True,
+    )
+    db.add(simple)
+    db.commit()
+
+    msg = Message(
+        booking_request_id=br.id,
+        sender_id=client.id,
+        sender_type=SenderType.CLIENT,
+        message_type=MessageType.TEXT,
+        content='Hello',
+    )
+    db.add(msg)
+    db.commit()
+    db.close()
+    return client
+
+
+def test_export_me_returns_data(monkeypatch):
+    Session = setup_app()
+    user = create_data(Session)
+
+    token = create_access_token({'sub': user.email})
+    client = TestClient(app)
+
+    resp = client.get('/api/v1/users/me/export', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['user']['email'] == 'client@test.com'
+    assert len(data['bookings']) == 1
+    assert len(data['payments']) == 1
+    assert len(data['messages']) == 1
+
+
+def test_delete_me_requires_password_and_sends_email(monkeypatch):
+    Session = setup_app()
+    user = create_data(Session)
+    called = {}
+
+    def fake_send(to, subject, body):
+        called['email'] = to
+
+    monkeypatch.setattr(api_user, 'send_email', fake_send)
+
+    token = create_access_token({'sub': user.email})
+    client = TestClient(app)
+
+    resp = client.request(
+        'DELETE',
+        '/api/v1/users/me',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'password': 'pw'},
+    )
+    assert resp.status_code == 204
+
+    db = Session()
+    assert db.query(User).filter(User.id == user.id).first() is None
+    assert called['email'] == 'client@test.com'
+    db.close()
+

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -69,6 +69,19 @@ These sample commands demonstrate the basic booking flow using the API. Replace 
      http://localhost:8000/api/v1/bookings/my-bookings
    ```
 
+9. **Export or delete your account**
+   ```bash
+   # Download a JSON export
+   curl -H "Authorization: Bearer CLIENT_TOKEN" \
+     http://localhost:8000/api/v1/users/me/export
+
+   # Delete the account after confirming the password
+   curl -X DELETE http://localhost:8000/api/v1/users/me \
+     -H "Authorization: Bearer CLIENT_TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{"password":"pass"}'
+   ```
+
 8. **Run database migrations**
    ```bash
    alembic upgrade head

--- a/frontend/src/app/account/__tests__/DeleteAccountPage.test.tsx
+++ b/frontend/src/app/account/__tests__/DeleteAccountPage.test.tsx
@@ -1,0 +1,53 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import DeleteAccountPage from '../delete';
+import { deleteMyAccount } from '@/lib/api';
+import { useRouter } from 'next/navigation';
+
+jest.mock('@/lib/api');
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MainLayout';
+  return Mock;
+});
+jest.mock('@/components/ui/Button', () => {
+  const Btn = (props: Record<string, unknown>) => <button {...props} />;
+  Btn.displayName = 'Button';
+  return Btn;
+});
+
+describe('DeleteAccountPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits password and redirects', async () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    (deleteMyAccount as jest.Mock).mockResolvedValue({});
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<DeleteAccountPage />);
+    });
+    const input = div.querySelector('input#password') as HTMLInputElement;
+    if (!input) throw new Error('input not found');
+    await act(async () => {
+      input.value = 'pw';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const form = div.querySelector('form');
+    await act(async () => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(deleteMyAccount).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/login');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/account/__tests__/ExportAccountPage.test.tsx
+++ b/frontend/src/app/account/__tests__/ExportAccountPage.test.tsx
@@ -1,0 +1,34 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import ExportAccountPage from '../export';
+import { exportMyAccount } from '@/lib/api';
+
+jest.mock('@/lib/api');
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MainLayout';
+  return Mock;
+});
+
+describe('ExportAccountPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches data and displays JSON', async () => {
+    (exportMyAccount as jest.Mock).mockResolvedValue({ data: { user: { id: 1 } } });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ExportAccountPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(exportMyAccount).toHaveBeenCalled();
+    expect(div.textContent).toContain('"id": 1');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/account/delete.tsx
+++ b/frontend/src/app/account/delete.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import Button from '@/components/ui/Button';
+import { deleteMyAccount } from '@/lib/api';
+
+export default function DeleteAccountPage() {
+  const router = useRouter();
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleDelete = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      await deleteMyAccount(password);
+      router.push('/login');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Delete failed';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <MainLayout>
+      <div className="mx-auto max-w-sm py-10">
+        <h1 className="mb-4 text-2xl font-bold">Delete Account</h1>
+        <form onSubmit={handleDelete} className="space-y-4">
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Confirm password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand"
+            />
+          </div>
+          {error && <p className="text-red-600">{error}</p>}
+          <Button type="submit" disabled={loading} className="w-full bg-red-600 hover:bg-red-700">
+            {loading ? 'Deleting...' : 'Delete my account'}
+          </Button>
+        </form>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/app/account/export.tsx
+++ b/frontend/src/app/account/export.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import MainLayout from '@/components/layout/MainLayout';
+import { exportMyAccount } from '@/lib/api';
+
+export default function ExportAccountPage() {
+  const [data, setData] = useState<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    exportMyAccount()
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        console.error('Export error:', err);
+      });
+  }, []);
+
+  return (
+    <MainLayout>
+      <div className="mx-auto max-w-xl py-10 space-y-4">
+        <h1 className="text-2xl font-bold">Export Account Data</h1>
+        {data ? (
+          <pre data-testid="export-json" className="whitespace-pre-wrap break-all">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        ) : (
+          <p>Loading...</p>
+        )}
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -472,4 +472,11 @@ export const connectGoogleCalendar = () =>
 export const disconnectGoogleCalendar = () =>
   api.delete(`${API_V1}/google-calendar`);
 
+// ─── USER ACCOUNT ────────────────────────────────────────────────────────────
+export const exportMyAccount = () =>
+  api.get(`${API_V1}/users/me/export`);
+
+export const deleteMyAccount = (password: string) =>
+  api.delete(`${API_V1}/users/me`, { data: { password } });
+
 export default api;


### PR DESCRIPTION
## Summary
- implement user data export and account deletion endpoints
- add frontend pages for exporting data and deleting the account
- write integration tests for new endpoints and React pages
- document account export/delete in onboarding and README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68593d562758832e9739624cee85e21d