### PR TITLE
Improve notification titles

### DIFF
--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -141,7 +141,15 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     };
   }
   const defaultTitle = content.length > 36 ? `${content.slice(0, 36)}...` : content;
-  return { title: defaultTitle || 'Notification', subtitle: '', icon: '🔔' };
+  const typeTitle = n.type
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+  return {
+    title: defaultTitle || typeTitle || 'Notification',
+    subtitle: '',
+    icon: '🔔',
+  };
 }
 
 interface NotificationListItemProps {


### PR DESCRIPTION
## Summary
- ensure NotificationListItem falls back to the notification type when message text is missing
- all tests pass

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687780538b90832ebbf1aab47cd99d32