### PR TITLE
Fix SearchBar overflow clipping

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -160,7 +160,7 @@ export default function SearchBar({ size = 'md', className, wrapperClassName }: 
       <form
         onSubmit={onSubmit}
         className={clsx(
-          'flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-md overflow-hidden min-h-[48px]',
+          'flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-md overflow-visible min-h-[48px]',
           size === 'sm' && 'text-sm',
           className
         )}


### PR DESCRIPTION
## Summary
- allow dropdowns inside `SearchBar` to escape the form by using `overflow-visible`

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f8e379c04832ea3f2748f1d9695ba