### PR TITLE
Fix useNotifications auth + WS token

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
-* New `useNotifications` context fetches `/api/v1/notifications` and listens on `/ws/notifications` for real-time updates. The drawer components live under `components/notifications/`.
+* New `useNotifications` context fetches `/api/v1/notifications` with auth and listens on `/ws/notifications?token=...` for real-time updates. The drawer components live under `components/notifications/`.
 * Wrap the root layout in `<NotificationsProvider>` so badges and drawers update automatically across the app.
 
 ### Artist Profile Enhancements


### PR DESCRIPTION
## Summary
- authenticate notification requests and add tokenized WS URL
- update docs about the new auth-aware notifications hook

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68762b6cfd98832e8b7b45487c0b3d4c