### PR TITLE
Handle missing client data in dashboard

### DIFF
--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -119,9 +119,9 @@ export default function ArtistBookingsPage() {
             {bookings.map((b) => (
               <li key={b.id} className="bg-white p-4 shadow rounded-lg">
                 <div className="font-medium text-gray-900">
-                  {b.client.first_name} {b.client.last_name}
+                  {b.client?.first_name || 'Unknown'} {b.client?.last_name || ''}
                 </div>
-                <div className="text-sm text-gray-500">{b.service.title}</div>
+                <div className="text-sm text-gray-500">{b.service?.title || '—'}</div>
                 <div className="text-sm text-gray-500">
                   {format(new Date(b.start_time), 'MMM d, yyyy h:mm a')}
                 </div>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -450,10 +450,11 @@ export default function DashboardPage() {
                 renderItem={(booking) => (
                   <div key={booking.id} className="bg-white p-4 shadow rounded-lg">
                   <div className="font-medium text-gray-900">
-                    {booking.client.first_name} {booking.client.last_name}
+                    {booking.client?.first_name || 'Unknown'}{' '}
+                    {booking.client?.last_name || ''}
                   </div>
                   <div className="text-sm text-gray-500">
-                    {booking.service.title}
+                    {booking.service?.title || '—'}
                   </div>
                   <div className="text-sm text-gray-500">
                     {format(new Date(booking.start_time), 'MMM d, yyyy h:mm a')}


### PR DESCRIPTION
## Summary
- avoid runtime errors when a booking is missing client or service data
- display `Unknown` or `—` when client/service details are unavailable

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a26ad48a4832e896d9ff72c4ce692