### PR TITLE
Fix global high contrast theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,9 @@ and the preference is stored in `localStorage`.
 The high contrast palette uses pure black (`#000`) for page backgrounds and
 white (`#fff`) for text. Elements styled with `bg-brand-dark` also switch to a
 black background in this mode so button wording stays visible.
+The `ThemeSwitcher` now adds a `high-contrast` class to `<body>` so every
+component can conditionally style itself using Tailwind. The preference is still
+stored in `localStorage` and applied on page load via a small inline script.
 
 Update these colors in `frontend/tailwind.config.js` and
 `frontend/src/app/globals.css` to adjust the site's look and feel. The Tailwind

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -15,13 +15,43 @@
 }
 
 [data-theme='high-contrast'] {
+  --brand-color: #ffffff;
+  --brand-color-dark: #000000;
+  --brand-color-light: #ffffff;
   --color-background: var(--hc-background);
   --color-foreground: var(--hc-foreground);
 }
 
+[data-theme='high-contrast'] .bg-brand,
+[data-theme='high-contrast'] .bg-brand-light,
 [data-theme='high-contrast'] .bg-brand-dark,
 [data-theme='high-contrast'] .hover\:bg-brand-dark:hover {
   background-color: var(--hc-background) !important;
+  color: var(--hc-foreground) !important;
+}
+
+[data-theme='high-contrast'] a {
+  text-decoration: underline;
+  font-weight: 700;
+}
+
+[data-theme='high-contrast'] button {
+  background-color: var(--hc-background);
+  color: var(--hc-foreground);
+  border-color: var(--hc-foreground);
+}
+
+[data-theme='high-contrast'] button:hover {
+  background-color: var(--hc-foreground);
+  color: var(--hc-background);
+}
+
+[data-theme='high-contrast'] input,
+[data-theme='high-contrast'] select,
+[data-theme='high-contrast'] textarea {
+  background-color: #ffffff;
+  color: #000000;
+  border-color: #000000;
 }
 
 @layer base {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Inter } from 'next/font/google';
+import Script from 'next/script';
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider } from '@/contexts/AuthContext';
 import './globals.css';
@@ -22,6 +23,13 @@ export default function RootLayout({
   return (
     <html lang="en" className={inter.variable}>
       <body className="font-sans antialiased">
+        <Script
+          id="theme-init"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(() => { try { const t = localStorage.getItem('theme'); if (t === 'high-contrast') { document.documentElement.setAttribute('data-theme', 'high-contrast'); document.body.classList.add('high-contrast'); } } catch(e) { console.error('theme init failed', e); } })();`,
+          }}
+        />
         <AuthProvider>
           {children}
           <Toaster position="top-right" />

--- a/frontend/src/components/layout/ThemeSwitcher.tsx
+++ b/frontend/src/components/layout/ThemeSwitcher.tsx
@@ -11,15 +11,18 @@ export default function ThemeSwitcher() {
     if (stored === 'high-contrast') {
       setHighContrast(true);
       document.documentElement.setAttribute('data-theme', 'high-contrast');
+      document.body.classList.add('high-contrast');
     }
   }, []);
 
   useEffect(() => {
     if (highContrast) {
       document.documentElement.setAttribute('data-theme', 'high-contrast');
+      document.body.classList.add('high-contrast');
       localStorage.setItem('theme', 'high-contrast');
     } else {
       document.documentElement.removeAttribute('data-theme');
+      document.body.classList.remove('high-contrast');
       localStorage.setItem('theme', 'default');
     }
   }, [highContrast]);

--- a/frontend/src/components/layout/__tests__/ThemeSwitcher.test.tsx
+++ b/frontend/src/components/layout/__tests__/ThemeSwitcher.test.tsx
@@ -13,6 +13,7 @@ describe('ThemeSwitcher', () => {
     root = createRoot(container);
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
+    document.body.className = '';
   });
 
   afterEach(() => {
@@ -38,12 +39,14 @@ describe('ThemeSwitcher', () => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(document.documentElement.getAttribute('data-theme')).toBe('high-contrast');
+    expect(document.body.classList.contains('high-contrast')).toBe(true);
     expect(localStorage.getItem('theme')).toBe('high-contrast');
 
     act(() => {
       button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+    expect(document.body.classList.contains('high-contrast')).toBe(false);
     expect(localStorage.getItem('theme')).toBe('default');
   });
 });


### PR DESCRIPTION
## Summary
- add `high-contrast` body class toggled by ThemeSwitcher
- set theme on initial page load with an inline script
- enforce black & white styles under `[data-theme='high-contrast']`
- mention new body class in README
- update ThemeSwitcher test expectations

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685957eac13c832ea00ca39d5eef6218