### PR TITLE
Fix SendQuoteModal snapshot timing

### DIFF
--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -5,6 +5,15 @@ import SendQuoteModal from '../SendQuoteModal';
 import * as api from '@/lib/api';
 import { formatCurrency } from '@/lib/utils';
 
+const flushPromises = () =>
+  new Promise<void>((resolve) => {
+    if (typeof setImmediate === 'function') {
+      setImmediate(resolve);
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+
 jest.mock('@/lib/api');
 
 describe('SendQuoteModal', () => {
@@ -216,6 +225,9 @@ describe('SendQuoteModal', () => {
           serviceName="Live Performance"
         />,
       );
+    });
+    await act(async () => {
+      await flushPromises();
     });
     expect(div.firstChild).toMatchSnapshot();
     root.unmount();

--- a/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
+++ b/frontend/src/components/booking/__tests__/__snapshots__/SendQuoteModal.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SendQuoteModal matches snapshot 1`] = `
           Quote #2025-4394
         </div>
         <div>
-          July 18th, 2025
+          July 22nd, 2025
         </div>
         <input
           class="border rounded p-1"


### PR DESCRIPTION
## Summary
- ensure SendQuoteModal tests flush async work before taking snapshots
- update snapshot

## Testing
- `npm --prefix frontend test -- -u` *(fails: Test Suites: 8 failed)*
- `./scripts/test-all.sh` *(fails: Test Suites: 8 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f8a483f70832e983edf25568ea20d