### PR TITLE
Implement invoice generation with PDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,6 +959,17 @@ include this query string so clients can pay with one click.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 
+### Invoices
+
+```
+GET /api/v1/invoices/{invoice_id}
+POST /api/v1/invoices/{invoice_id}/mark-paid
+GET /api/v1/invoices/{invoice_id}/pdf
+```
+Fetching an invoice returns details including the amount due and current status.
+`mark-paid` updates the invoice status to **paid** and records an optional payment method.
+The PDF endpoint generates and downloads a basic invoice document.
+
 `DEFAULT_CURRENCY` in `frontend/src/lib/constants.ts` exports this value for use across the app. Call `formatCurrency(value, currency?, locale?)` from `frontend/src/lib/utils.ts` to format amounts consistently. UI labels such as "Price" and "Hourly Rate" automatically display this currency.
 
 Example usage:

--- a/backend/alembic/versions/05c00e13a615_add_invoices_table.py
+++ b/backend/alembic/versions/05c00e13a615_add_invoices_table.py
@@ -1,0 +1,39 @@
+"""add_invoices_table
+
+Revision ID: 05c00e13a615
+Revises: 80a1b6c7d8a9
+Create Date: 2025-08-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '05c00e13a615'
+down_revision: Union[str, None] = '80a1b6c7d8a9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'invoices',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('quote_id', sa.Integer(), sa.ForeignKey('quotes_v2.id'), nullable=False),
+        sa.Column('booking_id', sa.Integer(), sa.ForeignKey('bookings_simple.id'), nullable=False),
+        sa.Column('artist_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('client_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('issue_date', sa.Date(), nullable=False),
+        sa.Column('due_date', sa.Date(), nullable=True),
+        sa.Column('amount_due', sa.Numeric(10, 2), nullable=False),
+        sa.Column('status', sa.Enum('unpaid', 'partial', 'paid', 'overdue', name='invoicestatus'), nullable=False, server_default='unpaid'),
+        sa.Column('payment_method', sa.String(), nullable=True),
+        sa.Column('notes', sa.String(), nullable=True),
+        sa.Column('pdf_url', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('invoices')
+    op.execute("DROP TYPE IF EXISTS invoicestatus")

--- a/backend/app/api/api_invoice.py
+++ b/backend/app/api/api_invoice.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+import os
+import logging
+
+from .. import models, schemas, crud
+from ..database import get_db
+from .dependencies import get_current_user
+from ..services import invoice_pdf
+
+router = APIRouter(tags=["invoices"])
+logger = logging.getLogger(__name__)
+
+INVOICE_DIR = os.path.join(os.path.dirname(__file__), "..", "static", "invoices")
+os.makedirs(INVOICE_DIR, exist_ok=True)
+
+
+@router.get("/{invoice_id}", response_model=schemas.InvoiceRead)
+def read_invoice(invoice_id: int, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    invoice = crud.crud_invoice.get_invoice(db, invoice_id)
+    if not invoice or (invoice.client_id != current_user.id and invoice.artist_id != current_user.id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return schemas.InvoiceRead.model_validate(invoice)
+
+
+@router.post("/{invoice_id}/mark-paid", response_model=schemas.InvoiceRead)
+def mark_invoice_paid(invoice_id: int, mark: schemas.InvoiceMarkPaid, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    invoice = crud.crud_invoice.get_invoice(db, invoice_id)
+    if not invoice or (invoice.client_id != current_user.id and invoice.artist_id != current_user.id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    updated = crud.crud_invoice.mark_paid(db, invoice, mark.payment_method, mark.notes)
+    return schemas.InvoiceRead.model_validate(updated)
+
+
+@router.get("/{invoice_id}/pdf")
+def get_invoice_pdf(invoice_id: int, db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)):
+    invoice = crud.crud_invoice.get_invoice(db, invoice_id)
+    if not invoice or (invoice.client_id != current_user.id and invoice.artist_id != current_user.id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    pdf_bytes = invoice_pdf.generate_pdf(invoice)
+    filename = f"invoice_{invoice.id}.pdf"
+    path = os.path.join(INVOICE_DIR, filename)
+    with open(path, "wb") as f:
+        f.write(pdf_bytes)
+    return FileResponse(path, media_type="application/pdf", filename=filename)

--- a/backend/app/crud/crud_invoice.py
+++ b/backend/app/crud/crud_invoice.py
@@ -1,0 +1,34 @@
+from datetime import date
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+def create_invoice_from_quote(db: Session, quote: models.QuoteV2, booking: models.BookingSimple) -> models.Invoice:
+    invoice = models.Invoice(
+        quote_id=quote.id,
+        booking_id=booking.id,
+        artist_id=quote.artist_id,
+        client_id=quote.client_id,
+        issue_date=date.today(),
+        amount_due=quote.total,
+        status=models.InvoiceStatus.UNPAID,
+    )
+    db.add(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def get_invoice(db: Session, invoice_id: int) -> models.Invoice | None:
+    return db.query(models.Invoice).filter(models.Invoice.id == invoice_id).first()
+
+
+def mark_paid(db: Session, invoice: models.Invoice, payment_method: str | None = None, notes: str | None = None) -> models.Invoice:
+    invoice.status = models.InvoiceStatus.PAID
+    invoice.payment_method = payment_method
+    if notes is not None:
+        invoice.notes = notes
+    db.commit()
+    db.refresh(invoice)
+    return invoice

--- a/backend/app/crud/crud_quote_v2.py
+++ b/backend/app/crud/crud_quote_v2.py
@@ -16,6 +16,7 @@ from ..utils.notifications import (
 )
 from ..utils import error_response
 from .crud_booking import create_booking_from_quote_v2
+from . import crud_invoice
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +227,10 @@ def accept_quote(
         )
     db.refresh(db_quote)
     db.refresh(booking)
+
+    # Auto-create an invoice for this booking using the quote total
+    invoice = crud_invoice.create_invoice_from_quote(db, db_quote, booking)
+    db.refresh(invoice)
 
     # Send notifications to both artist and client
     artist = db_quote.artist

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ from .api import (
     api_message,
     api_notification,
     api_payment,
+    api_invoice,
     api_user,
     api_calendar,
     api_quote_template,
@@ -90,11 +91,13 @@ APP_STATIC_DIR = os.path.join(THIS_DIR, "static")  # backend/app/static
 PROFILE_PICS_DIR = os.path.join(APP_STATIC_DIR, "profile_pics")
 COVER_PHOTOS_DIR = os.path.join(APP_STATIC_DIR, "cover_photos")
 ATTACHMENTS_DIR = os.path.join(APP_STATIC_DIR, "attachments")
+INVOICE_PDFS_DIR = os.path.join(APP_STATIC_DIR, "invoices")
 
 # Ensure all the subfolders exist
 os.makedirs(PROFILE_PICS_DIR, exist_ok=True)
 os.makedirs(COVER_PHOTOS_DIR, exist_ok=True)
 os.makedirs(ATTACHMENTS_DIR, exist_ok=True)
+os.makedirs(INVOICE_PDFS_DIR, exist_ok=True)
 
 
 # ─── Mount “/static” so that requests to /static/... serve from backend/app/static/... ────
@@ -249,6 +252,13 @@ app.include_router(
     api_payment.router,
     prefix=f"{api_prefix}/payments",
     tags=["payments"],
+)
+
+# ─── INVOICE ROUTES (under /api/v1/invoices) ───────────────────────────
+app.include_router(
+    api_invoice.router,
+    prefix=f"{api_prefix}/invoices",
+    tags=["invoices"],
 )
 
 # ─── USER ROUTES (under /api/v1/users) ─────────────────────────────────────

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from .message import Message, SenderType, MessageType
 from .notification import Notification, NotificationType
 from .calendar_account import CalendarAccount, CalendarProvider
 from .email_token import EmailToken
+from .invoice import Invoice, InvoiceStatus
 
 __all__ = [
     "User",
@@ -40,4 +41,6 @@ __all__ = [
     "CalendarAccount",
     "CalendarProvider",
     "EmailToken",
+    "Invoice",
+    "InvoiceStatus",
 ]

--- a/backend/app/models/invoice.py
+++ b/backend/app/models/invoice.py
@@ -1,0 +1,35 @@
+import enum
+from datetime import date
+from sqlalchemy import Column, Integer, ForeignKey, Date, Numeric, String, Enum as SQLAlchemyEnum
+from sqlalchemy.orm import relationship
+
+from .base import BaseModel
+
+
+class InvoiceStatus(str, enum.Enum):
+    UNPAID = "unpaid"
+    PARTIAL = "partial"
+    PAID = "paid"
+    OVERDUE = "overdue"
+
+
+class Invoice(BaseModel):
+    __tablename__ = "invoices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    quote_id = Column(Integer, ForeignKey("quotes_v2.id"), nullable=False)
+    booking_id = Column(Integer, ForeignKey("bookings_simple.id"), nullable=False)
+    artist_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    client_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    issue_date = Column(Date, nullable=False)
+    due_date = Column(Date, nullable=True)
+    amount_due = Column(Numeric(10, 2), nullable=False)
+    status = Column(SQLAlchemyEnum(InvoiceStatus), nullable=False, default=InvoiceStatus.UNPAID)
+    payment_method = Column(String, nullable=True)
+    notes = Column(String, nullable=True)
+    pdf_url = Column(String, nullable=True)
+
+    quote = relationship("QuoteV2")
+    booking = relationship("BookingSimple")
+    artist = relationship("User", foreign_keys=[artist_id])
+    client = relationship("User", foreign_keys=[client_id])

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -39,6 +39,7 @@ from .notification import (
     ThreadNotificationResponse,
     BookingDetailsSummary,
 )
+from .invoice import InvoiceRead, InvoiceMarkPaid
 
 __all__ = [
     "UserBase",
@@ -92,4 +93,6 @@ __all__ = [
     "SoundProviderResponse",
     "ArtistSoundPreferenceBase",
     "ArtistSoundPreferenceResponse",
+    "InvoiceRead",
+    "InvoiceMarkPaid",
 ]

--- a/backend/app/schemas/invoice.py
+++ b/backend/app/schemas/invoice.py
@@ -1,0 +1,31 @@
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ..models.invoice import InvoiceStatus
+
+
+class InvoiceRead(BaseModel):
+    id: int
+    quote_id: int
+    booking_id: int
+    artist_id: int
+    client_id: int
+    issue_date: date
+    due_date: Optional[date] = None
+    amount_due: Decimal
+    status: InvoiceStatus
+    payment_method: Optional[str] = None
+    notes: Optional[str] = None
+    pdf_url: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class InvoiceMarkPaid(BaseModel):
+    payment_method: Optional[str] = None
+    notes: Optional[str] = None

--- a/backend/app/services/invoice_pdf.py
+++ b/backend/app/services/invoice_pdf.py
@@ -1,0 +1,25 @@
+from io import BytesIO
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+from .. import models
+
+
+def generate_pdf(invoice: models.Invoice) -> bytes:
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=A4)
+    c.setFont("Helvetica", 14)
+    c.drawString(50, 800, f"Invoice #{invoice.id}")
+    c.setFont("Helvetica", 10)
+    c.drawString(50, 780, f"Issued: {invoice.issue_date:%Y-%m-%d}")
+    c.drawString(50, 760, f"Artist ID: {invoice.artist_id}")
+    c.drawString(50, 740, f"Client ID: {invoice.client_id}")
+    c.drawString(50, 700, "Services")
+    c.drawRightString(550, 700, f"R{invoice.amount_due}")
+    c.line(50, 695, 550, 695)
+    c.setFont("Helvetica-Bold", 12)
+    c.drawRightString(550, 670, f"Total: R{invoice.amount_due}")
+    c.showPage()
+    c.save()
+    buffer.seek(0)
+    return buffer.read()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ ics==0.7.2
 authlib==1.3.0
 aiosmtplib==2.0.2
 itsdangerous==2.2.0
+reportlab==4.2.0

--- a/backend/tests/test_invoice.py
+++ b/backend/tests/test_invoice.py
@@ -1,0 +1,138 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from decimal import Decimal
+import datetime
+
+from app.main import app
+from app.models import (
+    User,
+    UserType,
+    BookingRequest,
+    Service,
+    QuoteV2,
+    QuoteStatusV2,
+    BookingSimple,
+    Invoice,
+)
+from app.models.base import BaseModel
+from app.api.dependencies import get_db, get_current_user
+from app.crud import crud_quote_v2
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_records(Session):
+    db = Session()
+    client = User(email="c@test.com", password="x", first_name="C", last_name="L", user_type=UserType.CLIENT)
+    artist = User(email="a@test.com", password="x", first_name="A", last_name="R", user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title="Show",
+        price=Decimal("100"),
+        duration_minutes=60,
+        service_type="Live Performance",
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    br = BookingRequest(client_id=client.id, artist_id=artist.id, service_id=service.id, proposed_datetime_1=datetime.datetime.utcnow())
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = QuoteV2(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[],
+        sound_fee=0,
+        travel_fee=0,
+        subtotal=Decimal("100"),
+        total=Decimal("100"),
+        status=QuoteStatusV2.PENDING,
+    )
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+
+    return db, client, artist, quote
+
+
+def override_user(user):
+    def _override():
+        return user
+
+    return _override
+
+
+def test_invoice_created_and_api():
+    Session = setup_app()
+    db, client_user, artist_user, quote = create_records(Session)
+
+    crud_quote_v2.accept_quote(db=db, quote_id=quote.id)
+
+    invoice = db.query(Invoice).first()
+    assert invoice is not None
+    assert invoice.amount_due == Decimal("100")
+
+    prev_db = app.dependency_overrides.get(get_db)
+    prev_user = app.dependency_overrides.get(get_current_user)
+
+    def _db_override():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_current_user] = override_user(client_user)
+    client = TestClient(app)
+
+    res = client.get(f"/api/v1/invoices/{invoice.id}")
+    assert res.status_code == 200
+    assert res.json()["id"] == invoice.id
+
+    res = client.post(f"/api/v1/invoices/{invoice.id}/mark-paid", json={"payment_method": "eft"})
+    assert res.status_code == 200
+    assert res.json()["status"] == "paid"
+
+    res = client.get(f"/api/v1/invoices/{invoice.id}/pdf")
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+
+    if prev_db is not None:
+        app.dependency_overrides[get_db] = prev_db
+    else:
+        app.dependency_overrides.pop(get_db, None)
+    if prev_user is not None:
+        app.dependency_overrides[get_current_user] = prev_user
+    else:
+        app.dependency_overrides.pop(get_current_user, None)
+    db.close()
+

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
           Quote #2025-4394
         </div>
         <div>
-          June 25th, 2025
+          June 26th, 2025
         </div>
         <input
           class="border rounded p-1"


### PR DESCRIPTION
## Summary
- introduce `Invoice` SQLAlchemy model and migrations
- create API endpoints to view, mark paid and download invoice PDFs
- auto-generate invoice when a quote is accepted
- build PDF invoices via ReportLab
- document invoice endpoints and update snapshot tests

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_685cea1fb250832e8023055941377176