### PR TITLE
Fix LCP warnings by preloading profile images

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -191,7 +191,7 @@ export default function ArtistProfilePage() {
               src={coverPhotoUrl}
               alt="Cover photo"
               fill
-              loading="lazy"
+              priority
               className="object-cover"
               sizes="(min-width: 768px) 100vw, 100vw"
             />
@@ -214,7 +214,7 @@ export default function ArtistProfilePage() {
                     height={160}
                     className="h-32 w-32 md:h-40 md:w-40 rounded-full ring-4 ring-white object-cover shadow-lg"
                     alt={artist.business_name || 'Artist'}
-                    loading="lazy"
+                    priority
                     onError={(e) => {
                       (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
                     }}


### PR DESCRIPTION
## Summary
- mark artist page hero images with `priority` to preload them
- run automated tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68596717abbc832e90ae879631e68255