### PR TITLE
Fix zero-network install & FAST checks (real cache hits)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           path: frontend/node_modules.tar.zst
           key: node-${{ env.NODE_VER }}-${{ env.FRONTEND_HASH }}-${{ runner.os }}
+      - name: Setup dependencies
+        run: ./setup.sh
       - name: Run tests
         run: |
           if [[ $GITHUB_REF != 'refs/heads/main' ]]; then

--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ automatically in CI).
 Use `WRITE_ARCHIVES=1` to rebuild the compressed dependency caches after
 installing packages. Hashes combine the lock files and the runtime versions so
 caches refresh automatically when either changes.
+Dependency checks rely on `.venv_hash`, `.pkg_hash`, and the `.meta` files; the
+deprecated `.install_complete` marker has been removed.
 
 Common skip flags:
 

--- a/scripts/archive-utils.sh
+++ b/scripts/archive-utils.sh
@@ -1,28 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Detect if zstd is available for compression/decompression
 use_zstd() {
   command -v zstd >/dev/null 2>&1
 }
 
-extract() {
-  local archive=$1
-  local dest=$2
-  if [ -f "$archive" ]; then
-    if [[ "$archive" == *.zst ]] && use_zstd; then
-      tar -C "$dest" -I zstd -xf "$archive"
-    else
-      tar -C "$dest" -zxf "$archive"
-    fi
-  fi
-}
-
+# Compresses SRC directory into ARCHIVE using zstd when available
+# Arguments:
+#   $1 - source directory path
+#   $2 - destination archive path
 compress() {
   local src=$1
   local archive=$2
+  local parent
+  parent="$(dirname "$src")"
   if use_zstd; then
-    tar -C "$(dirname "$src")" -I 'zstd -T0 -19' -cf "$archive" "$(basename "$src")"
+    tar -C "$parent" -I 'zstd -T0 -19' -cf "$archive" "$(basename "$src")"
   else
-    tar -C "$(dirname "$src")" -czf "$archive" "$(basename "$src")"
+    tar -C "$parent" -czf "$archive" "$(basename "$src")"
+  fi
+}
+
+# Extracts ARCHIVE into PARENT_DIR. The archive must contain a single top-level
+# directory which will be created under PARENT_DIR.
+extract() {
+  local archive=$1
+  local parent_dir=$2
+  if [ ! -f "$archive" ]; then
+    return
+  fi
+  if [[ "$archive" == *.zst ]] && use_zstd; then
+    tar -C "$parent_dir" -I zstd -xf "$archive"
+  else
+    tar -C "$parent_dir" -zxf "$archive"
   fi
 }

--- a/scripts/build-caches.sh
+++ b/scripts/build-caches.sh
@@ -13,29 +13,24 @@ NODE_VER=$(node --version | sed 's/^v//')
 BACKEND_HASH=$(sha256sum "$BACKEND_DIR/requirements.txt" "$ROOT_DIR/requirements-dev.txt" | sha256sum | awk '{print $1}')
 FRONTEND_HASH=$(sha256sum "$FRONTEND_DIR/package-lock.json" | awk '{print $1}')
 
-BACKEND_HASH_FILE="$BACKEND_DIR/.venv_hash"
-FRONTEND_HASH_FILE="$FRONTEND_DIR/.pkg_hash"
-
-# backend
 if [ -d "$BACKEND_DIR/venv" ]; then
   echo "$PY_VER" > "$BACKEND_DIR/venv/.meta"
-  previous=""
-  [ -f "$BACKEND_HASH_FILE" ] && previous="$(cat "$BACKEND_HASH_FILE")"
-  if [ "$previous" != "$BACKEND_HASH-$PY_VER" ] || [ "${FORCE:-}" = 1 ]; then
+  current=""
+  [ -f "$BACKEND_DIR/.venv_hash" ] && current="$(cat "$BACKEND_DIR/.venv_hash")"
+  if [ "$current" != "$BACKEND_HASH-$PY_VER" ] || [ "${FORCE:-}" = 1 ]; then
     echo "Archiving backend/venv"
     compress "$BACKEND_DIR/venv" "$BACKEND_DIR/venv.tar.zst"
-    echo "$BACKEND_HASH-$PY_VER" > "$BACKEND_HASH_FILE"
+    echo "$BACKEND_HASH-$PY_VER" > "$BACKEND_DIR/.venv_hash"
   fi
 fi
 
-# frontend
 if [ -d "$FRONTEND_DIR/node_modules" ]; then
   echo "$NODE_VER" > "$FRONTEND_DIR/node_modules/.meta"
-  previous=""
-  [ -f "$FRONTEND_HASH_FILE" ] && previous="$(cat "$FRONTEND_HASH_FILE")"
-  if [ "$previous" != "$FRONTEND_HASH-$NODE_VER" ] || [ "${FORCE:-}" = 1 ]; then
+  current=""
+  [ -f "$FRONTEND_DIR/.pkg_hash" ] && current="$(cat "$FRONTEND_DIR/.pkg_hash")"
+  if [ "$current" != "$FRONTEND_HASH-$NODE_VER" ] || [ "${FORCE:-}" = 1 ]; then
     echo "Archiving frontend/node_modules"
     compress "$FRONTEND_DIR/node_modules" "$FRONTEND_DIR/node_modules.tar.zst"
-    echo "$FRONTEND_HASH-$NODE_VER" > "$FRONTEND_HASH_FILE"
+    echo "$FRONTEND_HASH-$NODE_VER" > "$FRONTEND_DIR/.pkg_hash"
   fi
 fi

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -8,6 +8,7 @@ SCRIPT=${TEST_SCRIPT:-./scripts/test-all.sh}
 NETWORK=${DOCKER_TEST_NETWORK:-none}
 WORKDIR=/workspace
 HOST_REPO=$(pwd)
+source "$HOST_REPO/scripts/archive-utils.sh" || true # SC1091
 
 # Warn when DOCKER_TEST_NETWORK isn't specified so users know npm may fail
 if [ -z "${DOCKER_TEST_NETWORK+x}" ]; then
@@ -27,8 +28,7 @@ decompress_cache() {
   if [ ! -d "$dest" ] && [ -f "$archive" ]; then
     mkdir -p "$dest"
     echo "Extracting $(basename "$archive") to $dest"
-    # `unzstd` is used instead of `zstd` to decompress the archive.
-    tar --use-compress-program=unzstd -xf "$archive" -C "$(dirname "$dest")"
+    extract "$archive" "$(dirname "$dest")"
   fi
 }
 
@@ -95,7 +95,7 @@ compress_cache() {
   local archive=$2
   if [ -d "$src" ]; then
     echo "Archiving $(basename "$src") to $(basename "$archive")"
-    tar -C "$(dirname "$src")" --use-compress-program=zstd -cf "$archive" "$(basename "$src")"
+    compress "$src" "$archive"
   fi
 }
 

--- a/scripts/fast-check.sh
+++ b/scripts/fast-check.sh
@@ -36,10 +36,11 @@ else
 fi
 
 py_files=$(python3 scripts/py_changed.py)
-if [ -n "$py_files" ]; then
+read -ra py_array <<< "$py_files"
+if [ "${#py_array[@]}" -gt 0 ]; then
   echo "Running backend tests for changed files…"
   start_py=$(date +%s)
-  pytest -q "$py_files"
+  pytest -q "${py_array[@]}"
   end_py=$(date +%s)
   echo "Backend tests: $((end_py - start_py))s"
 else

--- a/scripts/py_changed.py
+++ b/scripts/py_changed.py
@@ -8,7 +8,8 @@ def main():
         base = subprocess.check_output(['git', 'rev-parse', 'HEAD^']).decode().strip()
     diff = subprocess.check_output(['git', 'diff', '--name-only', f'{base}...HEAD'])
     files = [f for f in diff.decode().splitlines() if f.endswith('.py')]
-    print(' '.join(files))
+    if files:
+        print(' '.join(files))
 
 
 if __name__ == '__main__':

--- a/scripts/test-frontend.sh
+++ b/scripts/test-frontend.sh
@@ -11,7 +11,6 @@ if [ "${SKIP_FRONTEND:-}" = 1 ]; then
   exit 0
 fi
 
-MARKER="node_modules/.install_complete"
 HASH_FILE="node_modules/.pkg_hash"
 CURRENT_HASH="$(sha256sum package-lock.json | awk '{print $1}')"
 CACHED_HASH=""
@@ -20,7 +19,7 @@ if [ -f "$HASH_FILE" ]; then
 fi
 
 if [ "${FAST:-}" != 1 ]; then
-  if [ ! -f "$MARKER" ] || [ "$CURRENT_HASH" != "$CACHED_HASH" ]; then
+  if [ ! -d node_modules ] || [ "$CURRENT_HASH" != "$CACHED_HASH" ]; then
     echo "Installing frontend dependencies..."
     npm config set install-links true
     if [ "${VERBOSE:-}" = "1" ]; then
@@ -45,7 +44,7 @@ if [ "${FAST:-}" != 1 ]; then
     fi
     rm -f npm-ci.log
     echo "$CURRENT_HASH" > "$HASH_FILE"
-    touch "$MARKER"
+    node --version | sed 's/^v//' > node_modules/.meta
   fi
 else
   if [ ! -d node_modules ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,8 @@ backend_archive_gz="$BACKEND_DIR/venv.tar.gz"
 frontend_archive_zst="$FRONTEND_DIR/node_modules.tar.zst"
 frontend_archive_gz="$FRONTEND_DIR/node_modules.tar.gz"
 
+rebuild_archives=0
+
 echo "--- STARTING setup.sh ---"
 
 # Backend setup
@@ -48,9 +50,7 @@ if [ ! -d "$BACKEND_DIR/venv" ] || [ "$current_hash" != "$BACKEND_HASH-$PY_VER" 
   pip install -r "$BACKEND_DIR/requirements.txt" -r "$ROOT_DIR/requirements-dev.txt"
   echo "$PY_VER" > "$backend_meta"
   echo "$BACKEND_HASH-$PY_VER" > "$BACKEND_DIR/.venv_hash"
-  if [ "${WRITE_ARCHIVES:-}" = 1 ]; then
-    compress "$BACKEND_DIR/venv" "$backend_archive_zst"
-  fi
+  rebuild_archives=1
 else
   # shellcheck source=/dev/null
   source "$BACKEND_DIR/venv/bin/activate"
@@ -81,9 +81,11 @@ if [ ! -d "$FRONTEND_DIR/node_modules" ] || [ "$current_pkg" != "$FRONTEND_HASH-
   popd >/dev/null
   echo "$NODE_VER" > "$frontend_meta"
   echo "$FRONTEND_HASH-$NODE_VER" > "$FRONTEND_DIR/.pkg_hash"
-  if [ "${WRITE_ARCHIVES:-}" = 1 ]; then
-    compress "$FRONTEND_DIR/node_modules" "$frontend_archive_zst"
-  fi
+  rebuild_archives=1
 fi
 
 echo "Setup complete."
+
+if [ "${WRITE_ARCHIVES:-}" = 1 ] && [ "${rebuild_archives:-0}" = 1 ]; then
+  ./scripts/build-caches.sh
+fi


### PR DESCRIPTION
## Summary
- improve archive utils with consistent compress/extract functions
- rebuild caches only when needed and simplify build-caches.sh
- update setup.sh to reuse caches and rebuild archives when WRITE_ARCHIVES=1
- streamline fast-check.sh and py_changed.py for changed-file testing
- drop `.install_complete` logic from test scripts
- update docker-test.sh and GitHub Actions workflow
- document new markers and flags in README

## Verification Steps
- `shellcheck scripts/archive-utils.sh scripts/build-caches.sh scripts/docker-test.sh scripts/fast-check.sh scripts/test-frontend.sh setup.sh`
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f5f050acc832ebf0de2b023a63533