### PR TITLE
Fix notification REST paths and optimistic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Clipboard icon opens `/booking-requests` with an unread badge.
 * Unified feed combines booking updates and message threads.
 * Mark-as-read endpoints and “Mark All as Read”.
+* Individual notifications are updated via `PATCH /api/notifications/{id}` and all can be cleared with `PATCH /api/notifications/mark-all-read`.
 * "Unread Only" toggle filters message threads and alerts in the drawer and full-screen modal.
 * Notification lists now use **react-window** for virtualization so scrolling large histories is smoother. Install `react-window` if you upgrade dependencies manually.
 * Grouped notification views are now generated in the UI from `/notifications` and the old `/notifications/grouped` endpoint was removed.


### PR DESCRIPTION
## Summary
- use PATCH `/api/notifications/:id` with optimistic update and rollback
- surface Axios errors correctly in `useNotifications`
- document new mark read endpoints in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687642ef79e8832ebd15f78b48f3800d