### PR TITLE
Implement gmpx autocomplete modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,17 @@ The host portion of `NEXT_PUBLIC_API_URL` is also used by
 Set this URL to match your API server so artist profile pictures and
 cover photos load without 400 errors from the `/_next/image` endpoint.
 
-The location input relies on the built-in Google Maps Places Autocomplete
-service instead of the experimental `@googlemaps/places` package. The previous
-dependency caused a build failure because it depended on Node-only modules like
-`fs`. No additional npm install step is required after this change.
-The location picker now opens a minimalist modal when the **Map** button is
-clicked. The modal contains only a search field with Google Places Autocomplete
-and no embedded map. It matches the search bar styling and closes via a soft
-"Close" button. Closing the modal blurs the original input so it doesn't
-instantly reopen when refocused.
+The location input now uses the `<gmpx-place-autocomplete>` web component from
+the `@googlemaps/places` package. The script is loaded in `layout.tsx` with:
+
+```html
+<script type="module" src="https://unpkg.com/@googlemaps/places@1.0.0/dist/index.min.js"></script>
+```
+
+The previous built-in autocomplete is deprecated. The location picker still
+opens a minimalist modal when the **Map** button is clicked. The modal contains
+just the search field and closes via a soft "Close" button. Closing the modal
+blurs the original input so it doesn't instantly reopen when refocused.
 
 To expose the app on your local network, replace `192.168.3.203` with your
 machine's LAN IP. Set the same address in `.env` under

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -89,6 +89,14 @@ const mockAutocomplete = jest.fn(function Autocomplete(this: any) {
 };
 (globalThis as any).mockAutocomplete = mockAutocomplete;
 
+// Stub gmpx-place-autocomplete web component used in LocationMapModal
+class GmpxPlaceAutocomplete extends HTMLElement {
+  value: any = null;
+}
+if (!customElements.get('gmpx-place-autocomplete')) {
+  customElements.define('gmpx-place-autocomplete', GmpxPlaceAutocomplete);
+}
+
 // Additional browser stubs
 (window as any).confirm = jest.fn(() => true);
 (window as any).URL.createObjectURL = jest.fn(() => 'blob:');

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter } from 'next/font/google';
 import { Toaster } from 'react-hot-toast';
+import Script from 'next/script';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { NotificationsProvider } from '@/hooks/useNotifications';
 import './globals.css';
@@ -29,6 +30,11 @@ export default function RootLayout({
             <Toaster position="top-right" />
           </NotificationsProvider>
         </AuthProvider>
+        <Script
+          src="https://unpkg.com/@googlemaps/places@1.0.0/dist/index.min.js"
+          type="module"
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- migrate LocationMapModal to use `<gmpx-place-autocomplete>`
- load `@googlemaps/places` script in root layout
- update documentation for the new autocomplete component
- stub the web component in Jest setup

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 10 failed, 1 skipped, 72 passed, 82 of 83 total)*

------
https://chatgpt.com/codex/tasks/task_e_687fb227b478832e90d9389f3c97748d