### PR TITLE
Implement PillButton for artist FilterBar

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -93,7 +93,8 @@ The Send Quote modal also generates a quote number automatically, shows today's 
 The artists page now uses a responsive grid that shows one card per row on
 mobile, two cards on tablets and three or more on larger screens. Filter options
 appear as animated pill buttons that transition smoothly on hover and when
-selected. Each artist card displays a skeleton placeholder until the image
+selected. These filters leverage the reusable `PillButton` component for
+consistent sizing and accessibility. Each artist card displays a skeleton placeholder until the image
 loads and reveals a **Book Now** overlay button when hovered.
 
 ## Testing

--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
-import clsx from 'clsx';
 import type { ChangeEventHandler } from 'react';
+import { PillButton } from '@/components/ui';
 
 export interface FilterBarProps {
   categories: string[];
@@ -33,19 +33,13 @@ export default function FilterBar({
     <div className="mt-6 mb-4 px-6 py-4 bg-white rounded-2xl shadow flex flex-wrap items-center gap-2">
       <div className="flex gap-2 overflow-x-auto whitespace-nowrap">
         {categories.map((c) => (
-          <button
+          <PillButton
             key={c}
-            type="button"
+            label={c}
+            selected={category === c}
             onClick={() => onCategory?.(c)}
-            className={clsx(
-              'px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 transition-colors duration-200 focus:outline-none focus-visible:ring-primary',
-              category === c
-                ? 'bg-primary text-white ring-primary'
-                : 'bg-white text-gray-800 hover:bg-gray-100',
-            )}
-          >
-            {c}
-          </button>
+            className="text-sm"
+          />
         ))}
       </div>
       <input

--- a/frontend/src/components/artist/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterBar.test.tsx
@@ -1,0 +1,44 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import FilterBar from '../FilterBar';
+
+describe('FilterBar component', () => {
+  const categories = ['All', 'Band'];
+
+  function renderBar() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <FilterBar
+          categories={categories}
+          category="Band"
+          onCategory={() => {}}
+          location=""
+          onLocation={() => {}}
+          sort=""
+          onSort={() => {}}
+          verifiedOnly={false}
+          onVerifiedOnly={() => {}}
+          filtersActive={false}
+        />,
+      );
+    });
+    return { container, root };
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders pill buttons for categories and highlights selected', () => {
+    const { container, root } = renderBar();
+    const buttons = container.querySelectorAll('button');
+    expect(buttons).toHaveLength(categories.length);
+    expect(buttons[1].getAttribute('aria-pressed')).toBe('true');
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
           Quote #2025-4394
         </div>
         <div>
-          July 14th, 2025
+          July 15th, 2025
         </div>
         <input
           class="border rounded p-1"

--- a/frontend/src/components/ui/PillButton.tsx
+++ b/frontend/src/components/ui/PillButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+import type { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export interface PillButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  selected?: boolean;
+}
+
+export default function PillButton({
+  label,
+  selected = false,
+  className,
+  ...props
+}: PillButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      {...props}
+      className={clsx(
+        'inline-flex items-center justify-center h-10 px-4 mx-1 rounded-full font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1',
+        selected
+          ? 'bg-indigo-600 text-white'
+          : 'bg-white text-gray-700 ring-1 ring-gray-200 hover:bg-gray-100',
+        className,
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/__tests__/PillButton.test.tsx
+++ b/frontend/src/components/ui/__tests__/PillButton.test.tsx
@@ -1,0 +1,47 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import PillButton from '../PillButton';
+
+describe('PillButton component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('renders default styles', () => {
+    act(() => {
+      root.render(<PillButton label="Test" />);
+    });
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.className).toContain('h-10');
+    expect(btn.className).toContain('px-4');
+    expect(btn.className).toContain('mx-1');
+    expect(btn.className).toContain('rounded-full');
+    expect(btn.className).toContain('bg-white');
+    expect(btn.className).toContain('text-gray-700');
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('shows selected state', () => {
+    act(() => {
+      root.render(<PillButton label="Active" selected />);
+    });
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.className).toContain('bg-indigo-600');
+    expect(btn.className).toContain('text-white');
+    expect(btn.className).not.toContain('ring-gray-200');
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -15,3 +15,4 @@ export { default as AlertBanner } from './AlertBanner';
 export { default as StatusBadge } from './StatusBadge';
 export { default as QuoteBubble } from '../booking/QuoteBubble';
 export { default as Tooltip } from './Tooltip';
+export { default as PillButton } from './PillButton';


### PR DESCRIPTION
## Summary
- add reusable `<PillButton>` component
- update FilterBar to use PillButton for category filters
- document PillButton usage in README
- update SendQuoteModal snapshot
- add unit tests for PillButton and FilterBar

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6876008e1944832e9686ab20583a62c1