### PR TITLE
Fix notification layout text wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking notes are visible only on the Booking details page, appearing beneath the Venue Type line in the details box, and are hidden from chat threads and booking request screens.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles and subtitles wrap up to two lines using the `line-clamp-2` utility so full names remain visible.
+* Avatars fall back to the sender's initials when no profile photo is available, ensuring every notification has a recognizable icon.
 * The drawer now opens as a rounded panel with a dark backdrop. Badges disappear when the unread count is 0. Adjust the badge styles in `frontend/src/components/layout/NotificationListItem.tsx`.
 * Drawer panel uses a frosted-glass style with a stronger blur, drop shadow and subtle border for better contrast. The panel width is now **w-80** so content has more breathing room.
 * Filter and bulk actions now appear in a separate sub-header below the title so the close button aligns cleanly to the right.

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -18,6 +18,15 @@ export interface ParsedNotification {
   unreadCount?: number;
 }
 
+function toInitials(name?: string): string | undefined {
+  return name
+    ? name
+        .split(' ')
+        .map((w) => w[0])
+        .join('')
+    : undefined;
+}
+
 export function parseItem(n: UnifiedNotification): ParsedNotification {
   const content = typeof n.content === 'string' ? n.content : '';
   if (n.type === 'message') {
@@ -30,12 +39,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       subtitle: snippet,
       icon: '💬',
       avatarUrl: n.avatar_url || undefined,
-      initials: n.name
-        ? n.name
-            .split(' ')
-            .map((w) => w[0])
-            .join('')
-        : undefined,
+      initials: toInitials(n.name || n.sender_name),
       unreadCount,
     };
   }
@@ -80,12 +84,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       subtitle,
       icon,
       avatarUrl: n.avatar_url || undefined,
-      initials: sender
-        ? sender
-            .split(' ')
-            .map((w) => w[0])
-            .join('')
-        : undefined,
+      initials: toInitials(sender),
       bookingType: formattedType,
       metadata,
     };
@@ -116,6 +115,8 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       title: 'Deposit Due',
       subtitle,
       icon: '💰',
+      avatarUrl: n.avatar_url || undefined,
+      initials: toInitials(n.sender_name || n.name),
     };
   }
   if (/new booking/i.test(content)) {
@@ -125,6 +126,8 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       title: 'Booking Confirmed',
       subtitle,
       icon: '📅',
+      avatarUrl: n.avatar_url || undefined,
+      initials: toInitials(n.sender_name || n.name),
     };
   }
   if (n.type === 'quote_accepted' || /quote accepted/i.test(content)) {
@@ -138,12 +141,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
       subtitle,
       icon: '✅',
       avatarUrl: n.avatar_url || undefined,
-      initials: name
-        ? name
-            .split(' ')
-            .map((w) => w[0])
-            .join('')
-        : undefined,
+      initials: toInitials(name),
     };
   }
   const defaultTitle = content.length > 36 ? `${content.slice(0, 36)}...` : content;
@@ -155,6 +153,8 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     title: defaultTitle || typeTitle || 'Notification',
     subtitle: '',
     icon: '🔔',
+    avatarUrl: n.avatar_url || undefined,
+    initials: toInitials(n.sender_name || n.name),
   };
 }
 
@@ -187,7 +187,7 @@ export default function NotificationListItem({ n, onClick, style, className = ''
       <Avatar src={parsed.avatarUrl} initials={parsed.initials} icon={parsed.icon} size={44} />
       <div className="flex-1 mx-3">
         <div className="flex items-start justify-between">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
             <span className="font-semibold text-gray-900 line-clamp-2" title={parsed.title}>{parsed.title}</span>
             {parsed.unreadCount > 0 && (
               <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full">

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -156,4 +156,28 @@ describe('NotificationListItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Quote accepted by Sam Client');
   });
+
+  it('uses initials fallback for deposit due', () => {
+    const n: UnifiedNotification = {
+      type: 'deposit_due',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Deposit R100 due by 2025-06-30',
+      sender_name: 'John Doe',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.initials).toBe('JD');
+  });
+
+  it('includes initials for unknown notification types', () => {
+    const n: UnifiedNotification = {
+      type: 'weird_event',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'Something random',
+      name: 'Jane Smith',
+    } as UnifiedNotification;
+    const parsed = parseItem(n);
+    expect(parsed.initials).toBe('JS');
+  });
 });


### PR DESCRIPTION
## Summary
- tweak layout to allow wrapping titles/subtitles
- show user initials when avatar is missing
- document avatar fallback in README
- test initials for various notification cases

## Testing
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0fe7ab4832e9df9d0bccc623e8a