### PR TITLE
Tighten FAST checks & docker-test cache logic (final zero-net cleanup)

### DIFF
--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -21,17 +21,13 @@ fi
 # `frontend/node_modules.tar.zst`. If the unpacked directories are
 # absent but the archives exist, extract them before continuing so
 # `setup.sh` sees the same hash markers.
-if [ -f "$HOST_REPO/backend/venv.tar.zst" ] && [ ! -d "$HOST_REPO/backend/venv" ]; then
-  mkdir -p "$HOST_REPO/backend"
-  echo "Extracting venv.tar.zst to backend/venv"
+[ ! -d "$HOST_REPO/backend/venv" ] && \
+  [ -f "$HOST_REPO/backend/venv.tar.zst" ] && \
   extract "$HOST_REPO/backend/venv.tar.zst" "$HOST_REPO/backend"
-fi
 
-if [ -f "$HOST_REPO/frontend/node_modules.tar.zst" ] && [ ! -d "$HOST_REPO/frontend/node_modules" ]; then
-  mkdir -p "$HOST_REPO/frontend"
-  echo "Extracting node_modules.tar.zst to frontend/node_modules"
+[ ! -d "$HOST_REPO/frontend/node_modules" ] && \
+  [ -f "$HOST_REPO/frontend/node_modules.tar.zst" ] && \
   extract "$HOST_REPO/frontend/node_modules.tar.zst" "$HOST_REPO/frontend"
-fi
 
 # Fallback to local tests when Docker is not installed. This allows CI
 # environments without Docker to still execute the full test suite.


### PR DESCRIPTION
## Summary
- ensure base_ref, git diff, and file arrays only calculated once in `scripts/fast-check.sh`
- restore caches in `scripts/docker-test.sh` with simple checks
- handle deduped Python files for a single pytest invocation

Shellcheck output:
```
```

## Verification
- `WRITE_ARCHIVES=1 ./setup.sh`
- `FORCE=1 ./scripts/build-caches.sh`
- `NETWORK=none ./setup.sh`
- `./scripts/test-all.sh`
- `FAST=1 ./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f649c4200832e8ba25dd74a78f221