### PR TITLE
Fix new message notification link

### DIFF
--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -24,7 +24,7 @@ def _build_response(db: Session, n: models.Notification) -> schemas.Notification
                 if match:
                     sender = match.group(1).strip()
                 else:
-                    br_match = re.search(r"/booking-requests/(\d+)", n.link)
+                    br_match = re.search(r"/(?:booking-requests|messages/thread)/(\d+)", n.link)
                     if br_match:
                         br_id = int(br_match.group(1))
                         br = (

--- a/backend/app/crud/crud_notification.py
+++ b/backend/app/crud/crud_notification.py
@@ -161,7 +161,7 @@ def mark_thread_read(db: Session, user_id: int, booking_request_id: int) -> None
         .filter(
             models.Notification.user_id == user_id,
             models.Notification.type == models.NotificationType.NEW_MESSAGE,
-            models.Notification.link == f"/booking-requests/{booking_request_id}",
+            models.Notification.link == f"/messages/thread/{booking_request_id}",
             models.Notification.is_read == False,
         )
         .all()

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -157,7 +157,7 @@ def notify_user_new_message(
         user.id,
         NotificationType.NEW_MESSAGE,
         message,
-        f"/booking-requests/{booking_request_id}",
+        f"/messages/thread/{booking_request_id}",
         sender_name=sender_name,
     )
     logger.info("Notify %s: %s", user.email, message)

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -103,7 +103,7 @@ def test_message_creates_notification():
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
     assert notifs[0].type.value == "new_message"
-    assert notifs[0].link == f"/booking-requests/{br.id}"
+    assert notifs[0].link == f"/messages/thread/{br.id}"
 
 
 def test_system_booking_summary_message_suppressed():
@@ -738,7 +738,7 @@ def test_new_message_notification_fallback_client_name():
         user_id=artist.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/booking-requests/{br.id}",
+        link=f"/messages/thread/{br.id}",
     )
     db.close()
 
@@ -795,7 +795,7 @@ def test_new_message_notification_fallback_business_name():
         user_id=client_user.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/booking-requests/{br.id}",
+        link=f"/messages/thread/{br.id}",
     )
     db.close()
 


### PR DESCRIPTION
## Summary
- update notification URLs for new messages
- adjust regex parsing in notification API
- mark message threads as read using the new URL
- update tests for the new message thread path

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt after backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b83044248832e8713b8911a783b98