### PR TITLE
Fix notification auth token usage

### DIFF
--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -87,7 +87,9 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const wsBase =
     process.env.NEXT_PUBLIC_WS_URL ||
     process.env.NEXT_PUBLIC_API_URL.replace(/^http/, 'ws');
-  const wsUrl = `${wsBase}/ws/notifications?token=${encodeURIComponent(token)}`;
+  const wsUrl = `${wsBase}/ws/notifications?token=${encodeURIComponent(
+    token || '',
+  )}`;
 
   const handleMessage = useCallback((event: MessageEvent) => {
     try {
@@ -102,9 +104,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
 
   const { onMessage } = useWebSocket(wsUrl);
 
-  useEffect(() => {
-    return onMessage(handleMessage);
-  }, [onMessage, handleMessage]);
+  useEffect(() => onMessage(handleMessage), [onMessage, handleMessage]);
 
   const markAsRead = useCallback(
     async (id: string) => {


### PR DESCRIPTION
## Summary
- ensure WebSocket auth token includes fallback empty string
- clean up ws effect registration

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68762d517a8c832e90aa20292e0fab94