### PR TITLE
Implement FilterBar apply handler

### DIFF
--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -34,6 +34,11 @@ export default function FilterBar({
   const [sheetOpen, setSheetOpen] = useState(false);
   const isMobile = useIsMobile();
 
+  const handleApply = () => {
+    onApply?.();
+    setSheetOpen(false);
+  };
+
   const handleCategory = (c: string) => {
     setSelectedCategory((prev) => (prev === c ? undefined : c));
     onCategory?.(c);
@@ -67,7 +72,7 @@ export default function FilterBar({
             sort={sort}
             onSort={onSort}
             onClear={clearAll}
-            onApply={onApply ?? (() => {})}
+            onApply={handleApply}
           />
         </>
       ) : (

--- a/frontend/src/components/artist/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterBar.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@/hooks/useIsMobile');
 describe('FilterBar component', () => {
   const categories = ['A', 'B', 'C', 'D'];
 
-  function renderBar() {
+  function renderBar(props: Partial<React.ComponentProps<typeof FilterBar>> = {}) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -24,6 +24,7 @@ describe('FilterBar component', () => {
           onSort={() => {}}
           onApply={() => {}}
           filtersActive={false}
+          {...props}
         />,
       );
     });
@@ -54,6 +55,32 @@ describe('FilterBar component', () => {
     const { container, root } = renderBar();
     const btn = container.querySelector('button');
     expect(btn?.textContent).toContain('Filters');
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('applies filters and calls onApply on mobile', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(true);
+    const onApply = jest.fn();
+    const onCategory = jest.fn();
+    const { container, root } = renderBar({ onApply, onCategory });
+    const btn = container.querySelector('button') as HTMLElement;
+    act(() => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const firstCheck = document.querySelector('input[type="checkbox"]') as HTMLElement;
+    act(() => {
+      firstCheck.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const applyBtn = Array.from(document.querySelectorAll('button')).find(
+      (el) => el.textContent === 'Apply filters',
+    ) as HTMLElement;
+    act(() => {
+      applyBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onCategory).toHaveBeenCalledWith(categories[0]);
+    expect(onApply).toHaveBeenCalled();
+    expect(document.activeElement).toBe(btn);
     act(() => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary
- update FilterBar to close the sheet and trigger a callback
- add mobile apply-filters test

## Testing
- `pytest -q`
- `npm test -- -u` *(fails: Test Suites: 7 failed, 1 skipped, 71 passed, 78 of 79 total)*

------
https://chatgpt.com/codex/tasks/task_e_687e0854a38c832eafa60303f2b0b902