### PR TITLE
Ensure avatar uses profile picture across UI

### DIFF
--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 import MainLayout from '@/components/layout/MainLayout';
 import useNotifications from '@/hooks/useNotifications';
-import { Spinner } from '@/components/ui';
+import { Spinner, Avatar } from '@/components/ui';
 
 
 interface BookingPreview {
@@ -129,9 +129,7 @@ export default function InboxPage() {
             onKeyPress={() => handleClick(t.booking_request_id)}
             className="flex items-center space-x-3 px-4 py-3 border-b cursor-pointer hover:bg-gray-50 active:bg-gray-100"
           >
-            <div className="w-10 h-10 rounded-full bg-indigo-100 text-indigo-700 flex items-center justify-center font-bold text-sm">
-              {initials}
-            </div>
+            <Avatar src={t.avatar_url || null} initials={initials} size={40} />
             <div className="flex-1 overflow-hidden">
               <div className="flex items-center gap-2">
                 <div className="font-medium text-sm">{t.name}</div>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -11,7 +11,7 @@ import NotificationBell from './NotificationBell';
 import BookingRequestIcon from './BookingRequestIcon';
 import MobileMenuDrawer from './MobileMenuDrawer';
 import MobileBottomNav from './MobileBottomNav';
-import { HelpPrompt } from '../ui';
+import { HelpPrompt, Avatar } from '../ui';
 
 const baseNavigation = [
   { name: 'Home', href: '/' },
@@ -71,11 +71,11 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                       <div>
                         <Menu.Button className="flex rounded-full bg-background text-sm focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2">
                           <span className="sr-only">Open user menu</span>
-                          <div className="h-8 w-8 rounded-full bg-brand-light flex items-center justify-center">
-                            <span className="text-brand-dark font-medium">
-                              {user.first_name?.[0] || user.email[0]}
-                            </span>
-                          </div>
+                          <Avatar
+                            src={user.profile_picture_url || null}
+                            initials={user.first_name?.[0] || user.email[0]}
+                            size={32}
+                          />
                         </Menu.Button>
                       </div>
                       <Transition


### PR DESCRIPTION
## Summary
- show profile picture in MainLayout dropdown
- display thread avatars in Inbox list

## Testing
- `./scripts/test-all.sh` *(75 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ce7cc9b04832e8729fa989a89af98