### PR TITLE
Fix Link import in MainLayout

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ComponentProps } from 'react';
+import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
 
 import Header from './Header';


### PR DESCRIPTION
## Summary
- fix missing `Link` import in `MainLayout`

## Testing
- `./scripts/test-all.sh` *(fails: 12 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a9083d0832eb8c3257462b39ef3