### PR TITLE
Integrate Google Maps autocomplete in filter bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ NEXT_PUBLIC_WS_URL=ws://192.168.3.203:8000
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyDm-BKmMtzMSMd-XUdfapjEUU6O5mYy2bk
 ```
 
+`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` should be a browser key with the Places API
+enabled. It powers the `LocationInput` autocomplete fields used in the artist
+filters and booking steps.
+
 The host portion of `NEXT_PUBLIC_API_URL` is also used by
 `next.config.js` to allow optimized image requests from the backend.
 Set this URL to match your API server so artist profile pictures and

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -135,7 +135,7 @@ export default function ArtistsPage() {
           categories={CATEGORIES}
           onCategory={onCategory}
           location={location}
-          onLocation={(e) => setLocation(e.target.value)}
+          onLocation={setLocation}
           sort={sort}
           onSort={(e) => setSort(e.target.value || undefined)}
           onClear={clearFilters}

--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -1,6 +1,7 @@
 'use client';
-import type { ChangeEventHandler } from 'react';
 import { useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+import LocationInput from '@/components/ui/LocationInput';
 import { PillButton } from '@/components/ui';
 import useIsMobile from '@/hooks/useIsMobile';
 import FilterPopover from './FilterPopover';
@@ -10,7 +11,7 @@ export interface FilterBarProps {
   categories: string[];
   onCategory?: (c: string) => void;
   location: string;
-  onLocation: ChangeEventHandler<HTMLInputElement>;
+  onLocation: (value: string) => void;
   sort?: string;
   onSort: ChangeEventHandler<HTMLSelectElement>;
   onClear?: () => void;
@@ -94,8 +95,7 @@ export default function FilterBar({
           />
         </div>
       )}
-      <input
-        placeholder="Location"
+      <LocationInput
         value={location}
         onChange={onLocation}
         className="h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"

--- a/frontend/src/components/artist/__tests__/FilterBar.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterBar.test.tsx
@@ -19,7 +19,9 @@ describe('FilterBar component', () => {
           categories={categories}
           onCategory={() => {}}
           location=""
-          onLocation={() => {}}
+          onLocation={() => {
+            /* noop */
+          }}
           sort=""
           onSort={() => {}}
           onApply={() => {}}
@@ -81,6 +83,21 @@ describe('FilterBar component', () => {
     expect(onCategory).toHaveBeenCalledWith(categories[0]);
     expect(onApply).toHaveBeenCalled();
     expect(document.activeElement).toBe(btn);
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('updates location via autocomplete', () => {
+    (useIsMobile as jest.Mock).mockReturnValue(false);
+    const onLocation = jest.fn();
+    const { container, root } = renderBar({ onLocation });
+    const mock = (global as { mockAutocomplete: jest.Mock }).mockAutocomplete;
+    const instance = mock.mock.instances[0];
+    instance.getPlace.mockReturnValue({ formatted_address: 'New York, NY' });
+    act(() => {
+      instance._cb();
+    });
+    expect(onLocation).toHaveBeenCalledWith('New York, NY');
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { useLoadScript } from '@react-google-maps/api';
+import TextInput from './TextInput';
+
+const MAP_LIBRARIES = ['places'] as const;
+
+interface LocationInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function LocationInput({
+  value,
+  onChange,
+  placeholder = 'Location',
+  className,
+}: LocationInputProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const autoRef = useRef<google.maps.places.Autocomplete | null>(null);
+  const { isLoaded } = useLoadScript({
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
+    libraries: MAP_LIBRARIES,
+  });
+
+  useEffect(() => {
+    if (!isLoaded || autoRef.current || !inputRef.current) return;
+    const autocomplete = new google.maps.places.Autocomplete(inputRef.current);
+    autocomplete.addListener('place_changed', () => {
+      const place = autocomplete.getPlace();
+      if (place.formatted_address) onChange(place.formatted_address);
+    });
+    autoRef.current = autocomplete;
+    return () => {
+      autoRef.current = null;
+    };
+  }, [isLoaded, onChange]);
+
+  useEffect(() => {
+    if (inputRef.current) inputRef.current.value = value;
+  }, [value]);
+
+  return (
+    <TextInput
+      ref={inputRef}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+      className={className}
+      loading={!isLoaded}
+      data-testid="location-input"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `LocationInput` component powered by `@react-google-maps/api`
- replace simple input in `FilterBar` with new component
- pass selected location string to `ArtistsPage`
- update FilterBar unit tests to mock Google Places autocomplete
- document Google Maps API key requirements in README

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt after backend tests but 77 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_687e1b8beff8832e94832f6d21e213b4