### PR TITLE
Add NotificationCard component

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Wrap the root layout in `<NotificationsProvider>` so badges and drawers update automatically across the app.
 * A new `parseNotification` utility maps each notification type to a friendly title, subtitle and icon. `<NotificationListItem>` consumes this data and opens the related link while marking the item read.
 * Unread notifications show a subtle brand-colored strip on the left while read cards remain plain white.
+* `NotificationCard` in `components/ui/` displays a single alert with the same soft shadowed style used in the drawer.
 * A rounded **Clear All** button is fixed at the bottom so users can dismiss everything at once.
 
 ### Artist Profile Enhancements

--- a/frontend/src/components/ui/NotificationCard.tsx
+++ b/frontend/src/components/ui/NotificationCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import clsx from 'clsx';
+import {
+  BellAlertIcon,
+  CalendarDaysIcon,
+  CheckCircleIcon,
+} from '@heroicons/react/24/outline';
+import Avatar from './Avatar';
+import TimeAgo from './TimeAgo';
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map(w => w[0])
+    .join('')
+    .toUpperCase();
+}
+
+interface NotificationCardProps {
+  /** Status type controls icon colour */
+  type: 'confirmed' | 'reminder' | 'due' | string;
+  /** Sender or source name */
+  from: string;
+  /** ISO timestamp */
+  createdAt: string | number | Date;
+  /** If true, show brand-coloured strip */
+  unread: boolean;
+  onClick: () => void;
+  avatarUrl?: string | null;
+  /** Short optional subtitle */
+  subtitle?: string;
+  /** Additional meta text */
+  metadata?: string;
+}
+
+const iconMap = {
+  confirmed: (
+    <CheckCircleIcon className="w-5 h-5 text-green-600" />
+  ),
+  reminder: (
+    <CalendarDaysIcon className="w-5 h-5 text-indigo-600" />
+  ),
+  due: (
+    <BellAlertIcon className="w-5 h-5 text-amber-500" />
+  ),
+} as const;
+
+export default function NotificationCard({
+  type,
+  from,
+  createdAt,
+  unread,
+  onClick,
+  avatarUrl,
+  subtitle,
+  metadata,
+}: NotificationCardProps) {
+  const initials = getInitials(from);
+  const icon =
+    iconMap[type as keyof typeof iconMap] || (
+      <BellAlertIcon className="w-5 h-5 text-gray-400" />
+    );
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onClick()}
+      className={clsx(
+        'flex items-center p-3 mb-2 rounded-xl cursor-pointer transition-shadow hover:shadow-lg',
+        unread
+          ? 'bg-brand-light border-l-4 border-brand shadow-md'
+          : 'bg-white shadow',
+        'hover:bg-gray-50',
+      )}
+    >
+      <Avatar src={avatarUrl} initials={initials} size={44} />
+      <div className="flex-1 mx-3">
+        <div className="flex items-start justify-between">
+          <span className="font-semibold text-gray-900 line-clamp-2" title={from}>
+            {from}
+          </span>
+          <TimeAgo timestamp={createdAt} className="text-xs text-gray-500" />
+        </div>
+        {subtitle && (
+          <p className="mt-1 text-sm text-gray-700 line-clamp-2">{subtitle}</p>
+        )}
+        {metadata && (
+          <p className="text-sm text-gray-500 truncate">{metadata}</p>
+        )}
+      </div>
+      {icon}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/__tests__/NotificationCard.test.tsx
+++ b/frontend/src/components/ui/__tests__/NotificationCard.test.tsx
@@ -1,0 +1,88 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import NotificationCard from '../NotificationCard';
+
+describe('NotificationCard', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows initials when avatar missing', () => {
+    act(() => {
+      root.render(
+        React.createElement(NotificationCard, {
+          type: 'reminder',
+          from: 'Jane Doe',
+          createdAt: new Date().toISOString(),
+          unread: true,
+          onClick: () => {},
+        }),
+      );
+    });
+    const avatar = container.querySelector('span');
+    expect(avatar?.textContent).toBe('JD');
+  });
+
+  it('applies unread styling', () => {
+    act(() => {
+      root.render(
+        React.createElement(NotificationCard, {
+          type: 'confirmed',
+          from: 'John',
+          createdAt: new Date().toISOString(),
+          unread: true,
+          onClick: () => {},
+        }),
+      );
+    });
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('border-brand');
+  });
+
+  it('fires onClick when clicked', () => {
+    const onClick = jest.fn();
+    act(() => {
+      root.render(
+        React.createElement(NotificationCard, {
+          type: 'due',
+          from: 'Bob',
+          createdAt: new Date().toISOString(),
+          unread: false,
+          onClick,
+        }),
+      );
+    });
+    const card = container.firstChild as HTMLElement;
+    card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('uses color coded icon for status', () => {
+    act(() => {
+      root.render(
+        React.createElement(NotificationCard, {
+          type: 'confirmed',
+          from: 'Status',
+          createdAt: new Date().toISOString(),
+          unread: false,
+          onClick: () => {},
+        }),
+      );
+    });
+    const icon = container.querySelector('svg.text-green-600');
+    expect(icon).not.toBeNull();
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -19,3 +19,4 @@ export { default as PillButton } from './PillButton';
 export { default as Avatar } from './Avatar';
 export { default as IconButton } from './IconButton';
 export { default as ToggleSwitch } from './ToggleSwitch';
+export { default as NotificationCard } from './NotificationCard';


### PR DESCRIPTION
## Summary
- create `NotificationCard` component for notifications
- export new UI component
- document `NotificationCard` usage
- add tests for `NotificationCard`

## Testing
- `npx jest src/components/ui/__tests__/NotificationCard.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687b55cf1c5c832eb164be68eff65774