### PR TITLE
Add homepage artist sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - A new animated Hero section on the homepage lets users search by category,
   location and date, persisting selections in the URL.
 - The Hero component now renders only on the homepage to avoid duplicate content.
+- The homepage now highlights popular, top rated, and new artists using the same
+  card layout as the Artists page.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,14 @@
 import MainLayout from '@/components/layout/MainLayout'
 import Hero from '@/components/layout/Hero'
+import ArtistsSection from '@/components/home/ArtistsSection'
 
 export default function HomePage() {
   return (
     <MainLayout>
       <Hero />
+      <ArtistsSection title="Popular Musicians" query={{ sort: 'popular' }} />
+      <ArtistsSection title="Top Rated" query={{ sort: 'rating_desc' }} />
+      <ArtistsSection title="New on Booka" query={{ sort: 'created_desc' }} />
     </MainLayout>
   )
 }

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import ArtistCard from '@/components/artist/ArtistCard';
+import { getArtists } from '@/lib/api';
+import { getFullImageUrl } from '@/lib/utils';
+import type { ArtistProfile, SearchParams } from '@/types';
+
+interface ArtistsSectionProps {
+  title: string;
+  query?: Partial<SearchParams>;
+  limit?: number;
+}
+
+function CardSkeleton() {
+  return (
+    <div className="rounded-2xl bg-white shadow-lg overflow-hidden animate-pulse">
+      <div className="h-48 bg-gray-200" />
+      <div className="p-6 space-y-2">
+        <div className="h-4 bg-gray-200 rounded w-2/3" />
+        <div className="h-3 bg-gray-200 rounded w-1/3" />
+      </div>
+    </div>
+  );
+}
+
+export default function ArtistsSection({
+  title,
+  query = {},
+  limit = 12,
+}: ArtistsSectionProps) {
+  const [artists, setArtists] = useState<ArtistProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    async function fetchArtists() {
+      setLoading(true);
+      try {
+        const res = await getArtists({ ...query, limit });
+        if (isMounted) {
+          setArtists(res.data);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+    fetchArtists();
+    return () => {
+      isMounted = false;
+    };
+  }, [JSON.stringify(query), limit]);
+
+  const seeAllHref = `/search?${new URLSearchParams(query as Record<string, string>).toString()}`;
+  const showSeeAll = artists.length === limit;
+
+  return (
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="flex items-end justify-between mb-6">
+        <h2 className="text-2xl font-semibold text-gray-900">{title}</h2>
+        {showSeeAll && (
+          <Link href={seeAllHref} className="text-sm text-brand hover:underline">
+            See all
+          </Link>
+        )}
+      </div>
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {Array.from({ length: limit }).map((_, i) => (
+            <CardSkeleton key={i} />
+          ))}
+        </div>
+      ) : artists.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {artists.map((a) => {
+            const name = a.business_name ||
+              (a.user ? `${a.user.first_name} ${a.user.last_name}` : 'Unknown Artist');
+            return (
+              <ArtistCard
+                key={a.id}
+                id={a.id}
+                name={name}
+                subtitle={a.custom_subtitle || undefined}
+                imageUrl={
+                  getFullImageUrl(a.profile_picture_url || a.portfolio_urls?.[0]) || undefined
+                }
+                price={
+                  a.hourly_rate && a.price_visible ? Number(a.hourly_rate) : undefined
+                }
+                location={a.location}
+                specialties={a.specialties}
+                rating={a.rating ?? undefined}
+                ratingCount={a.rating_count ?? undefined}
+                verified={a.user?.is_verified}
+                isAvailable={a.is_available}
+                href={`/artists/${a.id}`}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <p>No artists found.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
+++ b/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
@@ -1,0 +1,48 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ArtistsSection from '../ArtistsSection';
+import * as api from '@/lib/api';
+import type { ArtistProfile } from '@/types';
+
+jest.mock('@/lib/api');
+
+function setup() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('ArtistsSection', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('matches snapshot', async () => {
+    (api.getArtists as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          business_name: 'A',
+          user_id: 1,
+          user: { first_name: 'A', last_name: 'B', is_verified: false },
+        },
+      ] as unknown as ArtistProfile[],
+    });
+
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(<ArtistsSection title="Demo" />);
+      await Promise.resolve();
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
+++ b/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArtistsSection matches snapshot 1`] = `
+<section
+  class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+>
+  <div
+    class="flex items-end justify-between mb-6"
+  >
+    <h2
+      class="text-2xl font-semibold text-gray-900"
+    >
+      Demo
+    </h2>
+  </div>
+  <div
+    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+  >
+    <div
+      class="rounded-2xl bg-white shadow-lg overflow-hidden transition-shadow"
+    >
+      <a
+        href="/artists/1"
+      >
+        <div
+          class="relative h-48 w-full overflow-hidden rounded-t-2xl bg-gray-100"
+        >
+          <div
+            class="absolute inset-0 animate-pulse bg-gray-200"
+          />
+          <img
+            alt="A"
+            class="object-cover w-full h-full"
+            data-nimg="1"
+            decoding="async"
+            height="512"
+            loading="lazy"
+            src="/default-avatar.svg"
+            style="color: transparent;"
+            width="512"
+          />
+          <div
+            class="absolute inset-0 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition"
+          >
+            <button
+              class="text-sm bg-brand text-white px-4 py-1.5 rounded-md focus:outline-none focus-visible:ring"
+              type="button"
+            >
+              Book Now
+            </button>
+          </div>
+        </div>
+      </a>
+      <div
+        class="flex flex-col flex-1 p-6"
+      >
+        <div
+          class="flex items-center"
+        >
+          <h2
+            class="flex-1 text-lg font-semibold text-gray-900 truncate mt-4 mb-2"
+          >
+            A
+          </h2>
+        </div>
+        <hr
+          class="mt-4 mb-4 border-gray-200"
+        />
+        <div
+          class="flex justify-between items-center text-sm text-gray-700"
+        >
+          <span
+            class="flex items-center"
+          >
+            <svg
+              aria-hidden="true"
+              class="h-4 w-4 mr-1 text-yellow-400"
+              data-slot="icon"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="text-gray-400"
+            >
+              No ratings yet
+            </span>
+          </span>
+        </div>
+        <div
+          class="flex justify-between items-center mt-4"
+        >
+          <span />
+          <a
+            href="/artists/1"
+          >
+            <button
+              class="bg-brand text-white text-sm px-4 py-1.5 rounded-md hover:bg-brand-dark"
+              type="button"
+            >
+              View Profile
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,6 +39,16 @@ export interface ArtistProfile {
   updated_at: string;
 }
 
+export interface SearchParams {
+  category?: string;
+  location?: string;
+  sort?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  page?: number;
+  limit?: number;
+}
+
 export interface Service {
   id: number;
   artist_id: number;


### PR DESCRIPTION
## Summary
- document new home artist feed in README
- define `SearchParams` type for artist queries
- create `ArtistsSection` with loading skeleton grid
- render top artist sections on the homepage
- snapshot test for `ArtistsSection`

## Testing
- `./scripts/test-all.sh` *(fails: 8 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f6b76bd00832e9c175bb10b2fa028