### PR TITLE
Add auto-id generation for TextInput

### DIFF
--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 import type { InputHTMLAttributes } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useId } from 'react';
 import clsx from 'clsx';
 
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -10,32 +10,40 @@ export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  ({ label, id, error, loading = false, className, ...props }, ref) => (
-    <div className="w-full">
-      {label && (
-        <label htmlFor={id} className="block text-sm font-medium text-gray-700">
-          {label}
-        </label>
-      )}
-      <div className="mt-1 relative">
-        <input
-          ref={ref}
-          id={id}
-          className={clsx(
-            'block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
-            className,
-          )}
-          {...props}
-        />
-        {loading && (
-          <span className="absolute inset-y-0 right-2 flex items-center" aria-label="Loading">
-            <span className="h-4 w-4 animate-spin rounded-full border-2 border-brand border-t-transparent" />
-          </span>
+  ({ label, id, error, loading = false, className, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+
+    return (
+      <div className="w-full">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-gray-700"
+          >
+            {label}
+          </label>
         )}
+        <div className="mt-1 relative">
+          <input
+            ref={ref}
+            id={inputId}
+            className={clsx(
+              'block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
+              className,
+            )}
+            {...props}
+          />
+          {loading && (
+            <span className="absolute inset-y-0 right-2 flex items-center" aria-label="Loading">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-brand border-t-transparent" />
+            </span>
+          )}
+        </div>
+        {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
       </div>
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
-    </div>
-  ),
+    );
+  },
 );
 TextInput.displayName = 'TextInput';
 

--- a/frontend/src/components/ui/__tests__/TextInput.test.tsx
+++ b/frontend/src/components/ui/__tests__/TextInput.test.tsx
@@ -1,0 +1,56 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import TextInput from '../TextInput';
+
+describe('TextInput component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('uses provided id for label and input', () => {
+    act(() => {
+      root.render(<TextInput label="Name" id="email" />);
+    });
+    const label = container.querySelector('label') as HTMLLabelElement;
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(label.htmlFor).toBe('email');
+    expect(input.id).toBe('email');
+  });
+
+  it('generates id when none is provided', () => {
+    act(() => {
+      root.render(<TextInput label="First" />);
+    });
+    const label = container.querySelector('label') as HTMLLabelElement;
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input.id).toBeTruthy();
+    expect(label.htmlFor).toBe(input.id);
+  });
+
+  it('generates unique ids for multiple instances', () => {
+    act(() => {
+      root.render(
+        <>
+          <TextInput label="One" />
+          <TextInput label="Two" />
+        </>,
+      );
+    });
+    const inputs = container.querySelectorAll('input');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].id).not.toBe(inputs[1].id);
+  });
+});


### PR DESCRIPTION
## Summary
- generate an id with `useId` inside `TextInput` when none is supplied
- ensure the generated id is applied to both `<label>` and `<input>`
- add unit tests covering provided and generated ids

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c3f697018832e98418e9bc2cb7a92