### PR TITLE
Remove grouped notifications route

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Mark-as-read endpoints and “Mark All as Read”.
 * "Unread Only" toggle filters message threads and alerts in the drawer and full-screen modal.
 * Notification lists now use **react-window** for virtualization so scrolling large histories is smoother. Install `react-window` if you upgrade dependencies manually.
+* Grouped notification views are now generated in the UI from `/notifications` and the old `/notifications/grouped` endpoint was removed.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.

--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import Dict, List
+from typing import List
 import enum
 import logging
 
@@ -67,19 +67,6 @@ def read_my_notifications(
     return [_build_response(db, n) for n in notifs]
 
 
-@router.get(
-    "/notifications/grouped",
-    response_model=Dict[str, List[schemas.NotificationResponse]],
-)
-def read_my_notifications_grouped(
-    db: Session = Depends(get_db),
-    current_user: models.User = Depends(get_current_user),
-):
-    """Retrieve notifications grouped by type for the current user."""
-    grouped = crud.crud_notification.get_notifications_grouped_by_type(db, current_user.id)
-    return {
-        k: [_build_response(db, n) for n in v] for k, v in grouped.items()
-    }
 
 
 @router.put(

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3050,41 +3050,6 @@
         }
       }
     },
-    "/api/v1/notifications/grouped": {
-      "get": {
-        "tags": [
-          "notifications",
-          "notifications"
-        ],
-        "summary": "Read My Notifications Grouped",
-        "description": "Retrieve notifications grouped by type for the current user.",
-        "operationId": "read_my_notifications_grouped_api_v1_notifications_grouped_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "items": {
-                      "$ref": "#/components/schemas/NotificationResponse"
-                    },
-                    "type": "array"
-                  },
-                  "type": "object",
-                  "title": "Response Read My Notifications Grouped Api V1 Notifications Grouped Get"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ]
-      }
-    },
     "/api/v1/notifications/{notification_id}/read": {
       "put": {
         "tags": [

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -445,8 +445,6 @@ export const getNotifications = (skip = 0, limit = 20) =>
     `${API_V1}/notifications?skip=${skip}&limit=${limit}`,
   );
 
-export const getGroupedNotifications = () =>
-  api.get<Record<string, Notification[]>>(`${API_V1}/notifications/grouped`);
 
 export const markNotificationRead = (id: number) =>
   api.put<Notification>(`${API_V1}/notifications/${id}/read`);


### PR DESCRIPTION
## Summary
- remove `/notifications/grouped` API endpoint
- delete related frontend API helper
- document UI handling for grouped notifications
- sync OpenAPI spec

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685993be2db0832e9042a604deba88fb