### PR TITLE
Add Jest no-network mock

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '/node_modules/(?!(react-calendar|@wojtekmaj/date-utils|get-user-locale|warning|memoize|mimic-function)/)',
   ],
   moduleNameMapper: {
+    '^@/tests/(.*)$': '<rootDir>/tests/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',
     '\\.module\\.(css|less|scss|sass)$': 'identity-obj-proxy',

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -2,6 +2,7 @@
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 import React from "react";
+import "@/tests/mocks/no-network";
 
 jest.mock('next/navigation', () => {
   return {

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/tests/*": ["./tests/*"]
     }
   }
 } 

--- a/frontend/tests/mocks/no-network.ts
+++ b/frontend/tests/mocks/no-network.ts
@@ -1,0 +1,19 @@
+const fail = () => {
+  throw new Error('Network access is disabled in unit tests. Mock requests instead.');
+};
+
+(globalThis as any).fetch = jest.fn(() => fail());
+
+class NoXMLHttpRequest {
+  constructor() {
+    fail();
+  }
+}
+(globalThis as any).XMLHttpRequest = NoXMLHttpRequest as any;
+
+class NoWebSocket {
+  constructor() {
+    fail();
+  }
+}
+(globalThis as any).WebSocket = NoWebSocket as any;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/tests/*": ["./tests/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- block network APIs in front-end Jest environment
- load new mock module from `jest.setup.ts`
- map `@/tests/*` alias in TypeScript and Jest configs

## Testing
- `./scripts/test-all.sh` *(fails: 9 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f87e2593c832ea88cf530ee5c6692