### PR TITLE
Refactor artists page and nav styles

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -102,7 +102,7 @@ export default function ArtistsPage() {
 
   return (
     <MainLayout>
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-6">
         <div className="mb-4 text-center">
           <h1 className="text-xl md:text-2xl font-bold text-gray-900">
             Browse and book talented performers

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,7 +12,8 @@
   --color-foreground: #111827;
   --brand-color: var(--color-primary);
   --brand-color-dark: var(--color-secondary);
-  --brand-color-light: #a5b4fc;
+  /* lighter tint used for subtle page gradients */
+  --brand-color-light: #eef2ff;
   --color-link: var(--brand-color-dark);
   --color-link-hover: var(--brand-color);
 }
@@ -27,11 +28,12 @@
 
   a {
     color: var(--color-link);
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   a:hover {
     color: var(--color-link-hover);
+    text-decoration: underline;
   }
   .pb-safe {
     padding-bottom: env(safe-area-inset-bottom);

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -70,7 +70,7 @@ export default function ArtistCard({
     <motion.div
       whileHover={{ y: -4, boxShadow: '0 8px 24px rgba(0,0,0,0.15)' }}
       className={clsx(
-        'rounded-2xl border border-border bg-white shadow-sm overflow-hidden transition-shadow p-0 pb-4',
+        'rounded-2xl bg-white shadow-lg overflow-hidden transition-shadow',
         className,
       )}
       {...props}
@@ -114,12 +114,12 @@ export default function ArtistCard({
           </div>
         </div>
       </Link>
-      <div className="flex flex-col flex-1 px-4">
+      <div className="flex flex-col flex-1 p-6">
         <div className="flex items-center">
-          <h2 className="flex-1 text-lg font-semibold text-gray-900 truncate mt-3">{name}</h2>
+          <h2 className="flex-1 text-lg font-semibold text-gray-900 truncate mt-4 mb-2">{name}</h2>
           {verified && <CheckBadgeIcon className="h-4 w-4 text-brand" aria-label="Verified" />}
         </div>
-        {subtitle && <p className="text-sm text-gray-500 leading-tight mt-0.5 line-clamp-2">{subtitle}</p>}
+        {subtitle && <p className="text-sm text-gray-500 leading-tight line-clamp-2">{subtitle}</p>}
         {limitedTags.length > 0 && (
           <div className="flex flex-nowrap overflow-hidden gap-1 mt-2 whitespace-nowrap">
             {limitedTags.map((s) => (
@@ -129,7 +129,7 @@ export default function ArtistCard({
             ))}
           </div>
         )}
-        <hr className="my-3 border-gray-200" />
+        <hr className="mt-4 mb-4 border-gray-200" />
         <div className="flex justify-between items-center text-sm text-gray-700">
           <span className="flex items-center">
             <StarIcon className="h-4 w-4 mr-1 text-yellow-400" />
@@ -145,7 +145,7 @@ export default function ArtistCard({
             </span>
           )}
         </div>
-        <div className="flex justify-between items-center mt-2">
+        <div className="flex justify-between items-center mt-4">
           {location ? (
             <span className="text-sm text-gray-600 truncate">{location}</span>
           ) : (

--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -38,10 +38,10 @@ export default function FilterBar({
             type="button"
             onClick={() => onCategory?.(c)}
             className={clsx(
-              'px-3 py-1.5 rounded-full text-sm transition-colors border border-border focus:outline-none focus-visible:ring',
+              'px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 transition-colors duration-200 focus:outline-none focus-visible:ring-primary',
               category === c
-                ? 'bg-primary text-white'
-                : 'bg-white text-gray-800 hover:bg-primary hover:text-white',
+                ? 'bg-primary text-white ring-primary'
+                : 'bg-white text-gray-800 hover:bg-gray-100',
             )}
           >
             {c}
@@ -52,12 +52,12 @@ export default function FilterBar({
         placeholder="Location"
         value={location}
         onChange={onLocation}
-        className="text-sm px-3 py-1.5 rounded-md border border-border bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-primary w-[140px]"
+        className="text-sm px-3 py-1.5 rounded-md border border-border bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-primary transition-colors duration-200 w-[140px]"
       />
       <select
         value={sort}
         onChange={onSort}
-        className="text-sm px-3 py-1.5 rounded-md border border-border bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-primary"
+        className="text-sm px-3 py-1.5 rounded-md border border-border bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-primary transition-colors duration-200"
       >
         <option value="">Sort</option>
         <option value="top_rated">Top Rated</option>
@@ -77,7 +77,7 @@ export default function FilterBar({
         <button
           type="button"
           onClick={onClear}
-          className="text-sm text-primary hover:underline ml-auto"
+          className="text-sm text-primary hover:underline ml-auto transition-colors duration-200"
         >
           Clear filters
         </button>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -5,6 +5,7 @@ import { Disclosure, Menu, Transition } from '@headlessui/react';
 import { Bars3Icon } from '@heroicons/react/24/outline';
 import { useAuth } from '@/contexts/AuthContext';
 import Link from 'next/link';
+import NavLink from './NavLink';
 import { usePathname } from 'next/navigation';
 import NotificationBell from './NotificationBell';
 import BookingRequestIcon from './BookingRequestIcon';
@@ -38,7 +39,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-brand-light to-background">
+    <div className="min-h-screen bg-gray-50 bg-gradient-to-b from-brand-light/50 to-gray-50">
       <Disclosure as="nav" className="bg-background shadow-sm">
         {() => (
           <>
@@ -52,18 +53,13 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                   </div>
                   <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
                     {navigation.map((item) => (
-                      <Link
+                      <NavLink
                         key={item.name}
                         href={item.href}
-                        className={classNames(
-                          pathname === item.href
-                            ? 'border-brand text-gray-900'
-                            : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
-                          'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium'
-                        )}
+                        isActive={pathname === item.href}
                       >
                         {item.name}
-                      </Link>
+                      </NavLink>
                     ))}
                   </div>
                 </div>

--- a/frontend/src/components/layout/NavLink.tsx
+++ b/frontend/src/components/layout/NavLink.tsx
@@ -1,0 +1,33 @@
+'use client';
+import Link, { LinkProps } from 'next/link';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import clsx from 'clsx';
+
+interface NavLinkProps
+  extends LinkProps,
+    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  isActive?: boolean;
+  children: ReactNode;
+}
+
+export default function NavLink({
+  isActive,
+  className,
+  children,
+  ...props
+}: NavLinkProps) {
+  return (
+    <Link
+      {...props}
+      className={clsx(
+        'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors',
+        isActive
+          ? 'border-primary text-gray-900'
+          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+        className,
+      )}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- create `NavLink` component for better active link styling
- update navigation to use new component and new gradient background
- tweak global styles to remove default link underlines
- adjust FilterBar pill styling and transitions
- compact ArtistCard layout and spacing
- add vertical padding to Artists page

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68750962767c832e8f30beccdca6e05b