### PR TITLE
Fix notifications paging

### DIFF
--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -172,7 +172,7 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     try {
       const res = await api.get<Notification[]>('/notifications', {
         params: {
-          offset: notifications.length,
+          skip: notifications.length,
           limit: 20,
           unreadOnly: false,
         },


### PR DESCRIPTION
## Summary
- use the correct `skip` query param when loading more notifications

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687a4e9171b8832ead088a1189356637