### PR TITLE
Improve Send Quote modal usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
 * Artists can now send itemized quotes directly in the thread via a **Send Quote** modal. Clients can accept or decline, and accepted quotes show a confirmation banner.
+* The modal now includes a dynamic **[Service Type] fee** field and improved layout for easier data entry.
 * Accepting a quote now creates a booking instantly and notifies both parties.
 * Clients can once again accept quotes directly from the message thread.
 * Fixed issue where quotes sent via the thread were missing because no chat message was recorded.

--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -117,13 +117,14 @@ export default function BookingRequestDetailPage() {
             artistAvatarUrl={artistAvatar}
           />
         ) : (
-          <MessageThread
-            bookingRequestId={request.id}
-            serviceId={request.service_id ?? undefined}
-            clientName={request.client?.first_name}
-            artistName={artistName || request.artist?.user?.first_name}
-            artistAvatarUrl={artistAvatar}
-          />
+        <MessageThread
+          bookingRequestId={request.id}
+          serviceId={request.service_id ?? undefined}
+          clientName={request.client?.first_name}
+          artistName={artistName || request.artist?.user?.first_name}
+          artistAvatarUrl={artistAvatar}
+          serviceName={request.service?.title}
+        />
         )}
       </div>
     </MainLayout>

--- a/frontend/src/app/messages/thread/[threadId]/page.tsx
+++ b/frontend/src/app/messages/thread/[threadId]/page.tsx
@@ -85,6 +85,7 @@ export default function ThreadPage() {
             request.artist?.business_name || request.artist?.user?.first_name
           }
           artistAvatarUrl={artistAvatar}
+          serviceName={request.service?.title}
         />
       </div>
     </MainLayout>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -65,6 +65,7 @@ interface MessageThreadProps {
   artistId?: number;
   artistAvatarUrl?: string | null;
   isSystemTyping?: boolean;
+  serviceName?: string;
 }
 
 const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
@@ -80,6 +81,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       artistId,
       artistAvatarUrl = null,
       isSystemTyping = false,
+      serviceName,
     }: MessageThreadProps,
     ref,
   ) {
@@ -111,6 +113,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
   const [openDetails, setOpenDetails] = useState<Record<number, boolean>>({});
   const prevLengthRef = useRef(0);
   const [acceptingQuoteId, setAcceptingQuoteId] = useState<number | null>(null);
+  const computedServiceName = serviceName ?? bookingDetails?.service?.title;
 
   const { openPaymentModal, paymentModal } = usePaymentModal(
     ({ status, amount, receiptUrl: url }) => {
@@ -880,6 +883,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             artistId={artistId ?? user.id}
             clientId={clientId ?? messages.find((m) => m.sender_type === 'client')?.sender_id ?? 0}
             bookingRequestId={bookingRequestId}
+            serviceName={computedServiceName}
           />
           {paymentModal}
           {bookingDetails &&

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -36,6 +36,7 @@ describe('SendQuoteModal', () => {
           artistId={2}
           clientId={3}
           bookingRequestId={4}
+          serviceName="Live Performance"
         />,
       );
     });
@@ -46,14 +47,16 @@ describe('SendQuoteModal', () => {
       select.dispatchEvent(new Event('change', { bubbles: true }));
     });
     const inputs = div.querySelectorAll('input[type="number"]');
-    expect(inputs[0].value).toBe('5');
-    expect(inputs[1].value).toBe('1');
-    expect(inputs[2].value).toBe('2');
+    expect(inputs[0].value).toBe('5'); // service fee
+    expect(inputs[1].value).toBe('1'); // sound fee
+    expect(inputs[2].value).toBe('2'); // travel fee
+    const serviceLabel = div.querySelector('label[for="service-fee"]');
     const soundLabel = div.querySelector('label[for="sound-fee"]');
     const travelLabel = div.querySelector('label[for="travel-fee"]');
     const discountLabel = div.querySelector('label[for="discount"]');
     const accommodationLabel = div.querySelector('label[for="accommodation"]');
     const expiryLabel = div.querySelector('label[for="expires-hours"]');
+    expect(serviceLabel?.textContent).toContain('Live Performance fee');
     expect(soundLabel?.textContent).toContain('Sound fee');
     expect(travelLabel?.textContent).toContain('Travel fee');
     expect(discountLabel?.textContent).toContain('Discount');
@@ -90,6 +93,7 @@ describe('SendQuoteModal', () => {
           artistId={2}
           clientId={3}
           bookingRequestId={4}
+          serviceName="Live Performance"
         />,
       );
     });
@@ -116,6 +120,7 @@ describe('SendQuoteModal', () => {
           artistId={1}
           clientId={2}
           bookingRequestId={3}
+          serviceName="Live Performance"
         />,
       );
     });

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -13,24 +13,48 @@ exports[`SendQuoteModal matches snapshot 1`] = `
       Send Quote
     </h2>
     <div
-      class="space-y-2 max-h-[60vh] overflow-y-auto"
+      class="space-y-3 max-h-[60vh] overflow-y-auto"
     >
-      <div
-        class="flex gap-2 items-center"
+      <label
+        class="flex flex-col text-sm font-bold"
+        for="service-fee"
       >
+        Live Performance
+         fee
         <input
-          class="flex-1 border rounded p-1"
-          placeholder="Description"
-          type="text"
-          value=""
-        />
-        <input
-          class="w-24 border rounded p-1"
-          placeholder="Price"
+          class="w-full border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          id="service-fee"
+          inputmode="numeric"
           type="number"
           value="0"
         />
-      </div>
+      </label>
+      <label
+        class="flex flex-col text-sm font-bold"
+        for="sound-fee"
+      >
+        Sound fee
+        <input
+          class="w-full border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          id="sound-fee"
+          inputmode="numeric"
+          type="number"
+          value="0"
+        />
+      </label>
+      <label
+        class="flex flex-col text-sm font-bold"
+        for="travel-fee"
+      >
+        Travel fee
+        <input
+          class="w-full border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          id="travel-fee"
+          inputmode="numeric"
+          type="number"
+          value="0"
+        />
+      </label>
       <button
         aria-busy="false"
         class="inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform active:scale-95 px-4 py-2 text-sm bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300 text-sm"
@@ -43,58 +67,35 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
       </button>
       <label
-        class="flex flex-col text-sm"
-        for="sound-fee"
-      >
-        Sound fee
-        <input
-          class="w-full border rounded p-1"
-          id="sound-fee"
-          type="number"
-          value="0"
-        />
-      </label>
-      <label
-        class="flex flex-col text-sm"
-        for="travel-fee"
-      >
-        Travel fee
-        <input
-          class="w-full border rounded p-1"
-          id="travel-fee"
-          type="number"
-          value="0"
-        />
-      </label>
-      <label
-        class="flex flex-col text-sm"
+        class="flex flex-col text-sm font-bold"
         for="accommodation"
       >
         Accommodation (optional)
         <textarea
-          class="w-full border rounded p-1"
+          class="w-full border rounded p-1 focus:outline-none focus:ring-2 focus:ring-brand"
           id="accommodation"
         />
       </label>
       <label
-        class="flex flex-col text-sm"
+        class="flex flex-col text-sm font-bold"
         for="discount"
       >
         Discount (optional)
         <input
-          class="w-full border rounded p-1"
+          class="w-full border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
           id="discount"
+          inputmode="numeric"
           type="number"
           value="0"
         />
       </label>
       <label
-        class="flex flex-col text-sm"
+        class="flex flex-col text-sm font-bold"
         for="expires-hours"
       >
         Expires in
         <select
-          class="w-full border rounded p-1"
+          class="w-full border rounded p-1 focus:outline-none focus:ring-2 focus:ring-brand"
           id="expires-hours"
         >
           <option


### PR DESCRIPTION
## Summary
- add dynamic service fee field to Send Quote modal
- move Add Item button below travel fee and update input focus styles
- expose `serviceName` to MessageThread and pages
- document new quote modal layout in README

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a5835eb88832e906d6e2993774b5a