### PR TITLE
Move booking notes into details section

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Optional SMS alerts when `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` are set in the backend environment.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
-* Booking notes are visible only on the Booking details page and are hidden from chat threads and booking request screens.
+* Booking notes are visible only on the Booking details page, appearing beneath the Venue Type line in the details box, and are hidden from chat threads and booking request screens.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles are limited to 36 characters and subtitles to 30 so long names don't wrap.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -199,13 +199,17 @@ export default function BookingWizard({
         setRequestId(res.data.id);
       }
       const idToUse = requestId || res.data.id;
-      const detailLines = [
+      const lines = [
         `Date: ${format(vals.date, 'yyyy-MM-dd')}`,
         `Location: ${vals.location}`,
         `Guests: ${vals.guests}`,
         `Sound: ${vals.sound}`,
         `Venue Type: ${vals.venueType}`,
-      ].join('\n');
+      ];
+      if (vals.notes) {
+        lines.push(`Notes: ${vals.notes}`);
+      }
+      const detailLines = lines.join('\n');
       await postMessageToBookingRequest(idToUse, {
         content: `Booking details:\n${detailLines}`,
         message_type: 'system',

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -706,11 +706,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                                     .trim()
                                     .split('\n')
                                     .map((line) => line.split(':'))
-                                    .filter(
-                                      (parts) =>
-                                        parts.length === 2 &&
-                                        parts[0].trim().toLowerCase() !== 'notes',
-                                    )
+                                    .filter((parts) => parts.length === 2)
                                     .map(([label, value]) => (
                                       <React.Fragment key={label.trim()}>
                                         <dt className="font-medium">{label.trim()}</dt>

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -342,7 +342,7 @@ describe('MessageThread component', () => {
           booking_request_id: 1,
           sender_id: 2,
           sender_type: 'artist',
-          content: 'Booking details:\nLocation: Test City',
+          content: 'Booking details:\nLocation: Test City\nNotes: Hello',
           message_type: 'system',
           timestamp: '2024-01-01T00:00:00Z',
         },
@@ -370,10 +370,10 @@ describe('MessageThread component', () => {
     });
     const content = container.querySelector('[data-testid="booking-details-content"]');
     expect(button?.getAttribute('aria-expanded')).toBe('true');
-    const dt = content?.querySelector('dt');
-    const dd = content?.querySelector('dd');
-    expect(dt?.textContent).toBe('Location');
-    expect(dd?.textContent).toBe('Test City');
+    const terms = Array.from(content?.querySelectorAll('dt') || []);
+    const values = Array.from(content?.querySelectorAll('dd') || []);
+    expect(terms.map((n) => n.textContent)).toEqual(['Location', 'Notes']);
+    expect(values.map((n) => n.textContent)).toEqual(['Test City', 'Hello']);
   });
 
   it('announces new messages when scrolled away from bottom', async () => {


### PR DESCRIPTION
## Summary
- show booking notes within the booking details message
- remove notes filter in message thread
- update tests for the new details layout
- clarify README about notes placement

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ab81fbed4832e8ff0b4a2539dda7f