### PR TITLE
Fix notifications WebSocket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
-* New `useNotifications` context fetches `/api/v1/notifications` with auth and listens on `/ws/notifications?token=...` for real-time updates. Notifications are reloaded every 30&nbsp;seconds via a shared Axios instance. The drawer components live under `components/notifications/`.
+* New `useNotifications` context fetches `/api/v1/notifications` with auth and listens on `/api/v1/ws/notifications?token=...` for real-time updates. Notifications are reloaded every 30&nbsp;seconds via a shared Axios instance. The drawer components live under `components/notifications/`.
 * Wrap the root layout in `<NotificationsProvider>` so badges and drawers update automatically across the app.
 
 ### Artist Profile Enhancements

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -105,12 +105,13 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     return () => clearInterval(id);
   }, [fetchNotifications, token]);
 
-  // Build the WebSocket URL without the REST prefix.
+  // Build the WebSocket URL including the API prefix so it matches
+  // the FastAPI router mounted at `/api/v1`.
   const wsHost =
     process.env.NEXT_PUBLIC_WS_URL ||
     process.env.NEXT_PUBLIC_API_URL.replace(/^http/, 'ws');
   const wsUrl = token
-    ? `${wsHost}/ws/notifications?token=${encodeURIComponent(token)}`
+    ? `${wsHost}/api/v1/ws/notifications?token=${encodeURIComponent(token)}`
     : null;
 
   const handleMessage = useCallback((event: MessageEvent) => {


### PR DESCRIPTION
## Summary
- connect to `/api/v1/ws/notifications` in notification hook
- update documentation

## Testing
- `npm test -- -w=2`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68766ed57ea4832eb9e7f0a0f577763b