### PR TITLE
Implement responsive filter bar

### DIFF
--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -2,6 +2,9 @@
 import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
 import { PillButton } from '@/components/ui';
+import useIsMobile from '@/hooks/useIsMobile';
+import FilterPopover from './FilterPopover';
+import FilterSheet from './FilterSheet';
 
 export interface FilterBarProps {
   categories: string[];
@@ -26,9 +29,11 @@ export default function FilterBar({
 }: FilterBarProps) {
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>();
   const [verifiedOnly, setVerifiedOnly] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const handleCategory = (c: string) => {
-    setSelectedCategory(c);
+    setSelectedCategory((prev) => (prev === c ? undefined : c));
     onCategory?.(c);
   };
 
@@ -39,53 +44,74 @@ export default function FilterBar({
   };
 
   return (
-    <div className="flex flex-wrap items-center gap-2 bg-white p-4 rounded-2xl shadow-sm">
-      <div className="flex flex-wrap gap-2 overflow-x-auto whitespace-nowrap">
-        {categories.map((c) => (
-          <PillButton
-            key={c}
-            label={c}
-            selected={c === selectedCategory}
-            onClick={() => handleCategory(c)}
-          />
-        ))}
-      </div>
-      <div className="ml-auto flex flex-wrap items-center gap-2">
-        <input
-          placeholder="Location"
-          value={location}
-          onChange={onLocation}
-          className="h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
-        />
-        <select
-          value={sort}
-          onChange={onSort}
-          className="h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
-        >
-          <option value="">Sort</option>
-          <option value="top_rated">Top Rated</option>
-          <option value="most_booked">Most Booked</option>
-          <option value="newest">Newest</option>
-        </select>
-        <label className="flex items-center gap-1 text-gray-700">
-          <input
-            type="checkbox"
-            checked={verifiedOnly}
-            onChange={(e) => setVerifiedOnly(e.target.checked)}
-            className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-300"
-          />
-          Verified Only
-        </label>
-        {filtersActive && (
+    <div className="flex items-center gap-2 p-4 bg-white rounded-2xl shadow-sm overflow-x-auto whitespace-nowrap">
+      {isMobile ? (
+        <>
           <button
             type="button"
-            onClick={clearAll}
-            className="text-indigo-600 hover:underline text-sm transition-colors duration-200"
+            onClick={() => setSheetOpen(true)}
+            className="flex items-center text-sm hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
           >
-            Clear filters
+            Filters
           </button>
-        )}
-      </div>
+          <FilterSheet
+            open={sheetOpen}
+            onClose={() => setSheetOpen(false)}
+            categories={categories}
+            selectedCategory={selectedCategory}
+            onSelectCategory={handleCategory}
+            verifiedOnly={verifiedOnly}
+            onVerifiedOnly={setVerifiedOnly}
+            sort={sort}
+            onSort={onSort}
+            onClear={clearAll}
+            onApply={() => {}}
+          />
+        </>
+      ) : (
+        <div className="flex items-center gap-2 overflow-x-auto">
+          {categories.slice(0, 3).map((c) => (
+            <PillButton
+              key={c}
+              label={c}
+              selected={c === selectedCategory}
+              onClick={() => handleCategory(c)}
+            />
+          ))}
+          <FilterPopover
+            categories={categories}
+            selectedCategory={selectedCategory}
+            onSelect={handleCategory}
+            verifiedOnly={verifiedOnly}
+            onVerified={setVerifiedOnly}
+          />
+        </div>
+      )}
+      <input
+        placeholder="Location"
+        value={location}
+        onChange={onLocation}
+        className="h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
+      />
+      <select
+        value={sort}
+        onChange={onSort}
+        className="h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
+      >
+        <option value="">Sort</option>
+        <option value="top_rated">Top Rated</option>
+        <option value="most_booked">Most Booked</option>
+        <option value="newest">Newest</option>
+      </select>
+      {filtersActive && (
+        <button
+          type="button"
+          onClick={clearAll}
+          className="text-indigo-600 hover:underline text-sm transition-colors duration-200"
+        >
+          Clear filters
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/artist/FilterPopover.tsx
+++ b/frontend/src/components/artist/FilterPopover.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { Fragment } from 'react';
+import { Popover, Transition } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
+
+interface FilterPopoverProps {
+  categories: string[];
+  selectedCategory?: string;
+  onSelect: (c: string) => void;
+  verifiedOnly: boolean;
+  onVerified: (v: boolean) => void;
+}
+
+export default function FilterPopover({
+  categories,
+  selectedCategory,
+  onSelect,
+  verifiedOnly,
+  onVerified,
+}: FilterPopoverProps) {
+  return (
+    <Popover className="relative">
+      <Popover.Button
+        className="flex items-center text-sm hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+        data-testid="more-filters"
+      >
+        More filters
+        <ChevronDownIcon className="ml-1 h-4 w-4" aria-hidden="true" />
+      </Popover.Button>
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <Popover.Panel className="absolute z-10 mt-2 w-56 rounded-lg bg-white shadow-lg p-4 space-y-2">
+          {categories.map((c) => (
+            <label key={c} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selectedCategory === c}
+                onChange={() => onSelect(c)}
+                className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+              />
+              <span>{c}</span>
+            </label>
+          ))}
+          <label className="flex items-center gap-2 pt-2 border-t border-gray-200">
+            <input
+              type="checkbox"
+              checked={verifiedOnly}
+              onChange={(e) => onVerified(e.target.checked)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+            />
+            <span>Verified Only</span>
+          </label>
+        </Popover.Panel>
+      </Transition>
+    </Popover>
+  );
+}

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -1,0 +1,103 @@
+'use client';
+import { useRef } from 'react';
+import type { ChangeEventHandler } from 'react';
+import { BottomSheet, Button } from '@/components/ui';
+
+interface FilterSheetProps {
+  open: boolean;
+  onClose: () => void;
+  categories: string[];
+  selectedCategory?: string;
+  onSelectCategory: (c: string) => void;
+  verifiedOnly: boolean;
+  onVerifiedOnly: (v: boolean) => void;
+  sort?: string;
+  onSort: ChangeEventHandler<HTMLSelectElement>;
+  onClear: () => void;
+  onApply: () => void;
+}
+
+export default function FilterSheet({
+  open,
+  onClose,
+  categories,
+  selectedCategory,
+  onSelectCategory,
+  verifiedOnly,
+  onVerifiedOnly,
+  sort,
+  onSort,
+  onClear,
+  onApply,
+}: FilterSheetProps) {
+  const firstRef = useRef<HTMLInputElement>(null);
+  return (
+    <BottomSheet open={open} onClose={onClose} initialFocus={firstRef}>
+      <div className="p-4 pb-32 space-y-4">
+        <h2 className="text-lg font-medium">Filters</h2>
+        <fieldset className="space-y-2">
+          <legend className="font-medium">Categories</legend>
+          {categories.map((c, idx) => (
+            <label key={c} className="flex items-center gap-2">
+              <input
+                ref={idx === 0 ? firstRef : undefined}
+                type="checkbox"
+                checked={selectedCategory === c}
+                onChange={() => onSelectCategory(c)}
+                className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+              />
+              <span>{c}</span>
+            </label>
+          ))}
+        </fieldset>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={verifiedOnly}
+            onChange={(e) => onVerifiedOnly(e.target.checked)}
+            className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+          />
+          <span>Verified Only</span>
+        </label>
+        <div>
+          <label htmlFor="sheet-sort" className="block text-sm font-medium mb-1">
+            Sort
+          </label>
+          <select
+            id="sheet-sort"
+            value={sort}
+            onChange={onSort}
+            className="w-full h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
+          >
+            <option value="">Sort</option>
+            <option value="top_rated">Top Rated</option>
+            <option value="most_booked">Most Booked</option>
+            <option value="newest">Newest</option>
+          </select>
+        </div>
+      </div>
+      <div className="fixed bottom-0 left-0 w-full flex gap-2 p-4 border-t bg-white">
+        <button
+          type="button"
+          onClick={() => {
+            onClear();
+          }}
+          className="flex-1 text-sm text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+        >
+          Clear all
+        </button>
+        <Button
+          type="button"
+          onClick={() => {
+            onApply();
+            onClose();
+          }}
+          className="flex-1"
+          fullWidth
+        >
+          Apply filters
+        </Button>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/frontend/src/components/artist/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterBar.test.tsx
@@ -2,9 +2,12 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import React from 'react';
 import FilterBar from '../FilterBar';
+import useIsMobile from '@/hooks/useIsMobile';
+
+jest.mock('@/hooks/useIsMobile');
 
 describe('FilterBar component', () => {
-  const categories = ['All', 'Band'];
+  const categories = ['A', 'B', 'C', 'D'];
 
   function renderBar() {
     const container = document.createElement('div');
@@ -30,15 +33,26 @@ describe('FilterBar component', () => {
     document.body.innerHTML = '';
   });
 
-  it('updates selected state when a pill is clicked', () => {
+  it('shows pills and popover on desktop', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(false);
     const { container, root } = renderBar();
-    const buttons = container.querySelectorAll('button');
-    expect(buttons).toHaveLength(categories.length);
-    expect(buttons[0].getAttribute('aria-pressed')).toBe('false');
+    const pills = container.querySelectorAll('button[aria-pressed]');
+    expect(pills).toHaveLength(3);
+    const more = container.querySelector('[data-testid="more-filters"]');
+    expect(more).not.toBeNull();
     act(() => {
-      buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      (more as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(buttons[0].getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('input[type="checkbox"]')).not.toBeNull();
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows single Filters button on mobile', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(true);
+    const { container, root } = renderBar();
+    const btn = container.querySelector('button');
+    expect(btn?.textContent).toContain('Filters');
     act(() => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary
- add `FilterPopover` and `FilterSheet` components
- update `FilterBar` with responsive popover/sheet logic
- expand FilterBar tests for desktop and mobile variants

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68761970943c832e979e70aa3e3a18dd