### PR TITLE
Refactor notification link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" only the first time a booking is confirmed. Subsequent reminders omit the greeting. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
 * Message notifications now include the sender name in both the stored text and the API response so the drawer can display "New message from Alice" without additional lookups.
-* Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}` so clients can quickly rate their experience.
+* Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can immediately leave feedback.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read.
 * Day divider lines show the full date, while relative times remain visible next to each message group.
 * Booking request notifications display the sender name as the title and the service type in the subtitle with contextual icons. Service names are converted from `PascalCase` or `snake_case` and truncated for readability. The `/api/v1/notifications` endpoint now includes `sender_name` and `booking_type` fields so the frontend no longer parses them from the message string.

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -73,13 +73,7 @@ export default function FullScreenNotificationModal({
     if (!item) return;
     await onItemClick(id);
 
-    if (item.type === 'message' && item.booking_request_id) {
-      router.push(`/messages/thread/${item.booking_request_id}`);
-    } else if (item.type === 'review_request' && item.link) {
-      const match = item.link.match(/bookings\/(\d+)/);
-      const bid = match ? match[1] : '';
-      router.push(`/dashboard/client/bookings/${bid}`);
-    } else if (item.link) {
+    if (item.link) {
       router.push(item.link);
     }
   };

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -59,13 +59,7 @@ export default function NotificationBell(): JSX.Element {
       await markItem(item);
     }
     setOpen(false);
-    if (item.type === 'message' && item.booking_request_id) {
-      router.push(`/messages/thread/${item.booking_request_id}`);
-    } else if (item.type === 'review_request' && item.link) {
-      const match = item.link.match(/bookings\/(\d+)/);
-      const bid = match ? match[1] : '';
-      router.push(`/dashboard/client/bookings/${bid}`);
-    } else if (item.link) {
+    if (item.link) {
       router.push(item.link);
     } else {
       console.warn('Notification missing link', item);

--- a/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
+++ b/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
@@ -33,14 +33,14 @@ describe('getNotificationDisplayProps', () => {
       timestamp: '2025-01-02T00:00:00Z',
       is_read: false,
       content: 'Deposit R50 due by 2025-01-10',
-      link: '/dashboard/client/bookings/5',
+      link: '/dashboard/client/bookings/5?pay=1',
     } as UnifiedNotification;
     const props = getNotificationDisplayProps(n);
     expect(props.type).toBe('due');
     expect(props.from).toBe('Deposit Due');
     expect(props.subtitle).toContain('R50');
     props.onClick();
-    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/5');
+    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/5?pay=1');
   });
 
   it('builds booking request display props', () => {
@@ -74,6 +74,6 @@ describe('getNotificationDisplayProps', () => {
     const props = getNotificationDisplayProps(n);
     expect(props.type).toBe('reminder');
     props.onClick();
-    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/7');
+    expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/7?review=1');
   });
 });

--- a/frontend/src/hooks/getNotificationDisplayProps.ts
+++ b/frontend/src/hooks/getNotificationDisplayProps.ts
@@ -16,12 +16,7 @@ export default function getNotificationDisplayProps(
 ): NotificationCardProps {
   const unified: UnifiedNotification = 'content' in n ? n : toUnifiedFromNotification(n);
   const parsed = parseItem(unified);
-  const link =
-    unified.type === 'message' && unified.booking_request_id
-      ? `/messages/thread/${unified.booking_request_id}`
-      : unified.type === 'review_request' && unified.link
-        ? `/dashboard/client/bookings/${unified.link.match(/bookings\/(\d+)/)?.[1] ?? ''}`
-        : unified.link;
+  const link = unified.link;
 
   const onClick = () => {
     if (link) {


### PR DESCRIPTION
## Summary
- use notification.link for all navigation
- simplify notification click handlers
- update notification display helper and tests
- document REVIEW_REQUEST link query string

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687b87d40ab8832ea2e5ae25f01a2b97