### PR TITLE
Fix tagline and search bar alignment

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -52,8 +52,8 @@ export default function Header() {
                 Booka.co.za
               </Link>
               {isHome && (
-                <span className="hidden sm:block -mt-1 text-[12px] leading-4 text-gray-600">
-                  Book legendary artists across South Africa
+                <span className="hidden sm:block -mt-0.5 text-[11px] sm:text-[12px] leading-4 text-gray-600">
+                  Book legendary artists
                 </span>
               )}
             </div>
@@ -180,7 +180,7 @@ export default function Header() {
           <div className="pb-3 pt-2">
             <SearchBar
               size="sm"
-              className="mx-auto w-full md:max-w-2xl shadow-sm ring-1 ring-gray-200"
+              className="mx-auto w-full md:max-w-2xl"
             />
           </div>
         )}

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -129,9 +129,9 @@ exports[`Header renders search bar on home page 1`] = `
             Booka.co.za
           </a>
           <span
-            class="hidden sm:block -mt-1 text-[12px] leading-4 text-gray-600"
+            class="hidden sm:block -mt-0.5 text-[11px] sm:text-[12px] leading-4 text-gray-600"
           >
-            Book legendary artists across South Africa
+            Book legendary artists
           </span>
         </div>
         <div
@@ -217,7 +217,7 @@ exports[`Header renders search bar on home page 1`] = `
       class="pb-3 pt-2"
     >
       <form
-        class="flex items-stretch bg-white rounded-full shadow-lg overflow-visible text-sm mx-auto w-full md:max-w-2xl shadow-sm ring-1 ring-gray-200"
+        class="flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-sm overflow-hidden text-sm mx-auto w-full md:max-w-2xl"
       >
         <div
           class="flex-1 px-4 flex flex-col text-left py-2"
@@ -305,7 +305,7 @@ exports[`Header renders search bar on home page 1`] = `
           </div>
         </div>
         <button
-          class="bg-pink-600 hover:bg-pink-700 flex items-center justify-center text-white h-10 w-10 rounded-full"
+          class="flex items-center justify-center w-12 h-12 md:w-11 md:h-11 bg-pink-600 hover:bg-pink-700 text-white"
           type="submit"
         >
           <svg

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -158,7 +158,7 @@ export default function SearchBar({ size = 'md', className }: SearchBarProps) {
     <form
       onSubmit={onSubmit}
       className={clsx(
-        'flex items-stretch bg-white rounded-full shadow-lg overflow-visible',
+        'flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-sm overflow-hidden',
         size === 'sm' && 'text-sm',
         className
       )}
@@ -174,12 +174,7 @@ export default function SearchBar({ size = 'md', className }: SearchBarProps) {
       />
       <button
         type="submit"
-        className={clsx(
-          'bg-pink-600 hover:bg-pink-700 flex items-center justify-center text-white',
-          size === 'sm'
-            ? 'h-10 w-10 rounded-full'
-            : 'px-5 py-3 rounded-r-full'
-        )}
+        className="flex items-center justify-center w-12 h-12 md:w-11 md:h-11 bg-pink-600 hover:bg-pink-700 text-white"
       >
         <MagnifyingGlassIcon className="h-5 w-5" />
         <span className="sr-only">Search</span>


### PR DESCRIPTION
## Summary
- adjust tagline text and styles
- tweak search bar form and button classes
- update Header snapshot

## Testing
- `npm run test:unit -- -u` *(fails: DashboardPage.test.tsx, Artists page tests, FilterBar tests, getNotificationDisplayProps test, ProfilePicturePage.test.tsx, etc.)*
- `./scripts/test-all.sh` *(fails: backend tests - test_client_bookings_status.py::test_filter_upcoming_and_past)*

------
https://chatgpt.com/codex/tasks/task_e_687f84a01984832ea9f10a86b5f27190