### PR TITLE
Handle chat thread notifications

### DIFF
--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -52,18 +52,23 @@ export default function NotificationItem({ notification, onMarkRead, onDelete }:
         {parsed.icon}
       </div>
       <div className="flex-1">
-      <div className="flex items-center justify-between">
-          <h3
-            className={clsx('text-sm font-medium truncate', localRead ? 'text-gray-500' : 'text-gray-800')}
-            title={parsed.title}
-          >
-            {parsed.title}
-          </h3>
-          <span className="text-xs text-gray-400">
+        <h3
+          className={clsx(
+            'text-sm font-medium truncate',
+            localRead ? 'text-gray-500' : 'text-gray-800',
+          )}
+          title={parsed.title}
+        >
+          {parsed.title}
+        </h3>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-gray-700 truncate" title={parsed.subtitle}>
+            {parsed.subtitle}
+          </p>
+          <span className="text-xs text-gray-400 flex-shrink-0">
             {formatDistanceToNow(new Date(notification.timestamp))} ago
           </span>
         </div>
-        <p className="text-xs text-gray-700 truncate">{parsed.subtitle}</p>
       </div>
       <button
         onClick={() => onDelete(notification.id)}

--- a/frontend/src/hooks/__tests__/parseNotification.test.ts
+++ b/frontend/src/hooks/__tests__/parseNotification.test.ts
@@ -81,4 +81,20 @@ describe('parseNotification', () => {
     expect(parsed.title).toBe('Review Request');
     expect(parsed.subtitle).toBe('Please review');
   });
+
+  it('parses message thread notification', () => {
+    const n: Notification = {
+      id: 6,
+      user_id: 1,
+      type: 'message_thread_notification',
+      message: 'Last message preview',
+      link: '/messages/2',
+      is_read: false,
+      timestamp: new Date().toISOString(),
+      sender_name: 'Thread with Bob',
+    } as Notification;
+    const parsed = parseNotification(n);
+    expect(parsed.title).toBe('Thread with Bob');
+    expect(parsed.subtitle).toBe('Last message preview');
+  });
 });

--- a/frontend/src/hooks/parseNotification.tsx
+++ b/frontend/src/hooks/parseNotification.tsx
@@ -27,6 +27,12 @@ export default function parseNotification(n: Notification): ParsedNotification {
         title: n.sender_name ?? 'New message',
         subtitle: truncate(n.message.replace(/^New message:\s*/i, '').trim()),
       };
+    case 'message_thread_notification':
+      return {
+        icon: <ChatBubbleLeftRightIcon className="w-5 h-5 text-indigo-600" />,
+        title: n.sender_name ?? 'Message thread',
+        subtitle: truncate(n.message),
+      };
     case 'new_booking_request':
       return {
         icon: <CalendarDaysIcon className="w-5 h-5 text-indigo-600" />,


### PR DESCRIPTION
## Summary
- support `message_thread_notification` in `parseNotification`
- open thread links from `NotificationItem` with a single-line subtitle/time row
- add unit test for new notification type

## Testing
- `npm test -- -w=1` in `frontend`
- `npm run lint` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687772b42e04832ebc8f109a2aa247a2