### PR TITLE
Improve high contrast docs and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,8 +1039,10 @@ Components reference these via utility classes such as `bg-brand` and
 
 A **High Contrast** theme can be enabled from the user menu via the
 `ThemeSwitcher` component. When toggled, CSS variables update site-wide colors
-and the preference is stored in `localStorage`. The high contrast palette now
-uses only black and white for maximum readability.
+and the preference is stored in `localStorage`.
+The high contrast palette now uses pure black (`#000`) and pure white (`#fff`)
+for all accents and backgrounds, so black buttons render white text and white
+buttons render black text for maximum readability.
 
 Update these colors in `frontend/tailwind.config.js` and
 `frontend/src/app/globals.css` to adjust the site's look and feel. The Tailwind

--- a/frontend/src/components/layout/ThemeSwitcher.tsx
+++ b/frontend/src/components/layout/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import clsx from 'clsx';
 
 export default function ThemeSwitcher() {
   const [highContrast, setHighContrast] = useState(false);
@@ -28,7 +29,12 @@ export default function ThemeSwitcher() {
       type="button"
       aria-pressed={highContrast}
       onClick={() => setHighContrast(!highContrast)}
-      className="px-3 py-1.5 rounded-md border text-sm bg-background text-foreground border-foreground"
+      className={clsx(
+        'px-3 py-1.5 rounded-md border text-sm',
+        highContrast
+          ? 'bg-black text-white border-white'
+          : 'bg-white text-black border-black',
+      )}
     >
       {highContrast ? 'Standard colors' : 'High contrast'}
     </button>

--- a/frontend/src/components/layout/__tests__/__snapshots__/ThemeSwitcher.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/ThemeSwitcher.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ThemeSwitcher matches snapshot 1`] = `
 <button
   aria-pressed="false"
-  class="px-3 py-1.5 rounded-md border text-sm bg-background text-foreground border-foreground"
+  class="px-3 py-1.5 rounded-md border text-sm bg-white text-black border-black"
   type="button"
 >
   High contrast


### PR DESCRIPTION
## Summary
- clarify that high contrast palette only uses pure black/white in README
- render high contrast toggle with explicit black/white button styles
- update snapshot

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68594b78e4b0832e9a9da8a910403bfb