### PR TITLE
Fix map modal autocomplete focus

### DIFF
--- a/frontend/src/components/ui/LocationMapModal.tsx
+++ b/frontend/src/components/ui/LocationMapModal.tsx
@@ -47,7 +47,9 @@ export default function LocationMapModal({
   useEffect(() => {
     if (!open) return undefined;
     const timeout = setTimeout(() => {
-      (autoRef.current as any)?.focus?.();
+      const el = autoRef.current as HTMLElement | null;
+      el?.focus?.();
+      (el?.shadowRoot?.querySelector('input') as HTMLInputElement | null)?.focus?.();
     }, 100);
     return () => clearTimeout(timeout);
   }, [open]);
@@ -80,10 +82,21 @@ export default function LocationMapModal({
               <Dialog.Title className="text-lg font-medium text-gray-900">Select Location</Dialog.Title>
               <gmpx-place-autocomplete
                 ref={autoRef}
-                placeholder="Search"
-                className="block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm p-2"
-                autoFocus
+                placeholder="Search address"
+                className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2 bg-white text-black"
+                style={{ minHeight: '44px', display: 'block' }}
+                data-testid="map-autocomplete"
               />
+              <button
+                onClick={() => {
+                  const el = autoRef.current as HTMLElement | null;
+                  el?.focus?.();
+                  (el?.shadowRoot?.querySelector('input') as HTMLInputElement | null)?.focus?.();
+                }}
+                className="hidden"
+              >
+                Force Focus
+              </button>
               <div className="flex justify-end">
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- ensure `<gmpx-place-autocomplete>` inside `LocationMapModal` is visible and focusable
- add fallback focus button for debugging
- focus internal input once modal opens

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 13 failed, 1 skipped, 69 passed, 82 of 83 total)*

------
https://chatgpt.com/codex/tasks/task_e_687fbf203658832eb0dce93662cce265