### PR TITLE
Fix line item insertion and unify SendQuoteModal rows

### DIFF
--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -135,6 +135,45 @@ const SendQuoteModal: React.FC<Props> = ({
               onChange={(e) => setDescription(e.target.value)}
             />
           </div>
+          <label htmlFor="service-fee" className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
+            <span className="flex-1">{serviceName ?? 'Service'} fee</span>
+            <input
+              id="service-fee"
+              type="number"
+              inputMode="numeric"
+              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="Enter amount"
+              value={serviceFee}
+              disabled
+              readOnly
+            />
+          </label>
+          <label htmlFor="sound-fee" className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
+            <span className="flex-1">Sound fee</span>
+            <input
+              id="sound-fee"
+              type="number"
+              inputMode="numeric"
+              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="Enter amount"
+              value={soundFee}
+              disabled
+              readOnly
+            />
+          </label>
+          <label htmlFor="travel-fee" className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
+            <span className="flex-1">Travel fee</span>
+            <input
+              id="travel-fee"
+              type="number"
+              inputMode="numeric"
+              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+              placeholder="Enter amount"
+              value={travelFee}
+              disabled
+              readOnly
+            />
+          </label>
           {services.map((s, i) => (
             <div key={i} className="flex gap-2 items-center mb-2">
               <input
@@ -159,42 +198,6 @@ const SendQuoteModal: React.FC<Props> = ({
               )}
             </div>
           ))}
-          <label htmlFor="service-fee" className="flex items-center gap-2 text-sm font-normal mb-2">
-            <span className="flex-1">{serviceName ?? 'Service'} fee</span>
-            <input
-              id="service-fee"
-              type="number"
-              inputMode="numeric"
-              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-              placeholder="Enter amount"
-              value={serviceFee}
-              onChange={(e) => setServiceFee(Number(e.target.value))}
-            />
-          </label>
-          <label htmlFor="sound-fee" className="flex items-center gap-2 text-sm font-normal mb-2">
-            <span className="flex-1">Sound fee</span>
-            <input
-              id="sound-fee"
-              type="number"
-              inputMode="numeric"
-              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-              placeholder="Enter amount"
-              value={soundFee}
-              onChange={(e) => setSoundFee(Number(e.target.value))}
-            />
-          </label>
-          <label htmlFor="travel-fee" className="flex items-center gap-2 text-sm font-normal mb-2">
-            <span className="flex-1">Travel fee</span>
-            <input
-              id="travel-fee"
-              type="number"
-              inputMode="numeric"
-              className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-              placeholder="Enter amount"
-              value={travelFee}
-              onChange={(e) => setTravelFee(Number(e.target.value))}
-            />
-          </label>
           <Button type="button" onClick={addService} className="text-sm" variant="secondary">
             Add Item
           </Button>

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         />
       </div>
       <label
-        class="flex items-center gap-2 text-sm font-normal mb-2"
+        class="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2"
         for="service-fee"
       >
         <span
@@ -47,15 +47,17 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          disabled=""
           id="service-fee"
           inputmode="numeric"
           placeholder="Enter amount"
+          readonly=""
           type="number"
           value="0"
         />
       </label>
       <label
-        class="flex items-center gap-2 text-sm font-normal mb-2"
+        class="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2"
         for="sound-fee"
       >
         <span
@@ -65,15 +67,17 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          disabled=""
           id="sound-fee"
           inputmode="numeric"
           placeholder="Enter amount"
+          readonly=""
           type="number"
           value="0"
         />
       </label>
       <label
-        class="flex items-center gap-2 text-sm font-normal mb-2"
+        class="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2"
         for="travel-fee"
       >
         <span
@@ -83,9 +87,11 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
+          disabled=""
           id="travel-fee"
           inputmode="numeric"
           placeholder="Enter amount"
+          readonly=""
           type="number"
           value="0"
         />


### PR DESCRIPTION
## Summary
- ensure SendQuoteModal appends new items beneath the preset fees
- style Persoonlike liedjie, Sound, and Travel fees like other line items
- disable editing of the preset fee inputs
- update snapshot tests

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a6c609b10832e8c80a983155f9468