### PR TITLE
Update high contrast theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,8 @@ Components reference these via utility classes such as `bg-brand` and
 
 A **High Contrast** theme can be enabled from the user menu via the
 `ThemeSwitcher` component. When toggled, CSS variables update site-wide colors
-and the preference is stored in `localStorage`.
+and the preference is stored in `localStorage`. The high contrast palette now
+uses only black and white for maximum readability.
 
 Update these colors in `frontend/tailwind.config.js` and
 `frontend/src/app/globals.css` to adjust the site's look and feel. The Tailwind

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9,15 +9,15 @@
   --brand-color-light: #a5b4fc;
   --color-background: #ffffff;
   --color-foreground: #111827;
-  --hc-brand-color: #ffff00;
+  --hc-brand-color: #ffffff;
   --hc-background: #000000;
   --hc-foreground: #ffffff;
 }
 
 [data-theme='high-contrast'] {
-  --brand-color: var(--hc-brand-color);
-  --brand-color-dark: var(--hc-brand-color);
-  --brand-color-light: #ffff66;
+  --brand-color: var(--hc-foreground);
+  --brand-color-dark: var(--hc-foreground);
+  --brand-color-light: var(--hc-foreground);
   --color-background: var(--hc-background);
   --color-foreground: var(--hc-foreground);
 }


### PR DESCRIPTION
## Summary
- simplify high contrast mode to pure black and white
- note the new palette in the README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685948127dac832e818dca9316a0e59d