### PR TITLE
Ensure sender_name included with new message notifications

### DIFF
--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -15,19 +15,20 @@ logger = logging.getLogger(__name__)
 
 def _build_response(db: Session, n: models.Notification) -> schemas.NotificationResponse:
     data = schemas.NotificationResponse.model_validate(n).model_dump()
-    sender = None
-    btype = None
+    sender = data.get("sender_name")
+    btype = data.get("booking_type")
     if n.type == models.NotificationType.NEW_MESSAGE:
-        try:
-            match = re.match(r"New message from ([^:]+):", n.message)
-            if match:
-                sender = match.group(1).strip()
-        except Exception as exc:  # pragma: no cover - defensive parsing
-            logger.warning(
-                "Failed to parse sender from message '%s': %s",
-                n.message,
-                exc,
-            )
+        if not sender:
+            try:
+                match = re.match(r"New message from ([^:]+):", n.message)
+                if match:
+                    sender = match.group(1).strip()
+            except Exception as exc:  # pragma: no cover - defensive parsing
+                logger.warning(
+                    "Failed to parse sender from message '%s': %s",
+                    n.message,
+                    exc,
+                )
     elif n.type == models.NotificationType.NEW_BOOKING_REQUEST:
         try:
             request_id = int(n.link.split("/")[-1])

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -158,6 +158,7 @@ def notify_user_new_message(
         NotificationType.NEW_MESSAGE,
         message,
         f"/booking-requests/{booking_request_id}",
+        sender_name=sender_name,
     )
     logger.info("Notify %s: %s", user.email, message)
     _send_sms(user.phone_number, message)


### PR DESCRIPTION
## Summary
- include `sender_name` when broadcasting new message notifications
- gracefully read `sender_name` from notification data before regex fallback
- verify notification API exposes `sender_name` for message alerts

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687b352b1f70832e9e6909eaae6a663e