### PR TITLE
Fix deposit defaults when BookingSimple missing

### DIFF
--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -171,14 +171,17 @@ def read_my_bookings(
         deposit_paid,
         booking_request_id,
     ) in rows:
-        if deposit_due is not None:
-            booking.deposit_due_by = deposit_due
-        if deposit_amount is not None:
+        has_simple = deposit_paid is not None
+
+        booking.deposit_due_by = deposit_due if has_simple else None
+        booking.payment_status = payment_status if has_simple else None
+        booking.deposit_paid = deposit_paid if has_simple else None
+
+        if deposit_amount is None:
+            booking.deposit_amount = Decimal("0")
+        else:
             booking.deposit_amount = deposit_amount
-        if payment_status is not None:
-            booking.payment_status = payment_status
-        if deposit_paid is not None:
-            booking.deposit_paid = deposit_paid
+
         if booking_request_id is not None:
             booking.booking_request_id = booking_request_id
         bookings.append(booking)
@@ -319,14 +322,17 @@ def read_booking_details(
             detail="You do not have permission to view this booking.",
         )
 
-    if deposit_due is not None:
-        booking.deposit_due_by = deposit_due
-    if deposit_amount is not None:
+    has_simple = deposit_paid is not None
+
+    booking.deposit_due_by = deposit_due if has_simple else None
+    booking.payment_status = payment_status if has_simple else None
+    booking.deposit_paid = deposit_paid if has_simple else None
+
+    if deposit_amount is None:
+        booking.deposit_amount = Decimal("0")
+    else:
         booking.deposit_amount = deposit_amount
-    if payment_status is not None:
-        booking.payment_status = payment_status
-    if deposit_paid is not None:
-        booking.deposit_paid = deposit_paid
+
     if booking_request_id is not None:
         booking.booking_request_id = booking_request_id
 

--- a/backend/tests/test_booking_deposit_fields.py
+++ b/backend/tests/test_booking_deposit_fields.py
@@ -152,7 +152,7 @@ def test_booking_endpoints_null_fields_when_no_simple():
         db=db, current_client=client, status_filter=None
     )
     first = result[0]
-    assert getattr(first, "deposit_amount", None) is None
+    assert first.deposit_amount == Decimal("0")
     assert getattr(first, "payment_status", None) is None
     assert getattr(first, "deposit_paid", None) is None
     assert getattr(first, "deposit_due_by", None) is None
@@ -161,7 +161,7 @@ def test_booking_endpoints_null_fields_when_no_simple():
     detail = api_booking.read_booking_details(
         db=db, booking_id=booking.id, current_user=client
     )
-    assert getattr(detail, "deposit_amount", None) is None
+    assert detail.deposit_amount == Decimal("0")
     assert getattr(detail, "payment_status", None) is None
     assert getattr(detail, "deposit_paid", None) is None
     assert getattr(detail, "deposit_due_by", None) is None


### PR DESCRIPTION
## Summary
- ensure deposit fields populated when BookingSimple row missing
- set deposit amount to zero when column is NULL
- update unit tests for default deposit fields

## Testing
- `./scripts/test-all.sh` *(fails: BookingWizard flow and others)*

------
https://chatgpt.com/codex/tasks/task_e_687f82fe92a4832e832edc0b8d41a779