### PR TITLE
Improve home artist cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - **React** 18.3 and **Next.js** 14.2
 - **Python** 3.12.11
 - **Node.js** 22 (v22.16.0)
-- Minor fix: the artists listing now gracefully handles incomplete user data from the API.
+- Artists with missing names are now hidden from listings to avoid "Unknown Artist" placeholders.
 - Artists page adds a **Load More** button that fetches additional results using
   the API's pagination parameters.
 - Artists page redesigned with a responsive grid, animated filter bar, skeleton
@@ -19,8 +19,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - A new animated Hero section on the homepage lets users search by category,
   location and date, persisting selections in the URL.
 - The Hero component now renders only on the homepage to avoid duplicate content.
-- The homepage now highlights popular, top rated, and new artists using the same
-  card layout as the Artists page.
+- The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/src/app/artists/__tests__/page.test.tsx
+++ b/frontend/src/app/artists/__tests__/page.test.tsx
@@ -66,7 +66,7 @@ describe('Artists page filters', () => {
     container.remove();
   });
 
-  it('displays fallback when user data is missing', async () => {
+  it('filters out entries with missing user data', async () => {
     jest.spyOn(api, 'getArtists').mockResolvedValue({
       data: [
         {
@@ -84,7 +84,8 @@ describe('Artists page filters', () => {
       root.render(React.createElement(ArtistsPage));
       await Promise.resolve();
     });
-    expect(container.textContent).toContain('Unknown Artist');
+    expect(container.textContent).not.toContain('Unknown Artist');
+    expect(container.textContent).toContain('No artists found');
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -110,8 +110,9 @@ export default function ArtistsPage() {
         page: pageOverride ?? page,
         limit: LIMIT,
       });
-      setHasMore(res.data.length === LIMIT);
-      setArtists((prev) => (append ? [...prev, ...res.data] : res.data));
+      const filtered = res.data.filter((a) => a.business_name || a.user);
+      setHasMore(filtered.length === LIMIT);
+      setArtists((prev) => (append ? [...prev, ...filtered] : filtered));
     } catch (err) {
       console.error(err);
       setError('Failed to load artists.');
@@ -167,8 +168,7 @@ export default function ArtistsPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {artists.map((a) => {
             const user = a.user;
-            const name = a.business_name ||
-              (user ? `${user.first_name} ${user.last_name}` : 'Unknown Artist');
+            const name = a.business_name || `${user.first_name} ${user.last_name}`;
             return (
               <ArtistCard
                 key={a.id}

--- a/frontend/src/components/artist/ArtistCardCompact.tsx
+++ b/frontend/src/components/artist/ArtistCardCompact.tsx
@@ -1,0 +1,96 @@
+'use client';
+import Image from 'next/image';
+import Link from 'next/link';
+import type { HTMLAttributes } from 'react';
+import { useState } from 'react';
+import {
+  StarIcon,
+} from '@heroicons/react/24/solid';
+import clsx from 'clsx';
+
+export interface ArtistCardCompactProps extends HTMLAttributes<HTMLDivElement> {
+  id: number;
+  name: string;
+  subtitle?: string;
+  imageUrl?: string;
+  price?: number;
+  rating?: number;
+  ratingCount?: number;
+  location?: string | null;
+  href: string;
+}
+
+export default function ArtistCardCompact({
+  id,
+  name,
+  subtitle,
+  imageUrl,
+  price,
+  rating,
+  ratingCount,
+  location,
+  href,
+  className,
+  ...props
+}: ArtistCardCompactProps) {
+  const [loaded, setLoaded] = useState(false);
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'group block rounded-xl overflow-hidden bg-white hover:shadow-md transition',
+        className,
+      )}
+      {...props}
+    >
+      <div className="relative aspect-[4/3] bg-gray-100 overflow-hidden">
+        {!loaded && (
+          <div className="absolute inset-0 animate-pulse bg-gray-200" />
+        )}
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={name}
+            fill
+            sizes="(max-width:768px) 50vw, 33vw"
+            className="object-cover w-full h-full group-hover:scale-105 transition-transform"
+            onLoad={() => setLoaded(true)}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+            }}
+          />
+        ) : (
+          <Image
+            src="/default-avatar.svg"
+            alt={name}
+            fill
+            sizes="(max-width:768px) 50vw, 33vw"
+            className="object-cover w-full h-full"
+            onLoad={() => setLoaded(true)}
+          />
+        )}
+        {rating !== undefined && (
+          <span className="absolute top-1 left-1 text-[10px] bg-white/90 rounded-full px-1.5 py-px flex items-center gap-0.5">
+            <StarIcon className="h-3 w-3 text-yellow-400" />
+            {rating}
+            {ratingCount ? (
+              <span className="text-gray-500 ml-0.5">({ratingCount})</span>
+            ) : null}
+          </span>
+        )}
+        {price !== undefined && (
+          <span className="absolute bottom-1 left-1 text-[10px] bg-white/90 rounded-full px-1.5 py-px">
+            from R{Math.round(price)}
+          </span>
+        )}
+      </div>
+      <div className="p-3 space-y-0.5">
+        <p className="text-sm font-semibold truncate">{name}</p>
+        {subtitle && <p className="text-xs text-gray-500 truncate">{subtitle}</p>}
+        {location && (
+          <p className="text-xs text-gray-400 truncate">{location}</p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/components/artist/__tests__/ArtistCardCompact.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCardCompact.test.tsx
@@ -1,0 +1,33 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ArtistCardCompact from '../ArtistCardCompact';
+
+function setup(props = {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const allProps = {
+    id: 1,
+    name: 'Test',
+    href: '/artists/1',
+    ...props,
+  };
+  return { container, root, allProps };
+}
+
+describe('ArtistCardCompact', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('matches snapshot', () => {
+    const { container, root, allProps } = setup();
+    act(() => {
+      root.render(React.createElement(ArtistCardCompact, allProps));
+    });
+    expect(container.firstChild).toMatchSnapshot();
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import ArtistCard from '@/components/artist/ArtistCard';
+import ArtistCardCompact from '@/components/artist/ArtistCardCompact';
 import { getArtists } from '@/lib/api';
 import { getFullImageUrl } from '@/lib/utils';
 import type { ArtistProfile, SearchParams } from '@/types';
@@ -16,11 +16,11 @@ interface ArtistsSectionProps {
 
 function CardSkeleton() {
   return (
-    <div className="rounded-2xl bg-white shadow-lg overflow-hidden animate-pulse">
-      <div className="h-48 bg-gray-200" />
-      <div className="p-6 space-y-2">
-        <div className="h-4 bg-gray-200 rounded w-2/3" />
-        <div className="h-3 bg-gray-200 rounded w-1/3" />
+    <div className="rounded-xl bg-white overflow-hidden animate-pulse">
+      <div className="aspect-[4/3] bg-gray-200" />
+      <div className="p-3 space-y-1">
+        <div className="h-3 bg-gray-200 rounded" />
+        <div className="h-2.5 bg-gray-200 rounded w-1/2" />
       </div>
     </div>
   );
@@ -42,7 +42,7 @@ export default function ArtistsSection({
       try {
         const res = await getArtists({ ...query, limit });
         if (isMounted) {
-          setArtists(res.data);
+          setArtists(res.data.filter((a) => a.business_name || a.user));
         }
       } catch (err) {
         console.error(err);
@@ -66,9 +66,9 @@ export default function ArtistsSection({
   const showSeeAll = artists.length === limit;
 
   return (
-    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <div className="flex items-end justify-between mb-6">
-        <h2 className="text-2xl font-semibold text-gray-900">{title}</h2>
+    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      <div className="flex items-end justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
         {showSeeAll && (
           <Link href={seeAllHref} className="text-sm text-brand hover:underline">
             See all
@@ -76,18 +76,17 @@ export default function ArtistsSection({
         )}
       </div>
       {loading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
           {Array.from({ length: limit }).map((_, i) => (
             <CardSkeleton key={i} />
           ))}
         </div>
       ) : artists.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
           {artists.map((a) => {
-            const name = a.business_name ||
-              (a.user ? `${a.user.first_name} ${a.user.last_name}` : 'Unknown Artist');
+            const name = a.business_name || `${a.user.first_name} ${a.user.last_name}`;
             return (
-              <ArtistCard
+              <ArtistCardCompact
                 key={a.id}
                 id={a.id}
                 name={name}
@@ -98,12 +97,9 @@ export default function ArtistsSection({
                 price={
                   a.hourly_rate && a.price_visible ? Number(a.hourly_rate) : undefined
                 }
-                location={a.location}
-                specialties={a.specialties}
                 rating={a.rating ?? undefined}
                 ratingCount={a.rating_count ?? undefined}
-                verified={a.user?.is_verified}
-                isAvailable={a.is_available}
+                location={a.location}
                 href={`/artists/${a.id}`}
               />
             );


### PR DESCRIPTION
## Summary
- hide artists that lack names
- add compact `ArtistCardCompact` component
- update home `ArtistsSection` to use compact grid
- adjust tests for filtering logic
- document the change in README

## Testing
- `FAST=1 ./scripts/test-all.sh` *(fails: need eslint download)*

------
https://chatgpt.com/codex/tasks/task_e_687f7196b97c832e9d97fd6ac57d8b00