### PR TITLE
Allow editing of quote fee fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
 * Artists can now send itemized quotes directly in the thread via a **Send Quote** modal. Quote numbers are generated automatically, today's date appears, and a short description can be added. A compact **Choose template** dropdown sits beside the "Send Quote" title and the **Add Item** button now sits below the travel fee. Totals highlight both the subtotal and overall total. Clients can accept or decline, and accepted quotes show a confirmation banner.
-* The modal uses the same horizontal layout for service, sound, travel, and discount fees as the "Add Item" rows. Future releases will add PDF preview, currency symbols inside inputs, and an artist signature/terms block.
+* The modal uses the same horizontal layout for service, sound, travel, and discount fees as the "Add Item" rows. These fee fields are now editable so artists can enter amounts directly. Future releases will add PDF preview, currency symbols inside inputs, and an artist signature/terms block.
 * Accepting a quote now creates a booking instantly and notifies both parties.
 * Clients can once again accept quotes directly from the message thread.
 * Fixed issue where quotes sent via the thread were missing because no chat message was recorded.

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -144,8 +144,7 @@ const SendQuoteModal: React.FC<Props> = ({
               className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
               placeholder="Enter amount"
               value={serviceFee}
-              disabled
-              readOnly
+              onChange={(e) => setServiceFee(Number(e.target.value))}
             />
           </label>
           <label htmlFor="sound-fee" className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
@@ -157,8 +156,7 @@ const SendQuoteModal: React.FC<Props> = ({
               className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
               placeholder="Enter amount"
               value={soundFee}
-              disabled
-              readOnly
+              onChange={(e) => setSoundFee(Number(e.target.value))}
             />
           </label>
           <label htmlFor="travel-fee" className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
@@ -170,8 +168,7 @@ const SendQuoteModal: React.FC<Props> = ({
               className="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
               placeholder="Enter amount"
               value={travelFee}
-              disabled
-              readOnly
+              onChange={(e) => setTravelFee(Number(e.target.value))}
             />
           </label>
           {services.map((s, i) => (

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -50,6 +50,20 @@ describe('SendQuoteModal', () => {
     expect(inputs[0].value).toBe('5'); // service fee
     expect(inputs[1].value).toBe('1'); // sound fee
     expect(inputs[2].value).toBe('2'); // travel fee
+    expect(inputs[0].disabled).toBe(false);
+    expect(inputs[1].disabled).toBe(false);
+    expect(inputs[2].disabled).toBe(false);
+    await act(async () => {
+      inputs[0].value = '6';
+      inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
+      inputs[1].value = '2';
+      inputs[1].dispatchEvent(new Event('input', { bubbles: true }));
+      inputs[2].value = '3';
+      inputs[2].dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(inputs[0].value).toBe('6');
+    expect(inputs[1].value).toBe('2');
+    expect(inputs[2].value).toBe('3');
     const serviceLabel = div.querySelector('label[for="service-fee"]');
     const soundLabel = div.querySelector('label[for="sound-fee"]');
     const travelLabel = div.querySelector('label[for="travel-fee"]');

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -47,11 +47,9 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-          disabled=""
           id="service-fee"
           inputmode="numeric"
           placeholder="Enter amount"
-          readonly=""
           type="number"
           value="0"
         />
@@ -67,11 +65,9 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-          disabled=""
           id="sound-fee"
           inputmode="numeric"
           placeholder="Enter amount"
-          readonly=""
           type="number"
           value="0"
         />
@@ -87,11 +83,9 @@ exports[`SendQuoteModal matches snapshot 1`] = `
         </span>
         <input
           class="w-24 border rounded p-1 text-left focus:outline-none focus:ring-2 focus:ring-brand"
-          disabled=""
           id="travel-fee"
           inputmode="numeric"
           placeholder="Enter amount"
-          readonly=""
           type="number"
           value="0"
         />


### PR DESCRIPTION
## Summary
- make fee inputs editable in SendQuoteModal
- update docs on editable fee fields
- test editing service, sound and travel fees

## Testing
- `npm --prefix frontend test -- -u`
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a7305e098832e906cb691080ef265