### PR TITLE
Fix message subtitle

### DIFF
--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -43,7 +43,10 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     ).trim();
     const snippet = cleaned.length > 30 ? `${cleaned.slice(0, 30)}...` : cleaned;
     const title = n.name || n.sender_name || 'Message';
-    return { ...base, title, subtitle: snippet, icon: '💬' };
+    const senderName = n.sender_name || n.name || 'Someone';
+    const subtitlePrefix = `New message from ${senderName}`;
+    const subtitle = snippet ? `${subtitlePrefix}: ${snippet}` : subtitlePrefix;
+    return { ...base, title, subtitle, icon: '💬' };
   }
 
   if (n.type === 'new_booking_request') {

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -69,7 +69,9 @@ describe('parseItem', () => {
   const parsed = parseItem(n);
   expect(parsed.title).toBe('Charlie Brown');
   expect(parsed.unreadCount).toBe(3);
-  expect(parsed.subtitle).toBe('Hello there, this is a long me...');
+  expect(parsed.subtitle).toBe(
+    'New message from Charlie Brown: Hello there, this is a long me...'
+  );
   });
 
   it('omits unread count when zero', () => {
@@ -85,7 +87,7 @@ describe('parseItem', () => {
     const parsed = parseItem(n);
     expect(parsed.title).toBe('Dana');
     expect(parsed.unreadCount).toBe(0);
-    expect(parsed.subtitle).toBe('Hi');
+    expect(parsed.subtitle).toBe('New message from Dana: Hi');
   });
 });
 

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -45,7 +45,7 @@ describe('NotificationListItem', () => {
 
   it('parses message preview from content', () => {
     const parsed = parseItem(baseNotification);
-    expect(parsed.subtitle).toBe('Hi');
+    expect(parsed.subtitle).toBe('New message from Alice: Hi');
   });
 
   it('parses deposit due notifications', () => {


### PR DESCRIPTION
## Summary
- include sender name in message subtitles
- adjust notification tests for new message subtitle prefix

## Testing
- `pytest -q --maxfail=1 --disable-warnings` *(fails: 70 passed, 532 warnings in 77.79s)*
- `npm test --silent` *(fails: 4 failed, 1 skipped, 70 passed, 74 of 75 total)*

------
https://chatgpt.com/codex/tasks/task_e_687b4d865204832eaa58a1412e7b1fb8