### PR TITLE
Prevent WebSocket connects before login

### DIFF
--- a/frontend/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/frontend/src/hooks/__tests__/useWebSocket.test.tsx
@@ -132,4 +132,18 @@ describe('useWebSocket', () => {
 
     jest.useRealTimers();
   });
+
+  it('does not connect when url is null', () => {
+    function Test() {
+      // explicitly pass null to skip connection
+      useWebSocket(null);
+      return null;
+    }
+
+    act(() => {
+      root.render(<Test />);
+    });
+
+    expect(StubSocket.instances.length).toBe(0);
+  });
 });

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -99,16 +99,19 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (!tokenRef.current) return;
     fetchNotifications();
     const id = setInterval(fetchNotifications, 30_000);
     return () => clearInterval(id);
-  }, [fetchNotifications]);
+  }, [fetchNotifications, token]);
 
   // Build the WebSocket URL without the REST prefix.
   const wsHost =
     process.env.NEXT_PUBLIC_WS_URL ||
     process.env.NEXT_PUBLIC_API_URL.replace(/^http/, 'ws');
-  const wsUrl = `${wsHost}/ws/notifications${token ? `?token=${encodeURIComponent(token)}` : ''}`;
+  const wsUrl = token
+    ? `${wsHost}/ws/notifications?token=${encodeURIComponent(token)}`
+    : null;
 
   const handleMessage = useCallback((event: MessageEvent) => {
     try {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -15,7 +15,7 @@ interface UseWebSocketReturn {
 export type ErrorHandler = (event?: CloseEvent) => void;
 
 export default function useWebSocket(
-  url: string,
+  url?: string | null,
   onError?: ErrorHandler,
 ): UseWebSocketReturn {
   const socketRef = useRef<WebSocket | null>(null);
@@ -37,6 +37,7 @@ export default function useWebSocket(
   }, []);
 
   useEffect(() => {
+    if (!url) return undefined;
     let cancelled = false;
 
     const connect = () => {


### PR DESCRIPTION
## Summary
- avoid connecting to notifications socket before authentication token exists
- handle null URL in generic useWebSocket hook
- test that useWebSocket skips connection when URL is null

## Testing
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687661d4aecc832e8ba62f27963d541c