### PR TITLE
Standardize flushPromises in frontend tests

### DIFF
--- a/frontend/src/app/account/__tests__/DeleteAccountPage.test.tsx
+++ b/frontend/src/app/account/__tests__/DeleteAccountPage.test.tsx
@@ -18,6 +18,10 @@ jest.mock('@/components/ui/Button', () => {
   return Btn;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('DeleteAccountPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -42,7 +46,7 @@ describe('DeleteAccountPage', () => {
     await act(async () => {
       form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(deleteMyAccount).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith('/login');
     act(() => {

--- a/frontend/src/app/account/__tests__/ExportAccountPage.test.tsx
+++ b/frontend/src/app/account/__tests__/ExportAccountPage.test.tsx
@@ -11,6 +11,10 @@ jest.mock('@/components/layout/MainLayout', () => {
   return Mock;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ExportAccountPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -23,7 +27,7 @@ describe('ExportAccountPage', () => {
     await act(async () => {
       root.render(<ExportAccountPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(exportMyAccount).toHaveBeenCalled();
     expect(div.textContent).toContain('"id": 1');
     act(() => {

--- a/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
+++ b/frontend/src/app/account/__tests__/ProfilePicturePage.test.tsx
@@ -31,6 +31,10 @@ jest.mock('@/components/ui/Button', () => {
   return Btn;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ProfilePicturePage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -55,7 +59,7 @@ describe('ProfilePicturePage', () => {
     await act(async () => {
       btn.dispatchEvent(new Event('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(uploadMyProfilePicture).toHaveBeenCalled();
     expect(refreshUser).toHaveBeenCalled();
     act(() => { root.unmount(); });

--- a/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
+++ b/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@/components/layout/MainLayout', () => {
   return Mock;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup(markItem = jest.fn()) {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' } });
   const push = jest.fn();
@@ -79,9 +83,7 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       root.render(<BookingRequestsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const aliceRow = container.querySelector('li[data-request-id="1"]');
     expect(aliceRow?.className).toContain('bg-brand-light');
     const badge = aliceRow?.querySelector('span.bg-red-600');
@@ -97,9 +99,7 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       root.render(<BookingRequestsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const input = container.querySelector(
       'input[aria-label="Search by client name"]',
     ) as HTMLInputElement;
@@ -107,9 +107,7 @@ describe('BookingRequestsPage', () => {
       input.value = 'Bob';
       input.dispatchEvent(new Event('input', { bubbles: true }));
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const bobRow = Array.from(container.querySelectorAll('li[data-request-id]')).find((li) =>
       li.textContent?.includes('Bob B'),
     );
@@ -126,16 +124,12 @@ describe('BookingRequestsPage', () => {
     await act(async () => {
       root.render(<BookingRequestsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const row = container.querySelector('li[data-request-id="1"]') as HTMLLIElement;
     await act(async () => {
       row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     expect(markItem).toHaveBeenCalled();
     expect(push).toHaveBeenCalledWith('/booking-requests/1');
     act(() => {

--- a/frontend/src/app/booking/__tests__/BookingPage.test.tsx
+++ b/frontend/src/app/booking/__tests__/BookingPage.test.tsx
@@ -12,6 +12,10 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(() => '/booking'),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 interface AuthValue {
   user: unknown;
   loading: boolean;
@@ -53,7 +57,7 @@ describe('BookingPage auth flow', () => {
     await act(async () => {
       root.render(<BookingPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(container.textContent).toContain('Date & Time');
     act(() => {
       root.unmount();

--- a/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/bookings/__tests__/ArtistBookingsPage.test.tsx
@@ -13,6 +13,10 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(() => '/dashboard/bookings'),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ArtistBookingsPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -45,7 +49,7 @@ describe('ArtistBookingsPage', () => {
     await act(async () => {
       root.render(<ArtistBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('View Quote');
     act(() => {
       root.unmount();
@@ -79,7 +83,7 @@ describe('ArtistBookingsPage', () => {
     await act(async () => {
       root.render(<ArtistBookingsPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     const icsBtn = Array.from(div.querySelectorAll('button')).find(
       (b) => b.textContent?.trim() === 'Add to Calendar',
@@ -97,7 +101,7 @@ describe('ArtistBookingsPage', () => {
     await act(async () => {
       completeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(api.updateBookingStatus).toHaveBeenCalledWith(1, 'completed');
     expect(div.textContent).toContain('Completed');
 

--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -23,6 +23,10 @@ jest.mock("next/link", () => {
 });
 /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe("BookingDetailsPage", () => {
   beforeEach(() => {
     (useSearchParams as jest.Mock).mockReturnValue({ get: () => null });
@@ -58,9 +62,7 @@ describe("BookingDetailsPage", () => {
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     expect(getBookingDetails).toHaveBeenCalledWith(1);
     expect(div.textContent).toContain("Gig - Artist");
@@ -106,9 +108,7 @@ describe("BookingDetailsPage", () => {
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const link = div.querySelector('[data-testid="booking-receipt-link"]');
     expect(link).not.toBeNull();
@@ -147,9 +147,7 @@ describe("BookingDetailsPage", () => {
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const help = div.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();
@@ -188,12 +186,8 @@ describe("BookingDetailsPage", () => {
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
+    await flushPromises();
 
     const msg = div.querySelector('[data-testid="message-artist-link"]');
     expect(msg).not.toBeNull();
@@ -237,9 +231,7 @@ describe("BookingDetailsPage", () => {
     await act(async () => {
       root.render(<BookingDetailsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const modalHeading = div.querySelector("h2");
     expect(modalHeading?.textContent).toContain("Pay Deposit");

--- a/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/ClientBookingsPage.test.tsx
@@ -23,6 +23,10 @@ jest.mock("next/link", () => {
 });
 /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe("ClientBookingsPage", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -87,9 +91,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     expect(getMyClientBookings).toHaveBeenCalledWith({ status: "upcoming" });
     expect(getMyClientBookings).toHaveBeenCalledWith({ status: "past" });
@@ -157,9 +159,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     expect(div.textContent).toContain("Leave review");
     const help = div.querySelector('[data-testid="help-prompt"]');
@@ -228,9 +228,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const payBtn = div.querySelector(
       '[data-testid="pay-deposit-button"]',
@@ -240,9 +238,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       payBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     expect(getBookingDetails).toHaveBeenCalledWith(5);
     const input = div.querySelector('input[type="text"]') as HTMLInputElement;
@@ -294,9 +290,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const msgLink = div.querySelector('[data-testid="message-artist-link"]');
     expect(msgLink).not.toBeNull();
@@ -349,9 +343,7 @@ describe("ClientBookingsPage", () => {
     await act(async () => {
       root.render(<ClientBookingsPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const alert = div.querySelector('[data-testid="pending-payment-alert"]');
     expect(alert).not.toBeNull();

--- a/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
+++ b/frontend/src/app/dashboard/client/quotes/__tests__/ClientQuotesPage.test.tsx
@@ -13,6 +13,10 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(() => '/dashboard/client/quotes'),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ClientQuotesPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -37,7 +41,7 @@ describe('ClientQuotesPage', () => {
     await act(async () => {
       root.render(<ClientQuotesPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     expect(getMyClientQuotes).toHaveBeenCalled();
     expect(div.textContent).toContain('My Quotes');
@@ -77,7 +81,7 @@ describe('ClientQuotesPage', () => {
     await act(async () => {
       root.render(<ClientQuotesPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     const select = div.querySelector('select') as HTMLSelectElement;
     (getMyClientQuotes as jest.Mock).mockResolvedValue({
@@ -99,7 +103,7 @@ describe('ClientQuotesPage', () => {
       select.value = 'accepted';
       select.dispatchEvent(new Event('change', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     expect(getMyClientQuotes).toHaveBeenLastCalledWith({ status: 'accepted' });
     expect(div.textContent).toContain('Accepted by Client');
@@ -122,7 +126,7 @@ describe('ClientQuotesPage', () => {
     await act(async () => {
       root.render(<ClientQuotesPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     const help = div.querySelector('[data-testid="help-prompt"]');
     expect(help).not.toBeNull();

--- a/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/CalendarSync.test.tsx
@@ -19,6 +19,10 @@ jest.mock('@/components/layout/MainLayout', () => {
   return Mock;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup(calendarParam: string | null = null, status = false) {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
@@ -48,21 +52,21 @@ describe('Google Calendar connect/disconnect', () => {
     await act(async () => {
       root.render(<EditArtistProfilePage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const connectBtn = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Connect') as HTMLButtonElement;
     await act(async () => {
       connectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(api.connectGoogleCalendar).toHaveBeenCalled();
 
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     act(() => { root.unmount(); });
     const newRoot = createRoot(div);
     (api.getGoogleCalendarStatus as jest.Mock).mockResolvedValue({
       data: { connected: true, email: 'test@example.com' },
     });
     await act(async () => { newRoot.render(<EditArtistProfilePage />); });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const disconnectBtn = Array.from(div.querySelectorAll('button')).find((b) => b.textContent === 'Disconnect') as HTMLButtonElement;
     await act(async () => {
       disconnectBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -77,7 +81,7 @@ describe('Google Calendar connect/disconnect', () => {
     await act(async () => {
       root.render(<EditArtistProfilePage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Status: Not connected');
     act(() => { root.unmount(); });
     const newRoot = createRoot(div);
@@ -85,7 +89,7 @@ describe('Google Calendar connect/disconnect', () => {
       data: { connected: true, email: 'test@example.com' },
     });
     await act(async () => { newRoot.render(<EditArtistProfilePage />); });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Status: Connected - test@example.com');
     act(() => { newRoot.unmount(); });
     div.remove();
@@ -96,7 +100,7 @@ describe('Google Calendar connect/disconnect', () => {
     await act(async () => {
       root.render(<EditArtistProfilePage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Google Calendar connected successfully!');
     expect(div.textContent).toContain('Status: Connected - test@example.com');
     act(() => { root.unmount(); });
@@ -108,7 +112,7 @@ describe('Google Calendar connect/disconnect', () => {
     await act(async () => {
       root.render(<EditArtistProfilePage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Failed to connect Google Calendar.');
     expect(div.textContent).toContain('Status: Not connected');
     act(() => { root.unmount(); });

--- a/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
+++ b/frontend/src/app/dashboard/profile/__tests__/PortfolioImages.test.tsx
@@ -19,6 +19,10 @@ jest.mock('@/components/layout/MainLayout', () => {
   return Mock;
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup() {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'artist' } });
   (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
@@ -46,7 +50,7 @@ describe('Portfolio images upload and reorder', () => {
     await act(async () => {
       root.render(<EditArtistProfilePage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const input = div.querySelector('#portfolioImagesInput') as HTMLInputElement;
     const file = new File(['1'], 'a.jpg', { type: 'image/jpeg' });
     await act(async () => {
@@ -54,7 +58,7 @@ describe('Portfolio images upload and reorder', () => {
       input.dispatchEvent(new Event('change', { bubbles: true }));
     });
     expect(api.uploadMyArtistPortfolioImages).toHaveBeenCalled();
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const items = div.querySelectorAll('[data-testid="portfolio-item"]');
     expect(items.length).toBe(3);
     await act(async () => {

--- a/frontend/src/app/dashboard/quotes/__tests__/ArtistQuotesPage.test.tsx
+++ b/frontend/src/app/dashboard/quotes/__tests__/ArtistQuotesPage.test.tsx
@@ -18,6 +18,10 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(() => '/dashboard/quotes'),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ArtistQuotesPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -42,7 +46,7 @@ describe('ArtistQuotesPage', () => {
     await act(async () => {
       root.render(<ArtistQuotesPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     const withdrawBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent === 'Withdraw') as HTMLButtonElement;
     expect(withdrawBtn).toBeTruthy();
@@ -86,7 +90,7 @@ describe('ArtistQuotesPage', () => {
     await act(async () => {
       root.render(<ArtistQuotesPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     const editBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent === 'Edit') as HTMLButtonElement;
     expect(editBtn).toBeTruthy();

--- a/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
+++ b/frontend/src/app/quotes/__tests__/QuoteDetailPage.test.tsx
@@ -9,6 +9,10 @@ import { useParams } from 'next/navigation';
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup() {
   (useParams as jest.Mock).mockReturnValue({ quoteId: '5' });
   (useAuth as jest.Mock).mockReturnValue({
@@ -48,9 +52,7 @@ describe('QuoteDetailPage', () => {
     await act(async () => {
       root.render(<QuoteDetailPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     expect(div.textContent).toContain('Quote #5');
     expect(div.textContent).toContain('Perf');
     act(() => {
@@ -65,9 +67,7 @@ describe('QuoteDetailPage', () => {
     await act(async () => {
       root.render(<QuoteDetailPage />);
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const acceptBtn = Array.from(div.querySelectorAll('button')).find(
       (b) => b.textContent === 'Accept',

--- a/frontend/src/app/services/[id]/__tests__/ServiceDetailPage.test.tsx
+++ b/frontend/src/app/services/[id]/__tests__/ServiceDetailPage.test.tsx
@@ -11,6 +11,10 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('ServiceDetailPage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -48,7 +52,7 @@ describe('ServiceDetailPage', () => {
     await act(async () => {
       root.render(<ServiceDetailPage />);
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     expect(getService).toHaveBeenCalledWith(1);
     expect(getServiceReviews).toHaveBeenCalledWith(1);

--- a/frontend/src/app/sound-providers/__tests__/page.test.tsx
+++ b/frontend/src/app/sound-providers/__tests__/page.test.tsx
@@ -10,6 +10,10 @@ jest.mock('@/contexts/AuthContext');
 // eslint-disable-next-line react/display-name
 jest.mock('@/components/layout/MainLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup() {
   (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist' } });
   (api.getSoundProviders as jest.Mock).mockResolvedValue({ data: [
@@ -31,7 +35,7 @@ describe('SoundProvidersPage', () => {
   it('allows editing providers', async () => {
     const { div, root } = setup();
     await act(async () => { root.render(<SoundProvidersPage />); });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const editBtn = div.querySelector('button[data-edit]') as HTMLButtonElement;
     expect(editBtn).toBeTruthy();
     await act(async () => {
@@ -47,7 +51,7 @@ describe('SoundProvidersPage', () => {
     await act(async () => {
       saveBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(api.updateSoundProvider).toHaveBeenCalledTimes(1);
     act(() => { root.unmount(); });
     div.remove();
@@ -56,7 +60,7 @@ describe('SoundProvidersPage', () => {
   it('submits artist preferences', async () => {
     const { div, root } = setup();
     await act(async () => { root.render(<SoundProvidersPage />); });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const select = div.querySelector('select[data-pref-provider]') as HTMLSelectElement;
     act(() => {
       select.value = '1';
@@ -71,7 +75,7 @@ describe('SoundProvidersPage', () => {
     await act(async () => {
       addBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(api.addArtistSoundPreference).toHaveBeenCalledTimes(1);
     act(() => { root.unmount(); });
     div.remove();

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -22,14 +22,9 @@ jest.mock('../SendQuoteModal', () => {
   return { __esModule: true, default: MockModal };
 });
 
-const flushPromises = () =>
-  new Promise<void>((resolve) => {
-    if (typeof setImmediate === 'function') {
-      setImmediate(resolve);
-    } else {
-      setTimeout(resolve, 0);
-    }
-  });
+const flushPromises = async () => {
+  await act(async () => {});
+};
 
 // Minimal WebSocket stub
 class StubSocket {
@@ -87,7 +82,7 @@ describe('MessageThread component', () => {
     });
     await new Promise((r) => setTimeout(r, 0));
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const scrollContainer = document.querySelector('.overflow-y-auto') as HTMLElement;
 
@@ -100,7 +95,7 @@ describe('MessageThread component', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     const button = container.querySelector('button[aria-label="Scroll to latest message"]');
@@ -128,7 +123,7 @@ describe('MessageThread component', () => {
     });
     
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const highlightedRow = container.querySelector('.bg-indigo-50');
     const senderName = container.querySelector('span.font-semibold');
@@ -303,7 +298,7 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     const socket = StubSocket.last as StubSocket;
@@ -446,7 +441,7 @@ describe('MessageThread component', () => {
       socket.onmessage?.({ data: JSON.stringify(msg) });
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const live = container.querySelector('div.sr-only[aria-live="polite"]');
     expect(live).not.toBeNull();
@@ -458,7 +453,7 @@ describe('MessageThread component', () => {
       root.render(<MessageThread bookingRequestId={1} clientId={1} artistId={2} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const buttons = container.querySelectorAll('button');
     const found = Array.from(buttons).find((b) => b.textContent === 'Send Quote');
@@ -473,7 +468,7 @@ describe('MessageThread component', () => {
       root.render(<MessageThread bookingRequestId={1} clientId={1} artistId={2} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     (api.getMessagesForBookingRequest as jest.Mock).mockClear();
@@ -484,11 +479,11 @@ describe('MessageThread component', () => {
     });
 
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     expect(api.createQuoteV2).toHaveBeenCalled();
@@ -517,10 +512,10 @@ describe('MessageThread component', () => {
       root.render(<MessageThread bookingRequestId={1} artistName="DJ" />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const banner = container.querySelector('[data-testid="booking-confirmed-banner"]');
     expect(banner?.textContent).toContain('Booking confirmed for DJ');
@@ -581,7 +576,7 @@ describe('MessageThread component', () => {
       await flushPromises();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     expect(api.getBookingDetails).toHaveBeenCalledWith(42);
     const dashboardLink = container.querySelectorAll(
@@ -972,7 +967,7 @@ it('declines quote using legacy endpoint', async () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const declineBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent === 'Decline',
@@ -1082,7 +1077,7 @@ it.skip('shows receipt link after paying deposit', async () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const acceptBtn = Array.from(container.querySelectorAll('button')).find(
       (b) => b.textContent === 'Accept',
@@ -1091,7 +1086,7 @@ it.skip('shows receipt link after paying deposit', async () => {
       acceptBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     const payBtn = Array.from(container.querySelectorAll('button')).find(
@@ -1101,13 +1096,13 @@ it.skip('shows receipt link after paying deposit', async () => {
       payBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     const banner = container.querySelector('[data-testid="payment-status-banner"]');
@@ -1163,10 +1158,10 @@ it.skip('shows receipt link after paying deposit', async () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
 
     const reviewBtn = Array.from(container.querySelectorAll('button')).find(
@@ -1186,7 +1181,7 @@ it.skip('shows receipt link after paying deposit', async () => {
       );
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const img = container.querySelector('img');
     expect(img).not.toBeNull();
@@ -1199,14 +1194,14 @@ it.skip('shows receipt link after paying deposit', async () => {
       root.render(<MessageThread bookingRequestId={1} />);
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const socket = StubSocket.last as StubSocket;
     act(() => {
       socket.onerror?.();
     });
     await act(async () => {
-      await Promise.resolve();
+      await flushPromises();
     });
     const alert = container.querySelector('p[role="alert"]:last-child');
     expect(alert?.textContent).toContain('refresh the page');

--- a/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
@@ -8,6 +8,10 @@ import * as api from '@/lib/api';
 jest.mock('@/lib/api');
 jest.mock('../../../ui/Toast', () => ({ __esModule: true, default: { success: jest.fn(), error: jest.fn() } }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function Wrapper() {
   const { control, setValue } = useForm();
   return (
@@ -66,9 +70,7 @@ describe('NotesStep attachment upload', () => {
       input.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
 
     const nextButton = Array.from(container.querySelectorAll('button')).find((b) =>
       b.textContent?.includes('Next'),

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -4,6 +4,10 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import VenueStep from '../VenueStep';
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function MobileWrapper() {
   const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
   return (
@@ -92,9 +96,7 @@ describe('VenueStep bottom sheet mobile', () => {
     act(() => {
       openButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const sheet = document.querySelector('[data-testid="bottom-sheet"]');
     expect(sheet).not.toBeNull();
     const outdoor = sheet?.querySelector('input[value="outdoor"]') as HTMLInputElement;
@@ -102,9 +104,7 @@ describe('VenueStep bottom sheet mobile', () => {
       outdoor.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(document.querySelector('[data-testid="bottom-sheet"]')).toBeNull();
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     expect(document.activeElement).toBe(openButton);
   });
 });

--- a/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
+++ b/frontend/src/components/layout/__tests__/FullScreenNotificationModal.test.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { act } from 'react';
 import FullScreenNotificationModal from '../FullScreenNotificationModal';
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 const baseProps = {
   open: true,
   onClose: () => {},
@@ -52,8 +56,8 @@ describe('FullScreenNotificationModal', () => {
           error: new Error('Failed to load'),
         }),
       );
-      await Promise.resolve();
     });
+    await flushPromises();
     const err = document.querySelector('[data-testid="notification-error"]');
     expect(err?.textContent).toBe('Failed to load');
   });

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -13,6 +13,10 @@ jest.mock('next/navigation', () => ({
 }));
 jest.mock('@/contexts/AuthContext', () => ({ useAuth: jest.fn(() => ({ user: null, logout: jest.fn() })) }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function render() {
   const div = document.createElement('div');
   document.body.appendChild(div);
@@ -31,8 +35,8 @@ describe('Header', () => {
     const { div, root } = render();
     await act(async () => {
       root.render(<Header />);
-      await Promise.resolve();
     });
+    await flushPromises();
     expect(div.firstChild).toMatchSnapshot();
     act(() => root.unmount());
     div.remove();
@@ -43,8 +47,8 @@ describe('Header', () => {
     const { div, root } = render();
     await act(async () => {
       root.render(<Header />);
-      await Promise.resolve();
     });
+    await flushPromises();
     expect(div.firstChild).toMatchSnapshot();
     act(() => root.unmount());
     div.remove();

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -13,6 +13,10 @@ jest.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 describe('MainLayout user menu', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -26,7 +30,7 @@ describe('MainLayout user menu', () => {
     await act(async () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Sound Providers');
     expect(div.textContent).toContain('Quote Calculator');
     expect(div.textContent).toContain('Quote Templates');
@@ -35,7 +39,7 @@ describe('MainLayout user menu', () => {
     await act(async () => {
       menuBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('Quotes');
     expect(div.textContent).toContain('Quote Templates');
     expect(div.textContent).not.toContain('Account');
@@ -51,13 +55,13 @@ describe('MainLayout user menu', () => {
     await act(async () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     const menuBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent?.includes('Open user menu')) as HTMLButtonElement;
     expect(menuBtn).toBeTruthy();
     await act(async () => {
       menuBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
     expect(div.textContent).toContain('My Bookings');
     expect(div.textContent).toContain('Account');
     act(() => { root.unmount(); });

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -4,6 +4,10 @@ import { act } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 import type { User } from '@/types';
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 const nav = [
   { name: 'Home', href: '/' },
   { name: 'Artists', href: '/artists' },
@@ -42,9 +46,7 @@ describe('MobileMenuDrawer', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const bodyText = document.body.textContent || '';
     expect(bodyText).toContain('Home');
     expect(bodyText).toContain('Artists');
@@ -66,9 +68,7 @@ describe('MobileMenuDrawer', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const span = document.querySelector('span.sr-only');
     const button = span?.parentElement as HTMLButtonElement | null;
     expect(button?.className).toContain('focus-visible:ring-2');
@@ -88,9 +88,7 @@ describe('MobileMenuDrawer', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const body = document.body.textContent || '';
     expect(body).toContain('Quotes');
     expect(body).toContain('Sound Providers');
@@ -112,9 +110,7 @@ describe('MobileMenuDrawer', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const body = document.body.textContent || '';
     expect(body).toContain('My Bookings');
     expect(body).toContain('Account');

--- a/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
@@ -11,6 +11,10 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }));
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup() {
   (useNotifications as jest.Mock).mockReturnValue({
     items: [],
@@ -76,13 +80,13 @@ describe('NotificationBell accessibility', () => {
     const { container, root } = setup();
     await act(async () => {
       root.render(React.createElement(NotificationBell));
-      await Promise.resolve();
     });
+    await flushPromises();
     const bell = container.querySelector('button') as HTMLButtonElement;
     await act(async () => {
       bell.click();
-      await Promise.resolve();
     });
+    await flushPromises();
     const card = container.querySelector(
       '[data-testid="notification-list"] [role="button"]',
     ) as HTMLElement;

--- a/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBellPrefetch.test.tsx
@@ -28,6 +28,10 @@ jest.mock('../FullScreenNotificationModal', () => {
   };
 });
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 function setup() {
   (useNotifications as jest.Mock).mockReturnValue({
     items: [],
@@ -53,17 +57,17 @@ describe('NotificationBell prefetch', () => {
     const { container, root } = setup();
     await act(async () => {
       root.render(React.createElement(NotificationBell));
-      await Promise.resolve();
     });
+    await flushPromises();
     const button = container.querySelector('button') as HTMLButtonElement;
     await act(async () => {
       button.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-      await Promise.resolve();
     });
+    await flushPromises();
     await act(async () => {
       button.click();
-      await Promise.resolve();
     });
+    await flushPromises();
     expect(container.querySelector('[data-testid="drawer"]')).not.toBeNull();
     act(() => {
       root.unmount();
@@ -75,13 +79,13 @@ describe('NotificationBell prefetch', () => {
     const { container, root } = setup();
     await act(async () => {
       root.render(React.createElement(NotificationBell));
-      await Promise.resolve();
     });
+    await flushPromises();
     const button = container.querySelector('button') as HTMLButtonElement;
     await act(async () => {
       button.click();
-      await Promise.resolve();
     });
+    await flushPromises();
     expect(container.querySelector('[data-testid="drawer"]')).not.toBeNull();
     act(() => {
       root.unmount();

--- a/frontend/src/components/layout/__tests__/NotificationVirtualization.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationVirtualization.test.tsx
@@ -5,6 +5,10 @@ import NotificationDrawer from '../NotificationDrawer';
 import FullScreenNotificationModal from '../FullScreenNotificationModal';
 import type { UnifiedNotification } from '@/types';
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 const baseProps = {
   open: true,
   onClose: () => {},
@@ -49,9 +53,7 @@ describe('Notification virtualization', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const list = document.querySelector('[data-testid="notification-list"]') as HTMLElement;
     expect(list.querySelectorAll('div[style]').length).toBeLessThan(items.length);
   });
@@ -68,9 +70,7 @@ describe('Notification virtualization', () => {
         }),
       );
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flushPromises();
     const list = document.querySelector('[data-testid="notification-modal-list"]') as HTMLElement;
     expect(list.querySelectorAll('button').length).toBeLessThan(items.length);
     const loadMore = jest.fn();

--- a/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
+++ b/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
@@ -4,6 +4,10 @@ import React from 'react';
 import ReviewFormModal from '../ReviewFormModal';
 import { createReviewForBooking } from '@/lib/api';
 
+const flushPromises = async () => {
+  await act(async () => {});
+};
+
 jest.mock('@/lib/api');
 
 describe('ReviewFormModal', () => {
@@ -65,7 +69,7 @@ describe('ReviewFormModal', () => {
     await act(async () => {
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     });
-    await act(async () => { await Promise.resolve(); });
+    await flushPromises();
 
     expect(createReviewForBooking).toHaveBeenCalledWith(
       1,


### PR DESCRIPTION
## Summary
- ensure tests use a `flushPromises` helper instead of `Promise.resolve`
- wrap relevant async steps in `act` via `flushPromises`
- update many frontend test suites accordingly

## Testing
- `./scripts/test-all.sh` *(fails: 20 failed, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f94d572fc832eb64e8d913e3e3f45