### PR TITLE
Improve notification drawer UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,7 +758,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New `useNotifications` context fetches `/api/v1/notifications` with auth and listens on `/api/v1/ws/notifications?token=...` for real-time updates. Notifications are reloaded every 30&nbsp;seconds via a shared Axios instance. The drawer components live under `components/notifications/`.
 * Wrap the root layout in `<NotificationsProvider>` so badges and drawers update automatically across the app.
 * A new `parseNotification` utility maps each notification type to a friendly title, subtitle and icon. `<NotificationItem>` consumes this data and opens the related link while marking the item read.
-* The drawer footer now keeps a **Load more** button visible whenever additional notifications are available.
+* Unread notifications now have a colored left border so they stand out in the drawer.
+* The drawer footer keeps a **Load more** button visible whenever additional notifications are available.
 
 ### Artist Profile Enhancements
 

--- a/frontend/src/components/notifications/NotificationDrawer.tsx
+++ b/frontend/src/components/notifications/NotificationDrawer.tsx
@@ -71,7 +71,7 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
                 </button>
               </div>
             </header>
-            <div className="flex-1 overflow-y-auto px-4 py-2 space-y-1 pb-20">
+            <div className="flex-1 overflow-y-auto px-4 py-2 space-y-2">
               {filtered.map((n) => (
                 <NotificationItem
                   key={n.id}
@@ -87,7 +87,7 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
                 </AlertBanner>
               )}
             </div>
-            <footer className="sticky bottom-0 flex items-center justify-between p-4 border-t bg-white">
+            <footer className="flex items-center justify-between p-4 border-t bg-white">
               {hasMore && (
                 <button
                   onClick={loadMore}

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -44,8 +44,8 @@ export default function NotificationItem({ notification, onMarkRead, onDelete }:
         if (e.key === 'Enter') handleClick();
       }}
       className={clsx(
-        'flex items-start gap-3 p-2 border-b cursor-pointer transition-colors',
-        localRead ? 'bg-white' : 'bg-indigo-50',
+        'flex items-start gap-3 p-2 border-b border-l-4 cursor-pointer transition-colors',
+        localRead ? 'bg-white border-transparent' : 'bg-indigo-50 border-indigo-500',
       )}
     >
       <div className="h-8 w-8 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- highlight unread notifications with border
- keep drawer footer visible with Load more
- document improved notification list styling

## Testing
- `pytest -q`
- `npm test -- -w=2`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68776af3b64c832e99edd26012583ab4