### PR TITLE
Add cropping to account profile picture upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 - Quote modal items can now be removed even when only one item is present.
-- Clients can upload a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
+- Clients can upload and crop a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
 - The user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).

--- a/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
+++ b/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
@@ -5,6 +5,19 @@ import ProfilePicturePage from '../profile-picture';
 import { uploadMyProfilePicture } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 
+jest.mock('@/lib/imageCrop', () => ({
+  getCroppedImage: jest.fn(() =>
+    Promise.resolve(new File(['c'], 'c.jpg', { type: 'image/jpeg' })),
+  ),
+  centerAspectCrop: jest.fn(() => ({
+    unit: '%',
+    width: 90,
+    x: 0,
+    y: 0,
+    height: 90,
+  })),
+}));
+
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
 jest.mock('@/components/layout/MainLayout', () => {
@@ -38,9 +51,9 @@ describe('ProfilePicturePage', () => {
       Object.defineProperty(input, 'files', { value: [file], configurable: true });
       input.dispatchEvent(new Event('change', { bubbles: true }));
     });
-    const form = div.querySelector('form');
+    const btn = div.querySelector('[data-testid="crop-submit"]') as HTMLButtonElement;
     await act(async () => {
-      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      btn.dispatchEvent(new Event('click', { bubbles: true }));
     });
     await act(async () => { await Promise.resolve(); });
     expect(uploadMyProfilePicture).toHaveBeenCalled();

--- a/frontend/src/lib/imageCrop.ts
+++ b/frontend/src/lib/imageCrop.ts
@@ -1,0 +1,70 @@
+import { centerCrop, makeAspectCrop, type Crop, type PixelCrop } from 'react-image-crop';
+
+export function centerAspectCrop(mediaWidth: number, mediaHeight: number, aspect: number): Crop {
+  return centerCrop(
+    makeAspectCrop(
+      {
+        unit: '%',
+        width: 90,
+      },
+      aspect,
+      mediaWidth,
+      mediaHeight,
+    ),
+    mediaWidth,
+    mediaHeight,
+  );
+}
+
+export async function getCroppedImage(
+  imageSrc: string,
+  pixelCrop: PixelCrop,
+  fileName: string,
+  outputWidth: number = 300,
+  outputHeight: number = 300,
+): Promise<File | null> {
+  const image = new Image();
+  image.src = imageSrc;
+  await new Promise((resolve, reject) => {
+    image.onload = resolve;
+    image.onerror = reject;
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = outputWidth;
+  canvas.height = outputHeight;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx || pixelCrop.width === 0 || pixelCrop.height === 0) {
+    console.error('Failed to get 2D context or crop dims are zero.');
+    return null;
+  }
+
+  ctx.drawImage(
+    image,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    outputWidth,
+    outputHeight,
+  );
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        console.error('Canvas is empty or failed to create blob.');
+        resolve(null);
+        return;
+      }
+      const nameParts = fileName.split('.');
+      if (nameParts.length > 1) nameParts.pop();
+      const baseName = nameParts.join('.') || 'cropped_image';
+      const finalFileName = `${baseName}.jpg`;
+      const file = new File([blob], finalFileName, { type: 'image/jpeg' });
+      resolve(file);
+    }, 'image/jpeg', 0.85);
+  });
+}


### PR DESCRIPTION
## Summary
- allow clients to crop their profile picture before uploading
- extract shared image crop helpers
- update account profile picture tests
- document cropping feature in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_687caf500020832eb435f734e373e629