### PR TITLE
Improve notification components

### DIFF
--- a/frontend/src/components/notifications/NotificationDrawer.tsx
+++ b/frontend/src/components/notifications/NotificationDrawer.tsx
@@ -71,33 +71,31 @@ export default function NotificationDrawer({ isOpen, onClose }: Props) {
                 </button>
               </div>
             </header>
-            <div className="flex-1 overflow-y-auto px-4 py-2 space-y-2">
-              {filtered.map((n) => (
-                <NotificationItem
-                  key={n.id}
-                  notification={n}
-                  onMarkRead={markAsRead}
-                  onDelete={deleteNotification}
-                />
-              ))}
-              {loading && <Spinner className="mt-4" />}
-              {error && (
-                <AlertBanner variant="error" className="mt-2">
-                  {error?.message}
-                </AlertBanner>
-              )}
+            <div className="flex-1 overflow-y-auto">
+              <div className="px-4 py-2 space-y-2">
+                {filtered.map((n) => (
+                  <NotificationItem
+                    key={n.id}
+                    notification={n}
+                    onMarkRead={markAsRead}
+                    onDelete={deleteNotification}
+                  />
+                ))}
+                {loading && <Spinner className="mt-4" />}
+                {error && (
+                  <AlertBanner variant="error" className="mt-2">
+                    {error?.message}
+                  </AlertBanner>
+                )}
+              </div>
             </div>
-            <footer className="flex items-center justify-between p-4 border-t bg-white">
+            <footer className="sticky bottom-0 bg-white p-4 border-t flex justify-between">
               {hasMore && (
-                <button
-                  onClick={loadMore}
-                  className="text-sm text-indigo-600 hover:underline"
-                  type="button"
-                >
+                <button onClick={loadMore} className="text-sm hover:underline" type="button">
                   Load more
                 </button>
               )}
-              <Link href="/notifications" className="text-sm text-indigo-600 hover:underline">
+              <Link href="/notifications" className="text-sm hover:underline">
                 View all notifications
               </Link>
             </footer>

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -44,15 +44,15 @@ export default function NotificationItem({ notification, onMarkRead, onDelete }:
         if (e.key === 'Enter') handleClick();
       }}
       className={clsx(
-        'flex items-start gap-3 p-2 border-b border-l-4 cursor-pointer transition-colors',
-        localRead ? 'bg-white border-transparent' : 'bg-indigo-50 border-indigo-500',
+        'flex items-center gap-3 p-2 border-b cursor-pointer transition-colors',
+        localRead ? 'bg-white' : 'bg-indigo-50 border-l-4 border-indigo-500',
       )}
     >
       <div className="h-8 w-8 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center">
         {parsed.icon}
       </div>
       <div className="flex-1">
-        <div className="flex items-start justify-between">
+      <div className="flex items-center justify-between">
           <h3
             className={clsx('text-sm font-medium truncate', localRead ? 'text-gray-500' : 'text-gray-800')}
             title={parsed.title}


### PR DESCRIPTION
## Summary
- refine NotificationItem layout using parseNotification, icon, preview subtitle and timestamp
- simplify NotificationDrawer scrolling structure and add sticky footer

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68776f3e3580832ebc96196dd969280b