### PR TITLE
Fix notification drawer imports and tests

### DIFF
--- a/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@/hooks/useIsMobile');
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-jest.mock('../../notifications/NotificationDrawer', () => {
+jest.mock('../NotificationDrawer', () => {
   const React = require('react');
   return {
     __esModule: true,


### PR DESCRIPTION
## Summary
- fix NotificationBell dynamic import to use the modern NotificationDrawer
- ensure NavBar uses the same drawer component
- update NotificationBellPrefetch test for new import path

## Testing
- `./scripts/test-all.sh` *(backend tests pass)*
- `npm test -- --runInBand` *(frontend tests pass)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878bc4f31cc832eb654d04d82187332