### PR TITLE
Update home header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,8 @@ The July 2025 update bumps key dependencies and Docker base images:
   the API's pagination parameters.
 - Artists page redesigned with a responsive grid, animated filter bar, skeleton
   loaders and hover "Book Now" overlay for a modern, accessible look.
-- Homepage includes a central search bar so visitors can quickly look up artists by
-  destination and date.
-- A new animated Hero section on the homepage lets users search by category,
-  location and date, persisting selections in the URL.
-- The Hero component now renders only on the homepage to avoid duplicate content.
+- Homepage search now lives in the header on a light gray background.
+- An unobtrusive marketing strip replaces the old Hero section.
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -13,6 +13,7 @@ jest.mock('next/navigation', () => {
     }),
     usePathname: () => '/',
     useParams: jest.fn(() => ({})),
+    useSearchParams: () => new URLSearchParams(),
   };
 });
 
@@ -86,4 +87,12 @@ const mockAutocomplete = jest.fn(function Autocomplete(this: any) {
   },
 };
 (globalThis as any).mockAutocomplete = mockAutocomplete;
+
+// Additional browser stubs
+(window as any).confirm = jest.fn(() => true);
+(window as any).URL.createObjectURL = jest.fn(() => 'blob:');
+Object.defineProperty(window, 'location', {
+  value: { ...window.location, assign: jest.fn() },
+  writable: true,
+});
 

--- a/frontend/src/app/__tests__/HomePage.test.tsx
+++ b/frontend/src/app/__tests__/HomePage.test.tsx
@@ -8,21 +8,21 @@ jest.mock('@/components/layout/MainLayout', () => {
   Mock.displayName = 'MockMainLayout';
   return Mock;
 });
-jest.mock('@/components/layout/Hero', () => {
-  const Mock = () => <div data-testid="hero" />;
-  Mock.displayName = 'MockHero';
+jest.mock('@/components/home/MarketingStrip', () => {
+  const Mock = ({ text }: { text: string }) => <div data-testid="strip">{text}</div>;
+  Mock.displayName = 'MockMarketingStrip';
   return Mock;
 });
 
 describe('HomePage', () => {
-  it('renders hero section', async () => {
+  it('renders marketing strip', async () => {
     const div = document.createElement('div');
     document.body.appendChild(div);
     const root = createRoot(div);
     await act(async () => {
       root.render(<HomePage />);
     });
-    expect(div.querySelector('[data-testid="hero"]')).toBeTruthy();
+    expect(div.querySelector('[data-testid="strip"]')).toBeTruthy();
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,11 @@
 import MainLayout from '@/components/layout/MainLayout'
-import Hero from '@/components/layout/Hero'
+import MarketingStrip from '@/components/home/MarketingStrip'
 import ArtistsSection from '@/components/home/ArtistsSection'
 
 export default function HomePage() {
   return (
     <MainLayout>
-      <Hero variant="plain" />
+      <MarketingStrip text="Book legendary artists across South Africa" />
       <ArtistsSection
         title="Popular Musicians"
         query={{ sort: 'popular' }}

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -76,13 +76,13 @@ export default function ArtistsSection({
         )}
       </div>
       {loading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-5">
           {Array.from({ length: limit }).map((_, i) => (
             <CardSkeleton key={i} />
           ))}
         </div>
       ) : artists.length > 0 ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-5">
           {artists.map((a) => {
             const name = a.business_name || `${a.user.first_name} ${a.user.last_name}`;
             return (

--- a/frontend/src/components/home/MarketingStrip.tsx
+++ b/frontend/src/components/home/MarketingStrip.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+interface MarketingStripProps {
+  text: string;
+}
+
+export default function MarketingStrip({ text }: MarketingStripProps) {
+  return (
+    <div className="bg-brand-light text-brand-dark text-center py-2 text-sm font-medium">
+      {text}
+    </div>
+  );
+}

--- a/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
+++ b/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ArtistsSection matches snapshot 1`] = `
     </h2>
   </div>
   <div
-    class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4"
+    class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-5"
   >
     <a
       href="/artists/1"

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export default function Header() {
   const { user, logout } = useAuth();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
-  const showSearch = pathname === '/';
+  const isHome = pathname === '/';
 
   const navigation = [...baseNavigation];
   if (user?.user_type === 'artist') {
@@ -41,7 +41,7 @@ export default function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-40 bg-white">
+    <header className="sticky top-0 z-40 bg-gray-50">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {/* Row A */}
         <div className="h-16 flex items-center justify-between">
@@ -169,15 +169,13 @@ export default function Header() {
         </div>
 
         {/* Row B */}
-        {showSearch && (
-          <div className="pb-4">
-            <div className="w-full md:max-w-3xl mx-auto">
-              <SearchBar />
-            </div>
+        {isHome && (
+          <div className="pb-3 pt-2">
+            <SearchBar className="mx-auto w-full md:max-w-3xl shadow-sm ring-1 ring-gray-200" />
           </div>
         )}
       </div>
-      <div className="border-t border-gray-200" />
+      {isHome && <div className="border-t border-gray-200" />}
       <MobileMenuDrawer
         open={menuOpen}
         onClose={() => setMenuOpen(false)}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -80,7 +80,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         <Header />
 
         {/* CONTENT */}
-        <main className="py-10 pb-24">
+        <main className="py-8 pb-24">
           <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">{children}</div>
           <HelpPrompt className="mx-auto mt-10 max-w-7xl sm:px-6 lg:px-8" />
         </main>

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -6,7 +6,11 @@ import { usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 
 jest.mock('next/link', () => ({ __esModule: true, default: (props: Record<string, unknown>) => <a {...props} /> }));
-jest.mock('next/navigation', () => ({ usePathname: jest.fn() }));
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 jest.mock('@/contexts/AuthContext', () => ({ useAuth: jest.fn(() => ({ user: null, logout: jest.fn() })) }));
 
 function render() {

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header hides search bar on other pages 1`] = `
 <header
-  class="sticky top-0 z-40 bg-white"
+  class="sticky top-0 z-40 bg-gray-50"
 >
   <div
     class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
@@ -97,6 +97,227 @@ exports[`Header hides search bar on other pages 1`] = `
           </svg>
         </button>
       </div>
+    </div>
+  </div>
+</header>
+`;
+
+exports[`Header renders search bar on home page 1`] = `
+<header
+  class="sticky top-0 z-40 bg-gray-50"
+>
+  <div
+    class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
+  >
+    <div
+      class="h-16 flex items-center justify-between"
+    >
+      <div
+        class="flex"
+      >
+        <a
+          class="flex shrink-0 items-center text-xl font-bold text-brand-dark"
+          href="/"
+        >
+          Booka.co.za
+        </a>
+        <div
+          class="hidden sm:ml-6 sm:flex sm:space-x-8"
+        >
+          <a
+            class="inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            href="/artists"
+          >
+            Artists
+          </a>
+          <a
+            class="inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            href="/services"
+          >
+            Services
+          </a>
+          <a
+            class="inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            href="/faq"
+          >
+            FAQ
+          </a>
+          <a
+            class="inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            href="/contact"
+          >
+            Contact
+          </a>
+        </div>
+      </div>
+      <div
+        class="hidden sm:ml-6 sm:flex sm:items-center"
+      >
+        <div
+          class="space-x-4"
+        >
+          <a
+            class="text-gray-500 hover:text-gray-700 px-3 py-2 text-sm font-medium"
+            href="/login"
+          >
+            Sign in
+          </a>
+          <a
+            class="bg-brand-dark text-white hover:bg-brand-dark px-3 py-2 rounded-md text-sm font-medium"
+            href="/register"
+          >
+            Sign up
+          </a>
+        </div>
+      </div>
+      <div
+        class="flex items-center sm:hidden"
+      >
+        <button
+          class="-mr-2 ml-2 inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand"
+        >
+          <span
+            class="sr-only"
+          >
+            Open main menu
+          </span>
+          <svg
+            aria-hidden="true"
+            class="h-6 w-6"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      class="pb-3 pt-2"
+    >
+      <form
+        class="flex items-stretch bg-white rounded-full shadow-lg overflow-visible"
+      >
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
+        >
+          <span
+            class="text-xs text-gray-500"
+          >
+            Category
+          </span>
+          <div
+            class="relative w-full"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="mt-1 w-full flex justify-between items-center text-sm text-gray-700 focus:outline-none"
+              data-headlessui-state=""
+              id="headlessui-listbox-button-:r0:"
+              type="button"
+            >
+              <span>
+                Musician / Band
+              </span>
+              <svg
+                aria-hidden="true"
+                class="h-4 w-4 text-gray-400"
+                data-slot="icon"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m19.5 8.25-7.5 7.5-7.5-7.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="border-l border-gray-200"
+        />
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
+        >
+          <span
+            class="text-xs text-gray-500"
+          >
+            Where
+          </span>
+          <input
+            class="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
+            placeholder="City or venue"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="border-l border-gray-200"
+        />
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
+        >
+          <span
+            class="text-xs text-gray-500"
+          >
+            When
+          </span>
+          <div
+            class="react-datepicker-wrapper"
+          >
+            <div
+              class="react-datepicker__input-container"
+            >
+              <input
+                class="mt-1 w-full text-sm text-gray-700 focus:outline-none"
+                placeholder="Add date & time"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <button
+          class="bg-pink-600 hover:bg-pink-700 px-5 py-3 flex items-center justify-center text-white rounded-r-full"
+          type="submit"
+        >
+          <svg
+            aria-hidden="true"
+            class="h-5 w-5"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <span
+            class="sr-only"
+          >
+            Search
+          </span>
+        </button>
+      </form>
     </div>
   </div>
   <div


### PR DESCRIPTION
## Summary
- remove Hero section and add MarketingStrip under header
- style header on light gray with search pill and divider only on home
- tweak main layout padding and card grid gaps
- update docs for new header design
- update snapshots

## Testing
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: Not implemented window.scrollTo, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f7d42ff5c832e802bdf46bbfaf4cf