### PR TITLE
Remove earnings stats for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * The dashboard stats section now includes a **View All Quotes** link so artists can quickly jump to their quotes list.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
 * Artists can update or decline booking requests from the dashboard via a new **Update Request** modal.
-* Improved dashboard stats layout with monthly earnings card.
+* Improved dashboard stats layout. Artists now see a monthly earnings card.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.
 * Streamlined mobile dashboard with collapsible overview and sticky tabs.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -152,6 +152,57 @@ describe('DashboardPage artist stats', () => {
   });
 });
 
+describe('DashboardPage client stats', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 3, user_type: 'client', email: 'c@example.com' } });
+    (api.getMyClientBookings as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          artist_id: 2,
+          client_id: 3,
+          service_id: 4,
+          start_time: new Date().toISOString(),
+          end_time: new Date().toISOString(),
+          status: 'completed',
+          total_price: 100,
+          notes: '',
+          artist: {} as ArtistProfile,
+          client: {} as User,
+          service: {} as Service,
+        },
+      ],
+    });
+    (api.getMyBookingRequests as jest.Mock).mockResolvedValue({ data: [] });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+    await act(async () => { await Promise.resolve(); });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('hides earnings cards for clients', () => {
+    expect(container.textContent).not.toContain('Total Earnings');
+    expect(container.textContent).not.toContain('Earnings This Month');
+  });
+});
+
 describe('DashboardPage list toggles', () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -183,6 +183,14 @@ export default function DashboardPage() {
     })
     .reduce((acc, booking) => acc + booking.total_price, 0);
 
+  const overviewPrimaryStats = [{ label: 'Total Bookings', value: bookings.length }];
+  const overviewSecondaryStats: { label: string; value: string | number }[] = [];
+  if (user.user_type === 'artist') {
+    overviewPrimaryStats.push({ label: 'Total Earnings', value: formatCurrency(totalEarnings) });
+    overviewSecondaryStats.push({ label: 'Total Services', value: servicesCount });
+    overviewSecondaryStats.push({ label: 'Earnings This Month', value: formatCurrency(earningsThisMonth) });
+  }
+
   const visibleRequests = bookingRequests.slice(0, 5);
   const visibleBookings = bookings.slice(0, 5);
 
@@ -372,14 +380,8 @@ export default function DashboardPage() {
           {/* Stats */}
           <div className="mt-8">
           <OverviewAccordion
-            primaryStats={[
-              { label: 'Total Bookings', value: bookings.length },
-              { label: 'Total Earnings', value: formatCurrency(totalEarnings) },
-            ]}
-            secondaryStats={[
-              { label: 'Total Services', value: servicesCount },
-              { label: 'Earnings This Month', value: formatCurrency(earningsThisMonth) },
-            ]}
+            primaryStats={overviewPrimaryStats}
+            secondaryStats={overviewSecondaryStats}
           />
           {user.user_type === 'artist' && (
             <div className="mt-2 space-x-4">

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
           Quote #2025-4394
         </div>
         <div>
-          June 24th, 2025
+          June 25th, 2025
         </div>
         <input
           class="border rounded p-1"


### PR DESCRIPTION
## Summary
- hide earnings data on client dashboard
- document artist-only monthly earnings card
- update snapshots for SendQuoteModal
- add regression test for client dashboard stats

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685bcca94030832e837c0ca876bed191