### PR TITLE
Improve test scripts with caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Cache frontend node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+      - name: Cache backend venv
+        uses: actions/cache@v4
+        with:
+          path: backend/venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('backend/requirements.txt', 'requirements-dev.txt') }}
+      - name: Backend tests
+        run: ./scripts/test-backend.sh
+      - name: Frontend unit tests
+        run: ./scripts/test-frontend.sh --unit
+      - name: E2E tests
+        if: github.ref == 'refs/heads/main' || env.E2E == '1'
+        run: ./scripts/test-frontend.sh --e2e

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ backend/static/static/
 __pycache__/
 *.py[cod]
 
+# Test caches
+.cache/jest/
+.pytest_cache/
+
 # Ignore Node modules
 node_modules/
 # Additional ignores

--- a/README.md
+++ b/README.md
@@ -512,6 +512,17 @@ You can override the number of parallel Jest workers by setting the
 JEST_WORKERS=75% ./scripts/test-all.sh
 ```
 
+Common skip flags:
+
+```bash
+SKIP_FRONTEND=1 ./scripts/test-all.sh
+SKIP_BACKEND=1 ./scripts/test-all.sh
+./scripts/test-frontend.sh --unit
+```
+
+The scripts cache `backend/venv` and `frontend/node_modules` using hash files so
+installs are skipped unless `requirements.txt` or `package-lock.json` change.
+
 You can also run the tests inside the Docker image if you prefer not to install
 anything locally:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "pretest": "test -d node_modules || npm install",
-    "test": "jest"
+    "test": "jest --passWithNoTests",
+    "test:unit": "jest --testPathIgnorePatterns=e2e",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -16,60 +16,23 @@ if ! command -v npm >/dev/null; then
 fi
 echo "npm $(npm --version)"
 
-# Always run both backend and frontend tests
-echo "⚙️  Installing dependencies…"
-# When running this script inside Docker, use --network bridge or set
-# DOCKER_TEST_NETWORK=bridge if npm fails to contact registry.npmjs.org.
-./setup.sh
+run_e2e=0
+for arg in "$@"; do
+  [ "$arg" = "--e2e" ] && run_e2e=1
+done
 
-echo "🧪 Running backend tests…"
-source backend/venv/bin/activate
-pytest -q --maxfail=1 --disable-warnings
+if [ -z "${SKIP_BACKEND:-}" ]; then
+  echo "🧪 Running backend tests…"
+  ./scripts/test-backend.sh
+fi
 
-echo "🧪 Running frontend tests…"
-pushd frontend >/dev/null
-
-# only do npm ci once per container/session
-if [ ! -f node_modules/.install_complete ]; then
-  npm config set install-links true
-  if ! npm ci --prefer-offline --no-audit --progress=false 2>npm-ci.log; then
-    echo "\n❌ npm install failed." >&2
-    echo "   Verify your proxy settings or run ./scripts/docker-test.sh with DOCKER_TEST_NETWORK=bridge" >&2
-    if [ -s npm-ci.log ]; then
-      echo "--- npm ci output ---" >&2
-      cat npm-ci.log >&2
-    fi
-    NPM_LOG_DIR="$(npm config get cache)/_logs"
-    NPM_LOG_FILE="$(ls -t "$NPM_LOG_DIR"/*-debug.log 2>/dev/null | head -n 1)"
-    if [ -f "$NPM_LOG_FILE" ]; then
-      echo "--- npm debug log ($NPM_LOG_FILE) ---" >&2
-      cat "$NPM_LOG_FILE" >&2
-    fi
-    rm -f npm-ci.log
-    popd >/dev/null
-    exit 1
+if [ -z "${SKIP_FRONTEND:-}" ]; then
+  echo "🧪 Running frontend tests…"
+  if [ "$run_e2e" = 1 ] || [ "${E2E:-}" = 1 ]; then
+    ./scripts/test-frontend.sh --unit --e2e
+  else
+    ./scripts/test-frontend.sh --unit
   fi
-  rm -f npm-ci.log
-  touch node_modules/.install_complete
 fi
-
-JEST_BIN="node_modules/.bin/jest"
-if [ ! -x "$JEST_BIN" ]; then
-  JEST_BIN="$(command -v jest 2>/dev/null || true)"
-fi
-if [ ! -x "$JEST_BIN" ]; then
-  echo "❌ Jest binary not found. Did npm ci finish successfully?" >&2
-  exit 1
-fi
-echo "Jest $($JEST_BIN --version) at $JEST_BIN"
-
-if [ -n "${JEST_WORKERS:-}" ]; then
-  echo "▶️  Using JEST_WORKERS=$JEST_WORKERS"
-  npm test -- --maxWorkers="$JEST_WORKERS"
-else
-  npm test
-fi
-npm run lint --silent
-popd >/dev/null
 
 echo "--- ALL TESTS COMPLETE ---"

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/backend/venv"
+REQ_FILE="$ROOT_DIR/backend/requirements.txt"
+DEV_REQ_FILE="$ROOT_DIR/requirements-dev.txt"
+
+# Create virtualenv if missing
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating Python virtual environment..."
+  python3 -m venv "$VENV_DIR"
+fi
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+
+# Install dependencies if install marker missing or requirements changed
+INSTALL_MARKER="$VENV_DIR/.install_complete"
+REQ_HASH_FILE="$VENV_DIR/.req_hash"
+CURRENT_HASH="$(sha256sum "$REQ_FILE" "$DEV_REQ_FILE" | sha256sum | awk '{print $1}')"
+CACHED_HASH=""
+if [ -f "$REQ_HASH_FILE" ]; then
+  CACHED_HASH="$(cat "$REQ_HASH_FILE")"
+fi
+
+if [ ! -f "$INSTALL_MARKER" ] || [ "$CURRENT_HASH" != "$CACHED_HASH" ]; then
+  echo "Installing backend dependencies..."
+  pip install -r "$REQ_FILE" -r "$DEV_REQ_FILE"
+  echo "$CURRENT_HASH" > "$REQ_HASH_FILE"
+  touch "$INSTALL_MARKER"
+fi
+
+pytest_args=("-q" "--maxfail=1" "--disable-warnings")
+if python -c "import pkgutil, sys; sys.exit(pkgutil.find_loader('xdist') is None)"; then
+  pytest_args=("-n" "auto" "${pytest_args[@]}")
+fi
+
+cd "$ROOT_DIR"
+pytest "${pytest_args[@]}"

--- a/scripts/test-frontend.sh
+++ b/scripts/test-frontend.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+cd "$FRONTEND_DIR"
+
+MARKER="node_modules/.install_complete"
+HASH_FILE="node_modules/.pkg_hash"
+CURRENT_HASH="$(sha256sum package-lock.json | awk '{print $1}')"
+CACHED_HASH=""
+if [ -f "$HASH_FILE" ]; then
+  CACHED_HASH="$(cat "$HASH_FILE")"
+fi
+
+if [ ! -f "$MARKER" ] || [ "$CURRENT_HASH" != "$CACHED_HASH" ]; then
+  echo "Installing frontend dependencies..."
+  npm config set install-links true
+  if [ "${VERBOSE:-}" = "1" ]; then
+    npm ci --prefer-offline --no-audit || FAILED=1
+  else
+    npm ci --prefer-offline --no-audit --progress=false 2>npm-ci.log || FAILED=1
+  fi
+  if [ -n "${FAILED:-}" ]; then
+    echo "\n❌ npm ci failed." >&2
+    NPM_LOG_DIR="$(npm config get cache)/_logs"
+    NPM_LOG_FILE="$(ls -t "$NPM_LOG_DIR"/*-debug.log 2>/dev/null | head -n 1)"
+    if [ -f "$NPM_LOG_FILE" ]; then
+      echo "--- npm debug log ($NPM_LOG_FILE) ---" >&2
+      cat "$NPM_LOG_FILE" >&2
+    fi
+    if [ -f npm-ci.log ]; then
+      echo "--- npm ci output ---" >&2
+      cat npm-ci.log >&2
+    fi
+    rm -f npm-ci.log
+    exit 1
+  fi
+  rm -f npm-ci.log
+  echo "$CURRENT_HASH" > "$HASH_FILE"
+  touch "$MARKER"
+fi
+
+JEST_WORKERS_OPT="${JEST_WORKERS:-50%}"
+
+run_unit=0
+run_e2e=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --unit) run_unit=1 ;;
+    --e2e) run_e2e=1 ;;
+  esac
+done
+
+if [ "$run_unit" = 1 ]; then
+  npm run test:unit -- --maxWorkers="$JEST_WORKERS_OPT"
+else
+  npm test -- --maxWorkers="$JEST_WORKERS_OPT"
+fi
+
+if [ "$run_e2e" = 1 ]; then
+  npx playwright test
+fi
+
+if [ -z "${SKIP_LINT:-}" ]; then
+  npm run lint --silent
+fi


### PR DESCRIPTION
## Summary
- split backend and frontend test runners
- update test-all to use the new scripts
- speed up Node/Python installs with caching markers
- add CI workflow with GitHub Actions caching
- document skip flags and caching strategy in README
- ignore jest and pytest caches
- update frontend NPM scripts for unit/e2e separation

## Testing
- `./scripts/test-all.sh` *(fails: ran out of execution time)*

------
https://chatgpt.com/codex/tasks/task_e_687f47865840832eb0f2566fbd4456a8