### PR TITLE
Add location autocomplete to SearchBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyDm-BKmMtzMSMd-XUdfapjEUU6O5mYy2bk
 
 `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` should be a browser key with the Places API
 enabled. It powers the `LocationInput` autocomplete fields used in the artist
-filters and booking steps.
+filters, search bar, and booking steps.
 
 The host portion of `NEXT_PUBLIC_API_URL` is also used by
 `next.config.js` to allow optimized image requests from the backend.

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -7,6 +7,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 import { Listbox, Transition } from '@headlessui/react';
 import { ChevronDownIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
+import LocationInput from '@/components/ui/LocationInput';
 
 const CATEGORIES = [
   { value: 'musician', label: 'Musician / Band' },
@@ -99,11 +100,10 @@ const SearchFields = forwardRef<HTMLDivElement, FormFieldsProps>(
         )}
       >
         <span className="text-xs text-gray-500">Where</span>
-        <input
-          type="text"
-          placeholder="City or venue"
+        <LocationInput
           value={location}
-          onChange={(e) => setLocation(e.target.value)}
+          onChange={setLocation}
+          placeholder="City or venue"
           className="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
         />
       </div>

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -1,0 +1,53 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import SearchBar from '../SearchBar';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('SearchBar location input', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('updates location via autocomplete and pushes correct URL', async () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    (useSearchParams as jest.Mock).mockReturnValue({ get: () => null });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBar />);
+    });
+
+    const mock = (global as { mockAutocomplete: jest.Mock }).mockAutocomplete;
+    const instance = mock.mock.instances[0];
+    instance.getPlace.mockReturnValue({ formatted_address: 'Cape Town' });
+
+    await act(async () => {
+      instance._cb();
+      await flushPromises();
+    });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+      await flushPromises();
+    });
+
+    expect(push).toHaveBeenCalledWith('/artists?location=Cape%20Town');
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- enhance `SearchBar` to reuse `LocationInput` with Google Places autocomplete
- document the new search bar behaviour
- test SearchBar location updates via autocomplete

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 16 failed, 13 passed, 29 total)*

------
https://chatgpt.com/codex/tasks/task_e_687f92d6c000832e80c9a8efc835657c