### PR TITLE
Fix duplicate booking notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
+* Booking notes now appear only inside the Booking details message to avoid duplicate chat lines.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -92,16 +92,9 @@ def create_booking_request(
     new_request = crud.crud_booking_request.create_booking_request(
         db=db, booking_request=request_in, client_id=current_user.id
     )
-    if request_in.message:
-        crud.crud_message.create_message(
-            db=db,
-            booking_request_id=new_request.id,
-            sender_id=current_user.id,
-            sender_type=models.SenderType.CLIENT,
-            content=request_in.message,
-            message_type=models.MessageType.TEXT,
-            attachment_url=request_in.attachment_url,
-        )
+    # Store the initial notes on the booking request but avoid posting them as
+    # a separate chat message. The details system message posted later contains
+    # these notes, so creating a text message here would duplicate the content.
     # The chat thread used to include a generic "Booking request sent" system
     # message immediately after creation. This extra message cluttered the
     # conversation view, so it has been removed.

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -109,9 +109,6 @@ export default function InboxPage() {
             <div className="text-sm text-gray-600">
               📍 {b.location || '—'} | 👥 {b.guests || '—'} | 🏠 {b.venueType || '—'}
             </div>
-            {b.notes && (
-              <div className="text-xs text-gray-500 truncate">📝 {b.notes}</div>
-            )}
           </div>
         </li>
       ))}


### PR DESCRIPTION
## Summary
- skip creating chat message for booking notes when creating a booking request
- hide notes in Inbox preview
- document booking notes behaviour in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685aa6ba2e7c832ea3988a0cd258483d