### PR TITLE
Add tests for null deposit fields

### DIFF
--- a/backend/tests/test_client_bookings_status.py
+++ b/backend/tests/test_client_bookings_status.py
@@ -101,20 +101,20 @@ def test_filter_upcoming_and_past():
     data_upcoming = res_upcoming.json()
     assert len(data_upcoming) == 1
     assert data_upcoming[0]['status'] == 'confirmed'
-    assert 'deposit_due_by' in data_upcoming[0]
-    assert 'deposit_amount' in data_upcoming[0]
-    assert 'payment_status' in data_upcoming[0]
-    assert 'deposit_paid' in data_upcoming[0]
+    assert data_upcoming[0]['deposit_due_by'] is None
+    assert data_upcoming[0]['deposit_amount'] is None
+    assert data_upcoming[0]['payment_status'] is None
+    assert data_upcoming[0]['deposit_paid'] is None
 
     res_past = api_client.get('/api/v1/bookings/my-bookings?status=past')
     assert res_past.status_code == 200
     data_past = res_past.json()
     assert len(data_past) == 1
     assert data_past[0]['status'] == 'completed'
-    assert 'deposit_due_by' in data_past[0]
-    assert 'deposit_amount' in data_past[0]
-    assert 'payment_status' in data_past[0]
-    assert 'deposit_paid' in data_past[0]
+    assert data_past[0]['deposit_due_by'] is None
+    assert data_past[0]['deposit_amount'] is None
+    assert data_past[0]['payment_status'] is None
+    assert data_past[0]['deposit_paid'] is None
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- expand booking deposit field tests to cover null values
- check for null deposit fields in client bookings status API

## Testing
- `PYTHONPATH=backend backend/venv/bin/pytest backend/tests/test_booking_deposit_fields.py backend/tests/test_client_bookings_status.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7665e850832ebebb5327becd1264