### PR TITLE
Add notification display helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * A new `parseNotification` utility maps each notification type to a friendly title, subtitle and icon. `<NotificationListItem>` consumes this data and opens the related link while marking the item read.
 * Unread notifications show a subtle brand-colored strip on the left while read cards remain plain white.
 * `NotificationCard` in `components/ui/` displays a single alert with the same soft shadowed style used in the drawer.
+* `getNotificationDisplayProps` converts a `Notification` or unified feed item into the props required by `NotificationCard`.
 * A rounded **Clear All** button is fixed at the bottom so users can dismiss everything at once.
 
 ### Artist Profile Enhancements

--- a/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
+++ b/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
@@ -1,0 +1,79 @@
+import getNotificationDisplayProps from '../getNotificationDisplayProps';
+import type { Notification, UnifiedNotification } from '@/types';
+
+describe('getNotificationDisplayProps', () => {
+  const assignSpy = jest.spyOn(window.location, 'assign').mockImplementation(() => {});
+
+  afterEach(() => {
+    assignSpy.mockClear();
+  });
+
+  it('maps new message notification', () => {
+    const n: Notification = {
+      id: 1,
+      user_id: 1,
+      type: 'new_message',
+      message: 'New message from Bob: Hi there',
+      link: '/messages/thread/1',
+      is_read: false,
+      timestamp: '2025-01-01T00:00:00Z',
+      sender_name: 'Bob',
+    };
+    const props = getNotificationDisplayProps(n);
+    expect(props.type).toBe('reminder');
+    expect(props.from).toBe('Bob');
+    expect(props.subtitle).toContain('Hi there');
+    props.onClick();
+    expect(assignSpy).toHaveBeenCalledWith('/messages/thread/1');
+  });
+
+  it('maps deposit due unified notification', () => {
+    const n: UnifiedNotification = {
+      type: 'deposit_due',
+      timestamp: '2025-01-02T00:00:00Z',
+      is_read: false,
+      content: 'Deposit R50 due by 2025-01-10',
+      link: '/dashboard/client/bookings/5',
+    } as UnifiedNotification;
+    const props = getNotificationDisplayProps(n);
+    expect(props.type).toBe('due');
+    expect(props.from).toBe('Deposit Due');
+    expect(props.subtitle).toContain('R50');
+    props.onClick();
+    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/5');
+  });
+
+  it('builds booking request display props', () => {
+    const n: Notification = {
+      id: 2,
+      user_id: 1,
+      type: 'new_booking_request',
+      message: 'Request',
+      link: '/requests/2',
+      is_read: false,
+      timestamp: '2025-01-03T00:00:00Z',
+      sender_name: 'Alice',
+      booking_type: 'Acoustic Performance',
+    };
+    const props = getNotificationDisplayProps(n);
+    expect(props.type).toBe('reminder');
+    expect(props.from).toBe('Alice');
+    expect(props.subtitle).toBe('Acoustic Performance');
+    props.onClick();
+    expect(assignSpy).toHaveBeenCalledWith('/requests/2');
+  });
+
+  it('handles review request link mapping', () => {
+    const n: UnifiedNotification = {
+      type: 'review_request',
+      timestamp: '2025-01-04T00:00:00Z',
+      is_read: false,
+      content: 'Please review',
+      link: '/dashboard/client/bookings/7?review=1',
+    } as UnifiedNotification;
+    const props = getNotificationDisplayProps(n);
+    expect(props.type).toBe('reminder');
+    props.onClick();
+    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/7');
+  });
+});

--- a/frontend/src/hooks/getNotificationDisplayProps.ts
+++ b/frontend/src/hooks/getNotificationDisplayProps.ts
@@ -1,0 +1,44 @@
+import type { ComponentProps } from 'react';
+import NotificationCard from '@/components/ui/NotificationCard';
+import { parseItem } from '@/components/layout/NotificationListItem';
+import { toUnifiedFromNotification } from './notificationUtils';
+import type { Notification, UnifiedNotification } from '@/types';
+
+export type NotificationCardProps = ComponentProps<typeof NotificationCard>;
+
+/**
+ * Convert a Notification or UnifiedNotification into NotificationCard props.
+ * Provides a click handler that navigates to the related link using
+ * `window.location.assign`.
+ */
+export default function getNotificationDisplayProps(
+  n: Notification | UnifiedNotification,
+): NotificationCardProps {
+  const unified: UnifiedNotification = 'content' in n ? n : toUnifiedFromNotification(n);
+  const parsed = parseItem(unified);
+  const link =
+    unified.type === 'message' && unified.booking_request_id
+      ? `/messages/thread/${unified.booking_request_id}`
+      : unified.type === 'review_request' && unified.link
+        ? `/dashboard/client/bookings/${unified.link.match(/bookings\/(\d+)/)?.[1] ?? ''}`
+        : unified.link;
+
+  const onClick = () => {
+    if (link) {
+      window.location.assign(link);
+    }
+  };
+
+  return {
+    type: parsed.status ?? 'reminder',
+    from: parsed.title,
+    subtitle: parsed.subtitle,
+    metadata: parsed.metadata,
+    avatarUrl: parsed.avatarUrl ?? null,
+    createdAt: unified.timestamp,
+    unread: unified.type === 'message'
+      ? (unified.unread_count ?? 0) > 0
+      : !unified.is_read,
+    onClick,
+  };
+}


### PR DESCRIPTION
## Summary
- add `getNotificationDisplayProps` to convert notifications to `NotificationCard` props
- test the new helper
- document the helper in README

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687b5c09bca0832e8b6f781019c76bdc