### PR TITLE
Add security headers middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,7 @@ WORKDIR /app
 COPY --from=builder /app /app
 COPY setup.sh scripts/test-all.sh ./
 RUN chmod +x setup.sh scripts/test-all.sh
+ENV CONTENT_SECURITY_POLICY="default-src 'self'" \
+    STRICT_TRANSPORT_SECURITY="max-age=63072000; includeSubDomains" \
+    X_FRAME_OPTIONS="DENY"
 ENTRYPOINT ["bash","-lc","./setup.sh && ./scripts/test-all.sh"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+## Security Headers Middleware
+
+The API adds standard security headers to every response via
+`app/middleware/security_headers.py`. The middleware is enabled in
+`app/main.py` and sets the following headers:
+
+- `Content-Security-Policy: default-src 'self'`
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains`
+- `X-Frame-Options: DENY`
+
+Deployment configs such as the `Dockerfile` expose matching environment
+variables so reverse proxies or additional servers can mirror these
+headers.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,8 @@ import logging
 from fastapi import FastAPI, Request, status, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+
+from .middleware.security_headers import SecurityHeadersMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
@@ -120,6 +122,7 @@ logger.info("CORS origins set to: %s", allow_origins)
 # session cookie. Add SessionMiddleware so Authlib can sign and read
 # that cookie using our SECRET_KEY.
 app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 @app.middleware("http")

--- a/backend/app/middleware/security_headers.py
+++ b/backend/app/middleware/security_headers.py
@@ -1,0 +1,23 @@
+"""Middleware to add common security headers to responses."""
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach recommended security headers to every HTTP response."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault(
+            "Content-Security-Policy", "default-src 'self'"
+        )
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=63072000; includeSubDomains"
+        )
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        return response

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_security_headers():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.headers.get("Content-Security-Policy") == "default-src 'self'"
+    assert (
+        response.headers.get("Strict-Transport-Security")
+        == "max-age=63072000; includeSubDomains"
+    )
+    assert response.headers.get("X-Frame-Options") == "DENY"


### PR DESCRIPTION
## Summary
- set environment variables for security headers in the Dockerfile
- implement `SecurityHeadersMiddleware`
- enable middleware in `app/main.py`
- document security headers in `backend/README.md`
- test that responses include the security headers

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685941d10cf0832e97d6cb13de619eea