### PR TITLE
Enhance notification parsing

### DIFF
--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -23,7 +23,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
   if (n.type === 'message') {
     const cleaned = content.replace(/^New message:\s*/i, '').trim();
     const snippet = cleaned.length > 30 ? `${cleaned.slice(0, 30)}...` : cleaned;
-    const title = n.name || 'Message';
+    const title = n.name || n.sender_name || 'Message';
     const unreadCount = Number(n.unread_count) || 0;
     return {
       title,
@@ -59,7 +59,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
         .toLowerCase()
         .replace(/\b\w/g, (c) => c.toUpperCase());
     }
-    const subtitle = formattedType || 'Booking Request';
+    const subtitle = formattedType;
     const locMatch = content.match(/Location:\s*(.+)/i);
     const dateMatch = content.match(/Date:\s*(.+)/i);
     let metadata: string | undefined;
@@ -127,7 +127,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       icon: '📅',
     };
   }
-  if (/quote accepted/i.test(content)) {
+  if (n.type === 'quote_accepted' || /quote accepted/i.test(content)) {
     const name =
       n.sender_name || n.name || content.match(/Quote accepted by (.+)/i)?.[1];
     const title = name ? `Quote accepted by ${name}` : 'Quote accepted';

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -20,7 +20,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a new booking request for Perfo...');
+    expect(parsed.subtitle).toBe('Performance');
     expect(parsed.bookingType).toBe('Performance');
   });
 
@@ -37,7 +37,7 @@ describe('parseItem', () => {
     } as UnifiedNotification;
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Alice');
-    expect(parsed.subtitle).toBe('sent a new booking request for Perso...');
+    expect(parsed.subtitle).toBe('Personalized Video');
     expect(parsed.bookingType).toBe('Personalized Video');
   });
 
@@ -69,9 +69,7 @@ describe('parseItem', () => {
   const parsed = parseItem(n);
   expect(parsed.title).toBe('Charlie Brown');
   expect(parsed.unreadCount).toBe(3);
-  expect(parsed.subtitle).toBe(
-      'Last message: "Hello there, this is a long me..."',
-  );
+  expect(parsed.subtitle).toBe('Hello there, this is a long me...');
   });
 
   it('omits unread count when zero', () => {
@@ -87,7 +85,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Dana');
     expect(parsed.unreadCount).toBe(0);
-    expect(parsed.subtitle).toBe('Last message: "Hi"');
+    expect(parsed.subtitle).toBe('Hi');
   });
 });
 

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -43,6 +43,11 @@ describe('NotificationListItem', () => {
     expect(span?.getAttribute('title')).toBe('Alice');
   });
 
+  it('parses message preview from content', () => {
+    const parsed = parseItem(baseNotification);
+    expect(parsed.subtitle).toBe('Hi');
+  });
+
   it('parses deposit due notifications', () => {
     const n: UnifiedNotification = {
       type: 'deposit_due',
@@ -138,5 +143,17 @@ describe('NotificationListItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Quote accepted by Bob Builder');
     expect(parsed.initials).toBe('BB');
+  });
+
+  it('falls back to type when content lacks quote text', () => {
+    const n: UnifiedNotification = {
+      type: 'quote_accepted',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: '',
+      sender_name: 'Sam Client',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.title).toBe('Quote accepted by Sam Client');
   });
 });


### PR DESCRIPTION
## Summary
- refine `parseItem` for messages, booking requests and quote acceptance
- adjust notification list and drawer tests

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6878ea009a94832eb3859f56bd3abc49