### PR TITLE
Ensure avatars show in message notifications

### DIFF
--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -141,6 +141,7 @@ def notify_user_new_message(
             return
 
     sender_name = f"{sender.first_name} {sender.last_name}"
+    avatar_url = None
     if sender.user_type == models.UserType.ARTIST:
         profile = (
             db.query(models.ArtistProfile)
@@ -149,6 +150,11 @@ def notify_user_new_message(
         )
         if profile and profile.business_name:
             sender_name = profile.business_name
+        if profile and profile.profile_picture_url:
+            avatar_url = profile.profile_picture_url
+    
+    elif sender.profile_picture_url:
+        avatar_url = sender.profile_picture_url
 
     message = format_notification_message(
         NotificationType.NEW_MESSAGE,
@@ -162,6 +168,7 @@ def notify_user_new_message(
         message,
         f"/messages/thread/{booking_request_id}",
         sender_name=sender_name,
+        avatar_url=avatar_url,
     )
     logger.info("Notify %s: %s", user.email, message)
     _send_sms(user.phone_number, message)

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -707,6 +707,7 @@ def test_notifications_endpoint_returns_sender_name():
         first_name="C",
         last_name="User",
         user_type=UserType.CLIENT,
+        profile_picture_url="/static/profile_pics/client.jpg",
     )
     db.add_all([artist, client_user])
     db.commit()
@@ -742,6 +743,7 @@ def test_notifications_endpoint_returns_sender_name():
     data = res.json()
     assert len(data) == 1
     assert data[0]["sender_name"] == "C User"
+    assert data[0]["avatar_url"] == "/static/profile_pics/client.jpg"
     app.dependency_overrides.clear()
 
 


### PR DESCRIPTION
## Summary
- include `avatar_url` when broadcasting new message notifications
- always parse avatar from booking request link when fetching notifications
- test avatar URL is returned for new message notifications

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt after completion with 77 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687d4b25b760832e8f92e8a395a0a74e