### PR TITLE
Improve frontend test script flags

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "pretest": "test -d node_modules || npm install",
     "test": "jest --passWithNoTests",
-    "test:unit": "jest --testPathIgnorePatterns=e2e",
+    "test:unit": "jest --testPathIgnorePatterns=e2e --detectOpenHandles --forceExit",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/scripts/test-frontend.sh
+++ b/scripts/test-frontend.sh
@@ -53,14 +53,25 @@ for arg in "$@"; do
   esac
 done
 
+JEST_EXTRA_ARGS=(--detectOpenHandles --forceExit)
+
 if [ "$run_unit" = 1 ]; then
-  npm run test:unit -- --maxWorkers="$JEST_WORKERS_OPT"
+  start_unit=$(date +%s)
+  npm run test:unit -- --maxWorkers="$JEST_WORKERS_OPT" "${JEST_EXTRA_ARGS[@]}"
+  end_unit=$(date +%s)
+  echo "Unit tests completed in $((end_unit - start_unit)) seconds"
 else
-  npm test -- --maxWorkers="$JEST_WORKERS_OPT"
+  start_unit=$(date +%s)
+  npm test -- --maxWorkers="$JEST_WORKERS_OPT" "${JEST_EXTRA_ARGS[@]}"
+  end_unit=$(date +%s)
+  echo "Frontend tests completed in $((end_unit - start_unit)) seconds"
 fi
 
 if [ "$run_e2e" = 1 ]; then
+  start_e2e=$(date +%s)
   npx playwright test
+  end_e2e=$(date +%s)
+  echo "E2E tests completed in $((end_e2e - start_e2e)) seconds"
 fi
 
 if [ -z "${SKIP_LINT:-}" ]; then


### PR DESCRIPTION
## Summary
- append `--detectOpenHandles --forceExit` to frontend tests
- print elapsed time when running unit or e2e tests
- update `test:unit` npm script

## Testing
- `./scripts/test-all.sh` *(fails: 8 failed, 1 skipped, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f52102764832ebc8dd33e1fd9cb1a