### PR TITLE
Improve notification read UX

### DIFF
--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -1,45 +1,59 @@
 'use client';
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
+import { useEffect, useState } from 'react';
 import type { Notification } from '@/hooks/useNotifications';
 
 interface Props {
   notification: Notification;
-  onMarkRead: (id: string) => void;
+  onMarkRead: (id: string) => Promise<void>;
   onDelete: (id: string) => void;
 }
 
-export default function NotificationItem({
-  notification,
-  onMarkRead,
-  onDelete,
-}: Props) {
+export default function NotificationItem({ notification, onMarkRead, onDelete }: Props) {
+  const [localRead, setLocalRead] = useState(notification.read);
+
+  useEffect(() => {
+    setLocalRead(notification.read);
+  }, [notification.read]);
+
+  const handleClick = async () => {
+    if (localRead) return;
+    setLocalRead(true);
+    try {
+      await onMarkRead(notification.id);
+    } catch {
+      setLocalRead(false);
+    }
+  };
+
   return (
     <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') handleClick();
+      }}
       className={clsx(
-        'flex items-start justify-between p-3 rounded-xl transition-colors',
-        notification.read ? 'bg-white border border-transparent' : 'bg-indigo-50 border-l-4 border-indigo-600',
+        'flex items-start justify-between p-3 rounded-xl transition-colors cursor-pointer',
+        localRead ? 'bg-white border border-transparent' : 'bg-indigo-50 border-l-4 border-indigo-600',
       )}
     >
       <div className="flex-1">
         <div className="flex items-center justify-between">
-          <h3 className="font-medium text-gray-800">{notification.title}</h3>
+          <h3 className={clsx('font-medium', localRead ? 'text-gray-500' : 'text-gray-800')}>
+            {notification.title}
+          </h3>
           <span className="text-sm text-gray-400">
             {formatDistanceToNow(new Date(notification.timestamp))} ago
           </span>
         </div>
-        <p className="mt-1 text-gray-600 text-sm">{notification.body}</p>
+        <p className={clsx('mt-1 text-sm', localRead ? 'text-gray-500' : 'text-gray-600')}>
+          {notification.body}
+        </p>
       </div>
-      <div className="ml-4 flex flex-col space-y-2">
-        {!notification.read && (
-          <button
-            onClick={() => onMarkRead(notification.id)}
-            className="text-indigo-600 hover:text-indigo-800 text-sm"
-            type="button"
-          >
-            Mark read
-          </button>
-        )}
+      <div className="ml-4 flex flex-col space-y-2" onClick={(e) => e.stopPropagation()}>
         <button
           onClick={() => onDelete(notification.id)}
           className="text-gray-500 hover:text-gray-700 text-sm"


### PR DESCRIPTION
## Summary
- make clicking a notification mark it read immediately
- optimistic mark read in notification context and handle errors
- patch `/api/v1/notifications/:id` to persist read state

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68763c139bb0832eb7cd87cec4471ff3