### PR TITLE
Add quote number helper

### DIFF
--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import Button from '../ui/Button';
 import { ServiceItem, QuoteV2Create, QuoteTemplate } from '@/types';
 import { getQuoteTemplates } from '@/lib/api';
-import { formatCurrency } from '@/lib/utils';
+import { formatCurrency, generateQuoteNumber } from '@/lib/utils';
 
 interface Props {
   open: boolean;
@@ -49,10 +49,7 @@ const SendQuoteModal: React.FC<Props> = ({
       getQuoteTemplates(artistId)
         .then((res) => setTemplates(res.data))
         .catch(() => setTemplates([]));
-      const num = `${new Date().getFullYear()}-${Math.floor(Math.random() * 10000)
-        .toString()
-        .padStart(4, '0')}`;
-      setQuoteNumber(num);
+      setQuoteNumber(generateQuoteNumber());
     }
   }, [open, artistId]);
 
@@ -110,7 +107,7 @@ const SendQuoteModal: React.FC<Props> = ({
         <h2 className="text-lg font-medium mb-2">Send Quote</h2>
         <div className="space-y-3 max-h-[60vh] overflow-y-auto">
           <div className="flex flex-col gap-y-2 mb-2 text-sm">
-            <div>Quote #{quoteNumber}</div>
+            <div>{quoteNumber}</div>
             <div>{currentDate}</div>
             <input
               type="text"

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -19,8 +19,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         class="flex flex-col gap-y-2 mb-2 text-sm"
       >
         <div>
-          Quote #
-          2025-3772
+          Quote #2025-4394
         </div>
         <div>
           June 24th, 2025

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   getFullImageUrl,
   formatCurrency,
   formatStatus,
+  generateQuoteNumber,
 } from '../utils';
 import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
@@ -149,5 +150,12 @@ describe('formatStatus', () => {
 
   it('humanises unknown values', () => {
     expect(formatStatus('foo_bar')).toBe('Foo Bar');
+  });
+});
+
+describe('generateQuoteNumber', () => {
+  it('returns a formatted quote number', () => {
+    const quote = generateQuoteNumber();
+    expect(quote).toMatch(/^Quote #\d{4}-\d{4}$/);
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -177,3 +177,12 @@ export const formatDepositReminder = (
   }
   return parts.join(' ');
 };
+
+/**
+ * Generate a human-readable quote number like "Quote #2025-1234".
+ */
+export function generateQuoteNumber(): string {
+  const year = new Date().getFullYear();
+  const rand = Math.floor(1000 + Math.random() * 9000);
+  return `Quote #${year}-${rand}`;
+}


### PR DESCRIPTION
## Summary
- generate quote numbers via `generateQuoteNumber`
- use helper in `SendQuoteModal`
- test the helper and update snapshot

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a6258827c832eaa24ac22112a1fce