### PR TITLE
Fix Hero duplication in MainLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   destination and date.
 - A new animated Hero section on the homepage lets users search by category,
   location and date, persisting selections in the URL.
+- The Hero component now renders only on the homepage to avoid duplicate content.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/src/app/__tests__/HomePage.test.tsx
+++ b/frontend/src/app/__tests__/HomePage.test.tsx
@@ -8,6 +8,11 @@ jest.mock('@/components/layout/MainLayout', () => {
   Mock.displayName = 'MockMainLayout';
   return Mock;
 });
+jest.mock('@/components/layout/Hero', () => {
+  const Mock = () => <div data-testid="hero" />;
+  Mock.displayName = 'MockHero';
+  return Mock;
+});
 
 describe('HomePage', () => {
   it('renders search form', async () => {

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -13,7 +13,6 @@ import BookingRequestIcon from './BookingRequestIcon';
 import MobileMenuDrawer from './MobileMenuDrawer';
 import MobileBottomNav from './MobileBottomNav';
 import { HelpPrompt, Avatar } from '../ui';
-import Hero from './Hero';
 
 // --- CONSTANTS ---
 const baseNavigation = [
@@ -311,9 +310,6 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
           logout={logout}
           pathname={pathname}
         />
-
-        {/* HERO only on home */}
-        {pathname === '/' && <Hero />}
 
         {/* CONTENT */}
         <main className="py-10 pb-24">


### PR DESCRIPTION
## Summary
- ensure Hero only renders on home page
- adjust MainLayout to remove conditional Hero and duplicate `<main>`
- mock Hero in HomePage tests
- document hero update in README

## Testing
- `./scripts/test-all.sh` *(fails: 77 passed, 609 warnings in backend tests)*
- `npm test` *(fails: 8 failed, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f351017f4832e968420ab0052cfe5