### PR TITLE
Add artist filters with price range

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,7 +866,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 `GET /api/v1/artist-profiles/` supports pagination and optional filters:
 
 ```
-page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>
+page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>
 ```
 
 Profiles include `rating`, `rating_count`, and `is_available` fields. A new
@@ -881,7 +881,8 @@ page now rests on a soft gradient background from the brand color to white. A ne
 inputs. When no results match the current filters the page shows "No artists
 found" beneath the filter bar.
 Filter selections persist in the URL so sharing or reloading the page keeps
-the current view, e.g. `/artists?category=Live+Performance&location=NY`.
+the current view, e.g.
+`/artists?category=Live+Performance&location=NY&minPrice=0&maxPrice=200000`.
 
 ### Mobile Navigation & Inbox
 

--- a/frontend/src/app/artists/__tests__/page.test.tsx
+++ b/frontend/src/app/artists/__tests__/page.test.tsx
@@ -45,6 +45,13 @@ describe('Artists page filters', () => {
       catBtn.click();
       await Promise.resolve();
     });
+    const applyBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Apply',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      applyBtn.click();
+      await Promise.resolve();
+    });
     expect(spy).toHaveBeenLastCalledWith({
       category: 'Live Performance',
       location: undefined,
@@ -52,7 +59,9 @@ describe('Artists page filters', () => {
       page: 1,
       limit: 20,
     });
-    expect(push).toHaveBeenLastCalledWith('/artists?category=Live%20Performance');
+    expect(push).toHaveBeenLastCalledWith(
+      '/artists?category=Live%20Performance&minPrice=0&maxPrice=200000',
+    );
     act(() => root.unmount());
     container.remove();
   });
@@ -69,6 +78,8 @@ describe('Artists page filters', () => {
       ],
     });
     const { container, root } = setup();
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
     await act(async () => {
       root.render(React.createElement(ArtistsPage));
       await Promise.resolve();
@@ -191,6 +202,7 @@ describe('Artists page filters', () => {
       page: 1,
       limit: 20,
     });
+    expect(push).toHaveBeenLastCalledWith('/artists');
     act(() => root.unmount());
     container.remove();
   });
@@ -201,6 +213,8 @@ describe('Artists page filters', () => {
       category: 'Live Performance',
       location: 'Paris',
       sort: 'newest',
+      minPrice: '10',
+      maxPrice: '500',
     });
     await act(async () => {
       root.render(React.createElement(ArtistsPage));
@@ -214,11 +228,15 @@ describe('Artists page filters', () => {
     expect(selected).toBeTruthy();
     const sortSelect = container.querySelector('select') as HTMLSelectElement;
     expect(sortSelect.value).toBe('newest');
+    const applyBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Apply',
+    );
+    expect(applyBtn).not.toBeNull();
     act(() => root.unmount());
     container.remove();
   });
 
-  it('wraps FilterBar in a sticky container', async () => {
+  it('renders FilterBar without sticky container', async () => {
     jest.spyOn(api, 'getArtists').mockResolvedValue({ data: [] });
     const { container, root } = setup();
     await act(async () => {
@@ -226,7 +244,7 @@ describe('Artists page filters', () => {
       await Promise.resolve();
     });
     const sticky = container.querySelector('div.sticky.top-0.z-20.bg-white');
-    expect(sticky).not.toBeNull();
+    expect(sticky).toBeNull();
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/components/artist/FilterBar.tsx
+++ b/frontend/src/components/artist/FilterBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, forwardRef, Fragment, FC } from 'react';
+import React, { useState, useEffect, forwardRef, Fragment, FC } from 'react';
 import type { ChangeEventHandler } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
@@ -18,11 +18,14 @@ export interface FilterBarProps {
   onClear: () => void;
   onApply: (filters: { category?: string; minPrice?: number; maxPrice?: number }) => void;
   filtersActive: boolean;
+  initialCategory?: string;
+  initialMinPrice?: number;
+  initialMaxPrice?: number;
 }
 
-const SLIDER_MIN = 0;
-const SLIDER_MAX = 200_000;
-const SLIDER_STEP = 100;
+export const SLIDER_MIN = 0;
+export const SLIDER_MAX = 200_000;
+export const SLIDER_STEP = 100;
 const formatCurrency = (v: number) => `R${new Intl.NumberFormat().format(v)}`;
 
 const FilterBar: FC<FilterBarProps> = ({
@@ -35,12 +38,27 @@ const FilterBar: FC<FilterBarProps> = ({
   onClear,
   onApply,
   filtersActive,
+  initialCategory,
+  initialMinPrice = SLIDER_MIN,
+  initialMaxPrice = SLIDER_MAX,
 }) => {
-  const [cat, setCat] = useState<string | undefined>();
-  const [minPrice, setMinPrice] = useState<number>(SLIDER_MIN);
-  const [maxPrice, setMaxPrice] = useState<number>(SLIDER_MAX);
+  const [cat, setCat] = useState<string | undefined>(initialCategory);
+  const [minPrice, setMinPrice] = useState<number>(initialMinPrice);
+  const [maxPrice, setMaxPrice] = useState<number>(initialMaxPrice);
   const [sheetOpen, setSheetOpen] = useState(false);
   const isMobile = useIsMobile();
+
+  useEffect(() => {
+    setCat(initialCategory);
+  }, [initialCategory]);
+
+  useEffect(() => {
+    setMinPrice(initialMinPrice);
+  }, [initialMinPrice]);
+
+  useEffect(() => {
+    setMaxPrice(initialMaxPrice);
+  }, [initialMaxPrice]);
 
   const handleCategory = (value: string) => {
     const next = cat === value ? undefined : value;


### PR DESCRIPTION
## Summary
- support price range params in artist FilterBar and ArtistsPage
- maintain filter state in URL including minPrice/maxPrice
- update artist page tests for new apply flow and non-sticky bar
- document query parameters in README

## Testing
- `./scripts/test-all.sh` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687e8fd1eedc832e87909cfb1201926a