### PR TITLE
Improve notification card icon colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Avatars fall back to the sender's initials when no profile photo is available, ensuring every notification has a recognizable icon.
 * The drawer slides in from the right on a simple white panel with a soft shadow. Badges disappear when the unread count is 0.
 * Notification cards keep softly rounded corners and a gentle shadow. Unread items show a thin brand-colored strip on the left.
-* Each card displays a circular avatar, bold title, one-line subtitle, relative timestamp and a small status icon on the right.
+* Each card displays a circular avatar, bold title, one-line subtitle, relative timestamp and a small status icon on the right. Icons are color-coded (green for confirmed, indigo for reminders, amber for due alerts).
 * The header now just shows the “Notifications” title, an **Unread** toggle and a close **X** button.
 * A full-width rounded **Clear All** button stays pinned to the bottom of the panel.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" so clients immediately see the payment deadline. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -213,13 +213,13 @@ export default function NotificationListItem({ n, onClick, style, className = ''
         )}
       </div>
       {parsed.status === 'confirmed' && (
-        <CheckCircleIcon className="h-5 w-5 text-brand-dark" />
+        <CheckCircleIcon className="h-5 w-5 text-green-600" />
       )}
       {parsed.status === 'reminder' && (
         <CalendarIcon className="h-5 w-5 text-brand-dark" />
       )}
       {parsed.status === 'due' && (
-        <ExclamationCircleIcon className="h-5 w-5 text-brand-dark" />
+        <ExclamationCircleIcon className="h-5 w-5 text-amber-500" />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak notification card icons with color-coded status
- document colored status icons in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687902d5ef04832e9af94428ad05b608