### PR TITLE
Add account section and notification avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 - Quote modal items can now be removed even when only one item is present.
 - Clients can upload a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
+- The user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/app/account/__tests__/AccountPage.test.tsx
+++ b/frontend/src/app/account/__tests__/AccountPage.test.tsx
@@ -1,0 +1,31 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import AccountPage from '../page';
+
+jest.mock('@/components/layout/MainLayout', () => {
+  const Mock = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Mock.displayName = 'MainLayout';
+  return Mock;
+});
+
+describe('AccountPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders links to account actions', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<AccountPage />);
+    });
+    expect(div.textContent).toContain('Update Profile Picture');
+    expect(div.textContent).toContain('Export Account Data');
+    expect(div.textContent).toContain('Delete Account');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import MainLayout from '@/components/layout/MainLayout';
+import Link from 'next/link';
+
+export default function AccountPage() {
+  return (
+    <MainLayout>
+      <div className="mx-auto max-w-sm py-10 space-y-4">
+        <h1 className="text-2xl font-bold">Account</h1>
+        <ul className="space-y-2 list-disc list-inside">
+          <li>
+            <Link href="/account/profile-picture" className="text-indigo-700 underline">
+              Update Profile Picture
+            </Link>
+          </li>
+          <li>
+            <Link href="/account/export" className="text-indigo-700 underline">
+              Export Account Data
+            </Link>
+          </li>
+          <li>
+            <Link href="/account/delete" className="text-indigo-700 underline">
+              Delete Account
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -178,6 +178,19 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                           )}
                           <Menu.Item>
                             {({ active }) => (
+                              <Link
+                                href="/account"
+                                className={classNames(
+                                  active ? 'bg-gray-100' : '',
+                                  'block px-4 py-2 text-sm text-gray-700'
+                                )}
+                              >
+                                Account
+                              </Link>
+                            )}
+                          </Menu.Item>
+                          <Menu.Item>
+                            {({ active }) => (
                               <button
                                 onClick={logout}
                                 className={classNames(

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -140,6 +140,13 @@ export default function MobileMenuDrawer({
                     My Quotes
                   </Link>
                 )}
+                <Link
+                  href="/account"
+                  onClick={onClose}
+                  className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                >
+                  Account
+                </Link>
                 <button
                   type="button"
                   onClick={() => {

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -54,6 +54,7 @@ describe('MainLayout user menu', () => {
     });
     await act(async () => { await Promise.resolve(); });
     expect(div.textContent).toContain('My Bookings');
+    expect(div.textContent).toContain('Account');
     act(() => { root.unmount(); });
     div.remove();
   });

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -116,5 +116,6 @@ describe('MobileMenuDrawer', () => {
     });
     const body = document.body.textContent || '';
     expect(body).toContain('My Bookings');
+    expect(body).toContain('Account');
   });
 });

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -263,4 +263,28 @@ describe('NotificationListItem', () => {
     const icon = container.querySelector('svg.text-amber-500');
     expect(icon).not.toBeNull();
   });
+
+  it('passes avatarUrl to Avatar component', () => {
+    const n: UnifiedNotification = {
+      type: 'message',
+      timestamp: new Date().toISOString(),
+      is_read: false,
+      content: 'New message from Ana: hi',
+      booking_request_id: 8,
+      name: 'Ana',
+      avatar_url: '/static/avatar.jpg',
+    } as UnifiedNotification;
+
+    act(() => {
+      root.render(
+        React.createElement(NotificationListItem, {
+          n,
+          onClick: () => {},
+        }),
+      );
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toContain('/static/avatar.jpg');
+  });
 });

--- a/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
+++ b/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
@@ -76,4 +76,20 @@ describe('getNotificationDisplayProps', () => {
     props.onClick();
     expect(assignSpy).toHaveBeenCalledWith('/dashboard/client/bookings/7?review=1');
   });
+
+  it('includes avatarUrl when provided', () => {
+    const n: Notification = {
+      id: 3,
+      user_id: 1,
+      type: 'new_message',
+      message: 'New message from Ava: hi',
+      link: '/messages/thread/3',
+      is_read: false,
+      timestamp: '2025-01-05T00:00:00Z',
+      sender_name: 'Ava',
+      avatar_url: '/static/pic.jpg',
+    };
+    const props = getNotificationDisplayProps(n);
+    expect(props.avatarUrl).toBe('/static/pic.jpg');
+  });
 });

--- a/frontend/src/hooks/notificationUtils.ts
+++ b/frontend/src/hooks/notificationUtils.ts
@@ -60,6 +60,7 @@ export function toUnifiedFromNotification(n: Notification): UnifiedNotification 
     id: n.id,
     sender_name: n.sender_name,
     booking_type: n.booking_type,
+    avatar_url: n.avatar_url,
   };
 }
 


### PR DESCRIPTION
## Summary
- allow passing avatar_url through notificationUtils
- add dedicated account page and tests
- expose "Account" link in user menus
- update notification and account tests
- document new account page in README

## Testing
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687caa5f9ea0832eae70c3519c286860