### PR TITLE
Add accessible Tooltip component

### DIFF
--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -13,7 +13,7 @@ const Marker = dynamic(
   { ssr: false },
 );
 import { useRef, useState, useEffect } from 'react';
-import { Button, TextInput } from '../../ui';
+import { Button, TextInput, Tooltip } from '../../ui';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
 
 // Keeping the libraries array stable avoids unnecessary re-renders from
@@ -230,12 +230,10 @@ export default function LocationStep({
       >
         Use my location
       </Button>
-      <span
-        className="ml-1 text-gray-500 cursor-help"
-        title="A warning appears if this address is over 100km from the artist."
-      >
-        ?
-      </span>
+      <Tooltip
+        text="A warning appears if this address is over 100km from the artist."
+        className="ml-1"
+      />
       {geoError && <p className="text-red-600 text-sm">{geoError}</p>}
       <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
         {step > 0 && (

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -52,4 +52,17 @@ describe('LocationStep selection', () => {
     });
     expect(container.querySelector('[data-testid="map"]')).not.toBeNull();
   });
+
+  it('reveals tooltip on focus', async () => {
+    await act(async () => {
+      root.render(React.createElement(Wrapper));
+    });
+    const tooltipButton = container.querySelector('button[aria-describedby]') as HTMLButtonElement;
+    act(() => {
+      tooltipButton.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+      tooltipButton.focus();
+    });
+    const tip = container.querySelector('[role="tooltip"]');
+    expect(tip).not.toBeNull();
+  });
 });

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useId, type ReactNode } from 'react';
+import clsx from 'clsx';
+
+interface TooltipProps {
+  text: string;
+  children?: ReactNode;
+  className?: string;
+}
+
+export default function Tooltip({ text, children = '?', className }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  return (
+    <span className={clsx('relative inline-block', className)}>
+      <button
+        type="button"
+        aria-describedby={id}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        className="text-gray-500 cursor-help focus:outline-none"
+      >
+        {children}
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          id={id}
+          className="absolute left-full ml-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white z-10"
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/frontend/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,49 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import Tooltip from '../Tooltip';
+
+describe('Tooltip component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows text on focus', () => {
+    act(() => {
+      root.render(<Tooltip text="Hello" />);
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+      button.focus();
+    });
+    const tip = container.querySelector('[role="tooltip"]') as HTMLElement;
+    expect(tip).not.toBeNull();
+    expect(tip.textContent).toBe('Hello');
+  });
+
+  it('shows text on hover', () => {
+    act(() => {
+      root.render(<Tooltip text="World" />);
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+    const tip = container.querySelector('[role="tooltip"]') as HTMLElement;
+    expect(tip).not.toBeNull();
+    expect(tip.textContent).toBe('World');
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -14,3 +14,4 @@ export { default as SkeletonList } from './SkeletonList';
 export { default as AlertBanner } from './AlertBanner';
 export { default as StatusBadge } from './StatusBadge';
 export { default as QuoteBubble } from '../booking/QuoteBubble';
+export { default as Tooltip } from './Tooltip';


### PR DESCRIPTION
## Summary
- add `Tooltip` component with hover/focus support
- export tooltip from the UI index
- use the new tooltip in `LocationStep`
- test tooltip behaviour and update `LocationStep` tests

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c8027c418832eb9102a3c58f6eb88