### PR TITLE
Improve notification drawer design

### DIFF
--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -77,10 +77,10 @@ export default function NotificationDrawer({
                 leaveTo="translate-x-full"
               >
                 <Dialog.Panel
-                  className="pointer-events-auto w-screen max-w-sm sm:max-w-md rounded-l-2xl bg-white/60 backdrop-blur-md ring-1 ring-black/10 shadow-2xl flex flex-col"
+                  className="pointer-events-auto w-96 rounded-l-2xl bg-white/60 backdrop-blur-lg shadow-lg border border-white/20 flex flex-col"
                 >
-                  <div className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 backdrop-blur-md bg-white/60 border-b border-black/10">
-                    <Dialog.Title className="text-lg font-semibold text-gray-900">Notifications</Dialog.Title>
+                  <div className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 bg-white/60 backdrop-blur-lg shadow-lg border-b border-white/20">
+                    <Dialog.Title className="text-lg font-bold text-gray-900">Notifications</Dialog.Title>
                     <button
                       type="button"
                       className="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
@@ -90,7 +90,7 @@ export default function NotificationDrawer({
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
-                  <div className="sticky top-[48px] z-10 flex items-center justify-center gap-2 px-4 py-2 backdrop-blur-md bg-white/60 border-b border-black/10">
+                  <div className="sticky top-[56px] z-10 flex items-center justify-between px-4 py-2 bg-white/60 backdrop-blur-lg border-b border-white/20">
                     <button
                       type="button"
                       onClick={() => setShowUnread((prev) => !prev)}
@@ -143,11 +143,11 @@ export default function NotificationDrawer({
                       </List>
                     )}
                   </div>
-                  <div className="sticky bottom-0 z-10 flex items-center justify-between gap-2 px-4 py-3 backdrop-blur-md bg-white/60 border-t border-black/10">
+                  <div className="sticky bottom-0 z-10 flex items-center justify-between px-4 py-3 bg-white/60 backdrop-blur-lg border-t border-white/20">
                     <button
                       type="button"
                       onClick={markAllRead}
-                      className="rounded-full bg-brand-light px-3 py-1 text-sm font-medium text-brand-dark shadow hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                      className="rounded-full bg-red-100 px-3 py-1 text-sm font-medium text-red-800 shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
                     >
                       Clear All
                     </button>

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { format } from 'date-fns';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import TimeAgo from '../ui/TimeAgo';
 import { getFullImageUrl } from '@/lib/utils';
 import type { UnifiedNotification } from '@/types';
@@ -167,10 +168,10 @@ export default function NotificationListItem({ n, onClick, style, className = ''
       style={style}
       onClick={onClick}
       className={classNames(
-        'group flex w-full items-start gap-3 p-3 sm:p-4 text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition rounded-lg shadow-sm mx-2 my-2',
+        'group flex w-full items-center gap-4 p-4 text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-brand transition rounded-lg mx-2 my-2',
         n.is_read
-          ? 'bg-white/80 text-gray-700 hover:shadow-md'
-          : 'bg-indigo-50/70 border-l-4 border-indigo-500 shadow-md text-gray-900 font-medium',
+          ? 'bg-white/60 text-gray-700 border-b border-white/20'
+          : 'bg-white shadow-lg text-gray-900',
         className,
       )}
     >
@@ -179,21 +180,21 @@ export default function NotificationListItem({ n, onClick, style, className = ''
           <Image
             src={getFullImageUrl(parsed.avatarUrl) as string}
             alt="avatar"
-            width={40}
-            height={40}
+            width={44}
+            height={44}
             loading="lazy"
-            className="h-10 w-10 flex-shrink-0 rounded-full object-cover"
+            className="h-11 w-11 flex-shrink-0 rounded-full object-cover"
             onError={(e) => {
               (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
             }}
           />
         ) : (
-          <div className="h-10 w-10 flex-shrink-0 rounded-full bg-brand-light flex items-center justify-center text-brand-dark font-medium">
+          <div className="h-11 w-11 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-gray-700 font-medium">
             {parsed.initials}
           </div>
         )
       ) : (
-        <div className="h-10 w-10 flex-shrink-0 rounded-full bg-brand-light flex items-center justify-center text-brand-dark font-medium">
+        <div className="h-11 w-11 flex-shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-gray-700 font-medium">
           {parsed.icon}
         </div>
       )}
@@ -222,6 +223,7 @@ export default function NotificationListItem({ n, onClick, style, className = ''
           <p className="text-sm text-gray-500 truncate whitespace-nowrap overflow-hidden">{parsed.metadata}</p>
         )}
       </div>
+      <ChevronRightIcon className="h-5 w-5 text-gray-400 group-hover:text-gray-600 flex-shrink-0" />
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- restyle notification drawer with glass panel and wider layout
- update notification cards with cleaner layout and arrow icon

## Testing
- `./scripts/test-all.sh` *(fails: npm ci ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_6878d185559c832eace9889899b50ebc