### PR TITLE
Add sticky filter bar on artists page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -103,7 +103,9 @@ consistent sizing and accessibility. Each artist card displays a skeleton placeh
 loads and reveals a **Book Now** overlay button when hovered.
 The filter bar itself is built from the `FilterBar` component which combines these pills with
 location, sort and verification inputs. Pills scroll horizontally on overflow and the entire bar
-uses a softly rounded container for a polished look.
+uses a softly rounded container for a polished look. On long lists the bar remains visible thanks
+to a wrapping `<div>` with `className="sticky top-0 z-20 bg-white"`, so scrolling doesn't cause
+the content below to jump when filters stay pinned to the top.
 
 ## Testing
 

--- a/frontend/src/app/artists/__tests__/page.test.tsx
+++ b/frontend/src/app/artists/__tests__/page.test.tsx
@@ -217,4 +217,17 @@ describe('Artists page filters', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('wraps FilterBar in a sticky container', async () => {
+    jest.spyOn(api, 'getArtists').mockResolvedValue({ data: [] });
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(React.createElement(ArtistsPage));
+      await Promise.resolve();
+    });
+    const sticky = container.querySelector('div.sticky.top-0.z-20.bg-white');
+    expect(sticky).not.toBeNull();
+    act(() => root.unmount());
+    container.remove();
+  });
 });

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -131,17 +131,19 @@ export default function ArtistsPage() {
             Compare artists, check ratings, and book instantly.
           </p>
         </div>
-        <FilterBar
-          categories={CATEGORIES}
-          onCategory={onCategory}
-          location={location}
-          onLocation={(e) => setLocation(e.target.value)}
-          sort={sort}
-          onSort={(e) => setSort(e.target.value || undefined)}
-          onClear={clearFilters}
-          onApply={() => updateQuery(category, location || undefined, sort)}
-          filtersActive={filtersActive}
-        />
+        <div className="sticky top-0 z-20 bg-white pt-2 pb-4">
+          <FilterBar
+            categories={CATEGORIES}
+            onCategory={onCategory}
+            location={location}
+            onLocation={(e) => setLocation(e.target.value)}
+            sort={sort}
+            onSort={(e) => setSort(e.target.value || undefined)}
+            onClear={clearFilters}
+            onApply={() => updateQuery(category, location || undefined, sort)}
+            filtersActive={filtersActive}
+          />
+        </div>
         <div>
           {loading && <Spinner className="my-4" />}
           {error && <p className="text-red-600">{error}</p>}


### PR DESCRIPTION
## Summary
- keep filter bar visible while scrolling artists
- document sticky filter bar in README
- test that artists page uses sticky container

## Testing
- `npm test -- -t "wraps FilterBar"` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_687e14e267f4832e9a2fa22b2f9e2075