### PR TITLE
Fix notes message in chat

### DIFF
--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -119,6 +119,7 @@ export default function BookingRequestDetailPage() {
           artistName={artistName || request.artist?.user?.first_name}
           artistAvatarUrl={artistAvatar}
           serviceName={request.service?.title}
+          initialNotes={request.message ?? null}
         />
         )}
       </div>

--- a/frontend/src/app/messages/thread/[threadId]/page.tsx
+++ b/frontend/src/app/messages/thread/[threadId]/page.tsx
@@ -86,6 +86,7 @@ export default function ThreadPage() {
           }
           artistAvatarUrl={artistAvatar}
           serviceName={request.service?.title}
+          initialNotes={request.message ?? null}
         />
       </div>
     </MainLayout>

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -163,6 +163,39 @@ describe('MessageThread component', () => {
     expect(messageBubbles[1].textContent).toContain('Hello there');
   });
 
+  it('filters the initial notes message', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 1,
+          sender_type: 'client',
+          content: 'none',
+          message_type: 'text',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          booking_request_id: 1,
+          sender_id: 2,
+          sender_type: 'artist',
+          content: 'Booking details:\nNotes: none',
+          message_type: 'system',
+          timestamp: '2024-01-01T00:00:01Z',
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<MessageThread bookingRequestId={1} initialNotes="none" />);
+    });
+
+    const bubbles = container.querySelectorAll('.whitespace-pre-wrap');
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0].textContent).toContain('Booking details');
+  });
+
   it('groups messages into timestamp windows', async () => {
     (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
       data: [


### PR DESCRIPTION
## Summary
- add `initialNotes` prop to `MessageThread`
- filter out notes text from chat history
- hide notes message from WebSocket updates
- pass notes down from booking pages
- test filtering behavior

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685abe04aac8832ea29e0fdcdebba16d