### PR TITLE
Add new Hero component to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The July 2025 update bumps key dependencies and Docker base images:
   loaders and hover "Book Now" overlay for a modern, accessible look.
 - Homepage includes a central search bar so visitors can quickly look up artists by
   destination and date.
+- A new animated Hero section on the homepage lets users search by category,
+  location and date, persisting selections in the URL.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -39,3 +39,24 @@
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
+
+@layer components {
+  .hero-gradient {
+    @apply bg-gradient-to-br from-indigo-50 to-indigo-100;
+  }
+}
+
+@keyframes flashText {
+  0%, 100% {
+    opacity: 0.5;
+    transform: translateY(2px) scale(0.98);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(0) scale(1.02);
+  }
+}
+
+.animate-flash {
+  animation: flashText 1.5s ease-in-out infinite;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,12 @@
 import MainLayout from '@/components/layout/MainLayout'
 import Link from 'next/link'
 import HomeSearchForm from '@/components/landing/HomeSearchForm'
+import Hero from '@/components/layout/Hero'
 
 export default function HomePage() {
   return (
     <MainLayout>
+      <Hero />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center">
           <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">

--- a/frontend/src/components/layout/Hero.tsx
+++ b/frontend/src/components/layout/Hero.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState, useEffect, forwardRef, Fragment } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import ReactDatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
@@ -125,10 +126,33 @@ export default function Hero() {
   const [when, setWhen] = useState<Date | null>(null);
   const [isMobileOpen, setMobileOpen] = useState(false);
   const word = useCycle(WORDS);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const catParam = searchParams.get('category');
+    if (catParam) {
+      const found = CATEGORIES.find((c) => c.value === catParam);
+      if (found) setCategory(found);
+    }
+    const locParam = searchParams.get('location');
+    if (locParam) setLocation(locParam);
+    const whenParam = searchParams.get('when');
+    if (whenParam) {
+      const d = new Date(whenParam);
+      if (!Number.isNaN(d.getTime())) setWhen(d);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log({ category: category.value, location, when });
+    const params = new URLSearchParams();
+    if (category) params.set('category', category.value);
+    if (location) params.set('location', location);
+    if (when) params.set('when', when.toISOString());
+    const qs = params.toString();
+    router.push(qs ? `/artists?${qs}` : '/artists');
     setMobileOpen(false);
   };
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -81,7 +81,6 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   const { user, logout } = useAuth();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
-  const showOldContent = false; // Toggle for old page content
 
   const navigation = [...baseNavigation];
   if (user?.user_type === 'artist') {
@@ -317,19 +316,10 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         {pathname === '/' && <Hero />}
 
         {/* CONTENT */}
-        {pathname === '/' ? (
-          showOldContent ? (
-            <main className="py-10 pb-24">
-              <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">{children}</div>
-              <HelpPrompt className="mx-auto mt-10 max-w-7xl sm:px-6 lg:px-8" />
-            </main>
-          ) : null
-        ) : (
-          <main className="py-10 pb-24">
-            <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">{children}</div>
-            <HelpPrompt className="mx-auto mt-10 max-w-7xl sm:px-6 lg:px-8" />
-          </main>
-        )}
+        <main className="py-10 pb-24">
+          <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">{children}</div>
+          <HelpPrompt className="mx-auto mt-10 max-w-7xl sm:px-6 lg:px-8" />
+        </main>
       </div>
 
       {/* RENDER THE FOOTER HERE */}


### PR DESCRIPTION
## Summary
- display new Hero on homepage
- simplify MainLayout and remove legacy flag
- persist Hero search params in URL
- tweak hero styles in global CSS
- document homepage hero in README

## Testing
- `./scripts/test-all.sh` *(fails to show full output but backend tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_687e976e9168832eac46da4d468c1397