### PR TITLE
Allow removing first added quote item

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - A **Leave Review** button now appears in chat when a completed booking has no review.
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
+- Quote modal items can now be removed even when only one item is present.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/app/dashboard/profile/quote-templates/page.tsx
+++ b/frontend/src/app/dashboard/profile/quote-templates/page.tsx
@@ -203,7 +203,7 @@ export default function QuoteTemplatesPage() {
                 value={s.price}
                 onChange={(e) => updateService(i, 'price', e.target.value)}
               />
-              {services.length > 1 && (
+              {services.length > 0 && (
                 <button type="button" onClick={() => removeService(i)} className="text-red-600" aria-label="Remove">
                   ×
                 </button>
@@ -280,7 +280,7 @@ export default function QuoteTemplatesPage() {
                         value={s.price}
                         onChange={(e) => updateEditService(i, 'price', e.target.value)}
                       />
-                      {editServices.length > 1 && (
+                      {editServices.length > 0 && (
                         <button type="button" onClick={() => removeEditService(i)} className="text-red-600" aria-label="Remove">
                           ×
                         </button>

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -188,7 +188,7 @@ const SendQuoteModal: React.FC<Props> = ({
                 value={s.price}
                 onChange={(e) => updateService(i, 'price', e.target.value)}
               />
-              {services.length > 1 && (
+              {services.length > 0 && (
                 <button
                   type="button"
                   onClick={() => removeService(i)}

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -171,6 +171,34 @@ describe('SendQuoteModal', () => {
     root.unmount();
   });
 
+  it('shows remove button for a single added item', async () => {
+    (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <SendQuoteModal
+          open
+          onClose={() => {}}
+          onSubmit={() => {}}
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          serviceName="Live Performance"
+        />,
+      );
+    });
+    const addButton = Array.from(div.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Add Item'),
+    ) as HTMLButtonElement;
+    await act(async () => {
+      addButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const removeButton = div.querySelector('button[aria-label="Remove item"]');
+    expect(removeButton).not.toBeNull();
+    root.unmount();
+  });
+
   it('matches snapshot', async () => {
     (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
     jest.spyOn(Math, 'random').mockReturnValue(0.3772);


### PR DESCRIPTION
## Summary
- allow removing a service item even when it's the only one
- allow same behaviour in quote template editor
- document new quote modal functionality
- add regression test for remove button

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a850a7ce0832e812edb1c672f82be