### PR TITLE
Add client profile picture upload

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3853,6 +3853,54 @@
         ]
       }
     },
+    "/api/v1/users/me/profile-picture": {
+      "post": {
+        "tags": [
+          "users",
+          "users"
+        ],
+        "summary": "Upload or update current user's profile picture",
+        "description": "Uploads a new profile picture for the currently authenticated user, replacing any existing one.",
+        "operationId": "upload_profile_picture_me_api_v1_users_me_profile_picture_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_profile_picture_me_api_v1_users_me_profile_picture_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/users/me": {
       "delete": {
         "tags": [
@@ -4664,6 +4712,20 @@
           "file"
         ],
         "title": "Body_upload_booking_attachment_api_v1_booking_requests_attachments_post"
+      },
+      "Body_upload_profile_picture_me_api_v1_users_me_profile_picture_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_profile_picture_me_api_v1_users_me_profile_picture_post"
       },
       "BookingCreate": {
         "properties": {
@@ -5783,6 +5845,17 @@
               }
             ],
             "title": "Booking Type"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
           }
         },
         "type": "object",
@@ -7207,6 +7280,17 @@
           "mfa_enabled": {
             "type": "boolean",
             "title": "Mfa Enabled"
+          },
+          "profile_picture_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Picture Url"
           }
         },
         "type": "object",

--- a/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
+++ b/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
@@ -1,0 +1,51 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import ProfilePicturePage from '../profile-picture';
+import { uploadMyProfilePicture } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MainLayout';
+  return Mock;
+});
+jest.mock('@/components/ui/Button', () => {
+  const Btn = (props: Record<string, unknown>) => <button {...props} />;
+  Btn.displayName = 'Button';
+  return Btn;
+});
+
+describe('ProfilePicturePage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploads file and refreshes user', async () => {
+    const refreshUser = jest.fn();
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' }, refreshUser });
+    (uploadMyProfilePicture as jest.Mock).mockResolvedValue({ data: {} });
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<ProfilePicturePage />);
+    });
+    const input = div.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['1'], 'a.jpg', { type: 'image/jpeg' });
+    await act(async () => {
+      Object.defineProperty(input, 'files', { value: [file], configurable: true });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    const form = div.querySelector('form');
+    await act(async () => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await act(async () => { await Promise.resolve(); });
+    expect(uploadMyProfilePicture).toHaveBeenCalled();
+    expect(refreshUser).toHaveBeenCalled();
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+});

--- a/frontend/src/app/account/profile-picture.tsx
+++ b/frontend/src/app/account/profile-picture.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import MainLayout from '@/components/layout/MainLayout';
+import Button from '@/components/ui/Button';
+import { uploadMyProfilePicture } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { getFullImageUrl } from '@/lib/utils';
+
+export default function ProfilePicturePage() {
+  const { user, refreshUser } = useAuth();
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError(null);
+    setSuccess(null);
+    const f = e.target.files?.[0] || null;
+    if (!f) return;
+    setFile(f);
+    setPreview(URL.createObjectURL(f));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    if (!file) {
+      setError('Please choose an image.');
+      return;
+    }
+    setUploading(true);
+    try {
+      await uploadMyProfilePicture(file);
+      setSuccess('Profile picture uploaded!');
+      await refreshUser?.();
+      setFile(null);
+    } catch (err: unknown) {
+      console.error('Failed to upload profile picture:', err);
+      const msg = err instanceof Error ? err.message : 'Upload failed';
+      setError(msg);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const currentUrl = user?.profile_picture_url
+    ? (getFullImageUrl(user.profile_picture_url) as string)
+    : null;
+
+  return (
+    <MainLayout>
+      <div className="mx-auto max-w-sm py-10 space-y-4">
+        <h1 className="text-2xl font-bold">Profile Picture</h1>
+        {preview ? (
+          <img
+            src={preview}
+            alt="Preview"
+            className="w-32 h-32 object-cover rounded-full"
+          />
+        ) : currentUrl ? (
+          <img
+            src={currentUrl}
+            alt="Current profile"
+            className="w-32 h-32 object-cover rounded-full"
+          />
+        ) : null}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleChange}
+            data-testid="file-input"
+          />
+          {error && <p className="text-red-600">{error}</p>}
+          {success && <p className="text-green-700">{success}</p>}
+          <Button type="submit" disabled={uploading} isLoading={uploading}>
+            Upload
+          </Button>
+        </form>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -32,6 +32,7 @@ interface AuthContextType {
   disableMfa: (code: string) => Promise<void>;
   register: (data: Partial<User>) => Promise<void>;
   logout: () => void;
+  refreshUser?: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -148,6 +149,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser((prev) => (prev ? { ...prev, mfa_enabled: false } : prev));
   };
 
+  const refreshUser = async () => {
+    try {
+      const res = await getCurrentUser();
+      setUser(res.data);
+      localStorage.setItem('user', JSON.stringify(res.data));
+    } catch (err) {
+      console.error('Failed to refresh user:', err);
+    }
+  };
+
   const register = async (data: Partial<User>) => {
     try {
       const response = await apiRegister(data);
@@ -183,6 +194,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         disableMfa,
         register,
         logout,
+        refreshUser,
       }}
     >
       {children}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -179,6 +179,14 @@ export const uploadMyArtistCoverPhoto = (file: File) => {
   );
 };
 
+export const uploadMyProfilePicture = (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return api.post<User>(`${API_V1}/users/me/profile-picture`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+};
+
 export const uploadMyArtistPortfolioImages = (files: File[]) => {
   const formData = new FormData();
   files.forEach((f) => formData.append('files', f));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface User {
   is_active: boolean;
   is_verified: boolean;
   mfa_enabled?: boolean;
+  profile_picture_url?: string | null;
 }
 
 export interface ArtistProfile {


### PR DESCRIPTION
## Summary
- allow uploading profile picture via `/api/v1/users/me/profile-picture`
- expose a `refreshUser` helper from `AuthContext`
- add page for clients to upload a profile picture
- update frontend types and API helpers
- regenerate OpenAPI spec

## Testing
- `pytest backend/tests/test_message_flow.py -k avatar_url_for_artist -q`
- *(tests attempted but environment had issues running full suite)*

------
https://chatgpt.com/codex/tasks/task_e_687c9fae4440832e93b2d915e8928a15