### PR TITLE
Restrict account link to clients only

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 - Quote modal items can now be removed even when only one item is present.
 - Clients can upload and crop a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
-- The user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
+- The client user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
 - Artist profile picture uploads now update the account avatar so the image persists after logout and page refreshes. When logged in as an artist, the profile picture from **Edit Profile** is shown across the site, including the top navigation menu.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -176,19 +176,21 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
                               )}
                             </Menu.Item>
                           )}
-                          <Menu.Item>
-                            {({ active }) => (
-                              <Link
-                                href="/account"
-                                className={classNames(
-                                  active ? 'bg-gray-100' : '',
-                                  'block px-4 py-2 text-sm text-gray-700'
-                                )}
-                              >
-                                Account
-                              </Link>
-                            )}
-                          </Menu.Item>
+                          {user && user.user_type === 'client' && (
+                            <Menu.Item>
+                              {({ active }) => (
+                                <Link
+                                  href="/account"
+                                  className={classNames(
+                                    active ? 'bg-gray-100' : '',
+                                    'block px-4 py-2 text-sm text-gray-700'
+                                  )}
+                                >
+                                  Account
+                                </Link>
+                              )}
+                            </Menu.Item>
+                          )}
                           <Menu.Item>
                             {({ active }) => (
                               <button

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -140,13 +140,15 @@ export default function MobileMenuDrawer({
                     My Quotes
                   </Link>
                 )}
-                <Link
-                  href="/account"
-                  onClick={onClose}
-                  className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                >
-                  Account
-                </Link>
+                {user.user_type === 'client' && (
+                  <Link
+                    href="/account"
+                    onClick={onClose}
+                    className="block px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                  >
+                    Account
+                  </Link>
+                )}
                 <button
                   type="button"
                   onClick={() => {

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -34,6 +34,7 @@ describe('MainLayout user menu', () => {
     await act(async () => { await Promise.resolve(); });
     expect(div.textContent).toContain('Quotes');
     expect(div.textContent).toContain('Quote Templates');
+    expect(div.textContent).not.toContain('Account');
     act(() => { root.unmount(); });
     div.remove();
   });

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -96,6 +96,7 @@ describe('MobileMenuDrawer', () => {
     expect(body).toContain('Sound Providers');
     expect(body).toContain('Quote Calculator');
     expect(body).toContain('Quote Templates');
+    expect(body).not.toContain('Account');
   });
 
   it('shows My Bookings link for clients', async () => {


### PR DESCRIPTION
## Summary
- hide account link for artist users
- update tests for layout changes
- clarify README entry about account link

## Testing
- `npm run lint` *(fails: unexpected any, unused vars, etc.)*
- `./scripts/test-all.sh` *(failed: KeyboardInterrupt during backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_687de5ae7d34832e88dea95a780aae6e