### PR TITLE
Fix search bar location styling

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -104,7 +104,7 @@ const SearchFields = forwardRef<HTMLDivElement, FormFieldsProps>(
           value={location}
           onChange={setLocation}
           placeholder="City or venue"
-          className="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
+          className="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none border-none shadow-none rounded-none bg-transparent p-0 focus:ring-0"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- use `LocationInput` with transparent style in `SearchBar`

## Testing
- `./scripts/test-all.sh` *(fails: 20 failed, 1 skipped, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f954e4e0c832eaf142d12c75344c0