### PR TITLE
Style dynamic quote items

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
 * Artists can now send itemized quotes directly in the thread via a **Send Quote** modal. Quote numbers are generated automatically, today's date appears, and a short description can be added. A compact **Choose template** dropdown sits beside the "Send Quote" title and the **Add Item** button now sits below the travel fee. Totals highlight both the subtotal and overall total. Clients can accept or decline, and accepted quotes show a confirmation banner.
-* The modal uses the same horizontal layout for service, sound, travel, and discount fees as the "Add Item" rows. These fee fields are now editable so artists can enter amounts directly. Future releases will add PDF preview, currency symbols inside inputs, and an artist signature/terms block.
+* The modal uses the same horizontal layout for service, sound, travel, and discount fees as the "Add Item" rows. Added line items now share the same bordered row styling with padding and rounded corners so everything aligns consistently. These fee fields are editable so artists can enter amounts directly. Future releases will add PDF preview, currency symbols inside inputs, and an artist signature/terms block.
 * Accepting a quote now creates a booking instantly and notifies both parties.
 * Clients can once again accept quotes directly from the message thread.
 * Fixed issue where quotes sent via the thread were missing because no chat message was recorded.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -85,7 +85,7 @@ Passing `service_id` skips the service selection step when a user clicks "Reques
 
 The artist dashboard includes a quotes page for managing offers. The `EditQuoteModal` allows artists to modify quote details and price inline without leaving the list. It opens when clicking the "Edit" button next to a pending quote and mirrors the style of `SendQuoteModal`. Both modals now wrap the sound fee, travel fee, discount, accommodation, and expiry fields in accessible labels so screen readers announce each input.
 
-The Send Quote modal also generates a quote number automatically, shows today's date and a description box, and positions a compact **Choose template** dropdown next to the title. The **Add Item** button sits beneath the travel fee input. Service, sound, travel, and discount fees now use the same horizontal pair layout as custom items. Totals at the bottom list the subtotal and final total. Future enhancements will include a PDF preview option, currency symbols within each field, and a signature/terms section.
+The Send Quote modal also generates a quote number automatically, shows today's date and a description box, and positions a compact **Choose template** dropdown next to the title. The **Add Item** button sits beneath the travel fee input. Service, sound, travel, and discount fees use the same horizontal pair layout as custom items, and newly added rows inherit the bordered styling so they visually match the preset fees. Totals at the bottom list the subtotal and final total. Future enhancements will include a PDF preview option, currency symbols within each field, and a signature/terms section.
 
 ### Artist Listing
 

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -172,7 +172,7 @@ const SendQuoteModal: React.FC<Props> = ({
             />
           </label>
           {services.map((s, i) => (
-            <div key={i} className="flex gap-2 items-center mb-2">
+            <div key={i} className="flex items-center gap-2 text-sm font-normal mb-2 border rounded p-2">
               <input
                 type="text"
                 className="flex-1 border rounded p-1"
@@ -189,7 +189,12 @@ const SendQuoteModal: React.FC<Props> = ({
                 onChange={(e) => updateService(i, 'price', e.target.value)}
               />
               {services.length > 1 && (
-                <button type="button" onClick={() => removeService(i)} aria-label="Remove item" className="text-red-600">
+                <button
+                  type="button"
+                  onClick={() => removeService(i)}
+                  aria-label="Remove item"
+                  className="text-red-600"
+                >
                   ×
                 </button>
               )}

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -123,6 +123,54 @@ describe('SendQuoteModal', () => {
     root.unmount();
   });
 
+  it('adds item row styled like fee rows', async () => {
+    (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <SendQuoteModal
+          open
+          onClose={() => {}}
+          onSubmit={() => {}}
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          serviceName="Live Performance"
+        />,
+      );
+    });
+    const addButton = Array.from(div.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Add Item'),
+    ) as HTMLButtonElement;
+    expect(addButton).not.toBeNull();
+    await act(async () => {
+      addButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const dynamicRow = Array.from(div.querySelectorAll('div')).find((el) =>
+      el.className.includes('border') &&
+      Array.from(el.children).some(
+        (c) => (c as HTMLElement).getAttribute('placeholder') === 'Description',
+      ),
+    ) as HTMLDivElement;
+    expect(dynamicRow).not.toBeNull();
+    const classes = [
+      'flex',
+      'items-center',
+      'gap-2',
+      'text-sm',
+      'font-normal',
+      'mb-2',
+      'border',
+      'rounded',
+      'p-2',
+    ];
+    classes.forEach((cls) => {
+      expect(dynamicRow.className).toContain(cls);
+    });
+    root.unmount();
+  });
+
   it('matches snapshot', async () => {
     (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
     jest.spyOn(Math, 'random').mockReturnValue(0.3772);


### PR DESCRIPTION
## Summary
- style Add Item rows in SendQuoteModal like the default fee rows
- describe consistent styling in documentation
- test that new rows receive proper classes

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a7ee6df10832ebdb11fc99b6a7114