### PR TITLE
Enhance dashboard components

### DIFF
--- a/frontend/src/components/dashboard/DashboardTabs.tsx
+++ b/frontend/src/components/dashboard/DashboardTabs.tsx
@@ -6,6 +6,8 @@ import './dashboard.css';
 interface Tab {
   id: string;
   label: string;
+  icon?: React.ReactNode;
+  count?: number;
 }
 
 interface DashboardTabsProps {
@@ -23,13 +25,19 @@ export default function DashboardTabs({ tabs, active, onChange }: DashboardTabsP
             key={tab.id}
             type="button"
             onClick={() => onChange(tab.id)}
-            className={`flex-1 px-3 py-2 ${
+            className={`flex-1 px-3 py-2 flex items-center justify-center space-x-1 ${
               active === tab.id
                 ? 'text-brand-dark border-b-2 border-brand-dark'
                 : 'text-gray-500'
             }`}
           >
-            {tab.label}
+            {tab.icon && <span className="h-4 w-4">{tab.icon}</span>}
+            <span>{tab.label}</span>
+            {tab.count && (
+              <span className="ml-1 inline-flex items-center justify-center rounded-full bg-gray-200 px-2 text-xs">
+                {tab.count}
+              </span>
+            )}
           </button>
         ))}
       </div>

--- a/frontend/src/components/dashboard/OverviewAccordion.tsx
+++ b/frontend/src/components/dashboard/OverviewAccordion.tsx
@@ -7,6 +7,7 @@ import CollapsibleSection from '../ui/CollapsibleSection';
 interface Stat {
   label: string;
   value: string | number;
+  icon?: React.ReactNode;
 }
 
 interface OverviewAccordionProps {
@@ -25,7 +26,10 @@ export default function OverviewAccordion({
       <div className="grid grid-cols-2 gap-2">
         {primaryStats.map((s) => (
           <div key={s.label} className="overview-card">
-            <span className="overview-label">{s.label}</span>
+            <span className="flex items-center space-x-1 overview-label">
+              {s.icon && <span className="h-4 w-4">{s.icon}</span>}
+              <span>{s.label}</span>
+            </span>
             <span className="overview-value">{s.value}</span>
           </div>
         ))}
@@ -40,7 +44,10 @@ export default function OverviewAccordion({
           <div className="mt-2 grid grid-cols-2 gap-2">
             {secondaryStats.map((s) => (
               <div key={s.label} className="overview-card">
-                <span className="overview-label">{s.label}</span>
+                <span className="flex items-center space-x-1 overview-label">
+                  {s.icon && <span className="h-4 w-4">{s.icon}</span>}
+                  <span>{s.label}</span>
+                </span>
                 <span className="overview-value">{s.value}</span>
               </div>
             ))}

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -9,7 +9,14 @@ export default function StatusBadge({ status, className, ...props }: StatusBadge
     Pending: 'bg-yellow-100 text-yellow-800',
     Accepted: 'bg-green-100 text-green-800',
     Rejected: 'bg-red-100 text-red-800',
-  }[status] || 'bg-gray-100 text-gray-800';
+  }[status] ||
+    (status.includes('Pending')
+      ? 'bg-yellow-100 text-yellow-800'
+      : status.includes('Confirmed') || status.includes('Accepted') || status === 'Paid'
+      ? 'bg-green-100 text-green-800'
+      : status.includes('Declined') || status.includes('Rejected') || status.includes('Withdrawn') || status === 'Cancelled'
+      ? 'bg-red-100 text-red-800'
+      : 'bg-gray-100 text-gray-800');
   return (
     <span
       {...props}


### PR DESCRIPTION
## Summary
- add optional `icon` support to OverviewAccordion
- add tab icons and counts to DashboardTabs
- colorize StatusBadge for more statuses

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a0fa1cdc0832eb106fa53ce5db7e9