### PR TITLE
Fix unread notifications styling

### DIFF
--- a/frontend/src/components/notifications/NotificationDrawer.tsx
+++ b/frontend/src/components/notifications/NotificationDrawer.tsx
@@ -29,7 +29,7 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
   const toggleUnreadOnly = () => setUnreadOnly((v) => !v);
 
   const filtered = unreadOnly
-    ? notifications.filter((n) => !n.read)
+    ? notifications.filter((n) => !n.is_read)
     : notifications;
 
   return (

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -2,20 +2,20 @@
 import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import { useEffect, useState } from 'react';
-import type { Notification } from '@/hooks/useNotifications';
+import type { Notification } from '@/types';
 
 interface Props {
   notification: Notification;
-  onMarkRead: (id: string) => Promise<void>;
-  onDelete: (id: string) => void;
+  onMarkRead: (id: number) => Promise<void>;
+  onDelete: (id: number) => void;
 }
 
 export default function NotificationItem({ notification, onMarkRead, onDelete }: Props) {
-  const [localRead, setLocalRead] = useState(notification.read);
+  const [localRead, setLocalRead] = useState(notification.is_read);
 
   useEffect(() => {
-    setLocalRead(notification.read);
-  }, [notification.read]);
+    setLocalRead(notification.is_read);
+  }, [notification.is_read]);
 
   const handleClick = async () => {
     if (localRead) return;


### PR DESCRIPTION
## Summary
- keep notification read state consistent across the frontend
- adjust components to use `is_read`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876794294f0832ea852d868012b42ea