### PR TITLE
Show all new artists

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The homepage now showcases musicians in horizontally scrollable carousels. Secti
 
 This discovery feed is experimental and may evolve in future updates.
 
+When there are no profiles to show, the **Popular** and **Top Rated** sections
+are hidden. The **New on Booka** section now displays up to 100 of the newest
+artists so they are easier to discover.
+
 ## Docker Setup
 
 Pull the pre-built image or build it yourself, then run the development

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,9 +6,21 @@ export default function HomePage() {
   return (
     <MainLayout>
       <Hero />
-      <ArtistsSection title="Popular Musicians" query={{ sort: 'popular' }} />
-      <ArtistsSection title="Top Rated" query={{ sort: 'rating_desc' }} />
-      <ArtistsSection title="New on Booka" query={{ sort: 'created_desc' }} />
+      <ArtistsSection
+        title="Popular Musicians"
+        query={{ sort: 'popular' }}
+        hideIfEmpty
+      />
+      <ArtistsSection
+        title="Top Rated"
+        query={{ sort: 'rating_desc' }}
+        hideIfEmpty
+      />
+      <ArtistsSection
+        title="New on Booka"
+        query={{ sort: 'newest' }}
+        limit={100}
+      />
     </MainLayout>
   )
 }

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -11,6 +11,7 @@ interface ArtistsSectionProps {
   title: string;
   query?: Partial<SearchParams>;
   limit?: number;
+  hideIfEmpty?: boolean;
 }
 
 function CardSkeleton() {
@@ -29,6 +30,7 @@ export default function ArtistsSection({
   title,
   query = {},
   limit = 12,
+  hideIfEmpty = false,
 }: ArtistsSectionProps) {
   const [artists, setArtists] = useState<ArtistProfile[]>([]);
   const [loading, setLoading] = useState(true);
@@ -55,6 +57,10 @@ export default function ArtistsSection({
       isMounted = false;
     };
   }, [JSON.stringify(query), limit]);
+
+  if (!loading && artists.length === 0 && hideIfEmpty) {
+    return null;
+  }
 
   const seeAllHref = `/search?${new URLSearchParams(query as Record<string, string>).toString()}`;
   const showSeeAll = artists.length === limit;

--- a/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
+++ b/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
@@ -45,4 +45,21 @@ describe('ArtistsSection', () => {
     });
     container.remove();
   });
+
+  it('hides section when empty and hideIfEmpty is true', async () => {
+    (api.getArtists as jest.Mock).mockResolvedValue({ data: [] });
+
+    const { container, root } = setup();
+    await act(async () => {
+      root.render(<ArtistsSection title="Demo" hideIfEmpty />);
+      await Promise.resolve();
+    });
+
+    expect(container.firstChild).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- adjust ArtistsSection to optionally hide empty sections
- display Popular/Top Rated only when artists exist
- fetch up to 100 artists for New on Booka
- update docs
- test ArtistsSection hideIfEmpty behavior

## Testing
- `./scripts/test-all.sh` *(fails: numerous jest tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687f6eff7afc832eb50c88f763fda1cc