### PR TITLE
Improve notification drawer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.
 * New `useNotifications` context fetches `/api/v1/notifications` with auth and listens on `/api/v1/ws/notifications?token=...` for real-time updates. Notifications are reloaded every 30&nbsp;seconds via a shared Axios instance. The drawer components live under `components/notifications/`.
 * Wrap the root layout in `<NotificationsProvider>` so badges and drawers update automatically across the app.
+* The drawer footer now keeps a **Load more** button visible whenever additional notifications are available.
 
 ### Artist Profile Enhancements
 

--- a/frontend/src/components/notifications/NotificationDrawer.tsx
+++ b/frontend/src/components/notifications/NotificationDrawer.tsx
@@ -23,6 +23,8 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
     markAsRead,
     markAllAsRead,
     deleteNotification,
+    loadMore,
+    hasMore,
   } = useNotifications();
   const [unreadOnly, setUnreadOnly] = useState(false);
 
@@ -69,7 +71,7 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
                 </button>
               </div>
             </header>
-            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            <div className="flex-1 overflow-y-auto px-4 py-2 space-y-1">
               {filtered.map((n) => (
                 <NotificationItem
                   key={n.id}
@@ -85,13 +87,20 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
                 </AlertBanner>
               )}
             </div>
-            {notifications.length > 20 && (
-              <footer className="p-4 border-t text-center">
-                <Link href="/notifications" className="text-indigo-600 hover:underline">
-                  View all notifications
-                </Link>
-              </footer>
-            )}
+            <footer className="flex items-center justify-between p-4 border-t">
+              {hasMore && (
+                <button
+                  onClick={loadMore}
+                  className="text-sm text-indigo-600 hover:underline"
+                  type="button"
+                >
+                  Load more
+                </button>
+              )}
+              <Link href="/notifications" className="text-sm text-indigo-600 hover:underline">
+                View all notifications
+              </Link>
+            </footer>
           </motion.div>
         </Dialog>
       )}

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import { formatDistanceToNow } from 'date-fns';
 import { useEffect, useState } from 'react';
 import type { Notification } from '@/types';
+import { parseItem } from '../layout/NotificationListItem';
+import { toUnifiedFromNotification } from '@/hooks/notificationUtils';
 
 interface Props {
   notification: Notification;
@@ -12,6 +14,7 @@ interface Props {
 
 export default function NotificationItem({ notification, onMarkRead, onDelete }: Props) {
   const [localRead, setLocalRead] = useState(notification.is_read);
+  const parsed = parseItem(toUnifiedFromNotification(notification));
 
   useEffect(() => {
     setLocalRead(notification.is_read);
@@ -36,32 +39,37 @@ export default function NotificationItem({ notification, onMarkRead, onDelete }:
         if (e.key === 'Enter') handleClick();
       }}
       className={clsx(
-        'flex items-start justify-between p-3 rounded-xl transition-colors cursor-pointer',
-        localRead ? 'bg-white border border-transparent' : 'bg-indigo-50 border-l-4 border-indigo-600',
+        'flex items-start gap-3 p-2 border-b cursor-pointer transition-colors',
+        localRead ? 'bg-white' : 'bg-indigo-50',
       )}
     >
+      <div className="h-8 w-8 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center">
+        {parsed.icon}
+      </div>
       <div className="flex-1">
-        <div className="flex items-center justify-between">
-          <h3 className={clsx('font-medium', localRead ? 'text-gray-500' : 'text-gray-800')}>
-            {notification.title}
+        <div className="flex items-start justify-between">
+          <h3
+            className={clsx('text-sm font-medium truncate', localRead ? 'text-gray-500' : 'text-gray-800')}
+            title={parsed.title}
+          >
+            {parsed.title}
           </h3>
-          <span className="text-sm text-gray-400">
+          <span className="text-xs text-gray-400">
             {formatDistanceToNow(new Date(notification.timestamp))} ago
           </span>
         </div>
-        <p className={clsx('mt-1 text-sm', localRead ? 'text-gray-500' : 'text-gray-600')}>
-          {notification.body}
-        </p>
+        <p className="text-xs text-gray-700 truncate">{parsed.subtitle}</p>
+        {parsed.metadata && (
+          <p className="text-xs text-gray-500 truncate">{parsed.metadata}</p>
+        )}
       </div>
-      <div className="ml-4 flex flex-col space-y-2" onClick={(e) => e.stopPropagation()}>
-        <button
-          onClick={() => onDelete(notification.id)}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-          type="button"
-        >
-          Delete
-        </button>
-      </div>
+      <button
+        onClick={() => onDelete(notification.id)}
+        className="ml-2 text-xs text-gray-500 hover:text-gray-700"
+        type="button"
+      >
+        Delete
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show icons and titles in notification items
- keep load more button visible in drawer footer
- document the new drawer behavior

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687747615ad8832eb3d0416c2c014e60