### PR TITLE
Handle frontend Google Maps env var in backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyDm-BKmMtzMSMd-XUdfapjEUU6O5mYy2bk
 enabled. It powers the `LocationInput` autocomplete fields used in the artist
 filters, search bar, and booking steps.
 
+If you source the same `.env` file for the backend, the API configuration now
+includes `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` as an optional setting. The backend
+does not use this key, but declaring it prevents a Pydantic validation error
+when extra environment variables are forbidden.
+
 The host portion of `NEXT_PUBLIC_API_URL` is also used by
 `next.config.js` to allow optimized image requests from the backend.
 Set this URL to match your API server so artist profile pictures and

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,6 +38,12 @@ class Settings(BaseSettings):
     GITHUB_CLIENT_ID: str = ""
     GITHUB_CLIENT_SECRET: str = ""
 
+    # API key used on the frontend for Google Maps components. The backend does
+    # not use this value but includes it so loading `.env` files shared with the
+    # frontend does not raise a validation error when extra fields are forbidden
+    # by Pydantic settings.
+    NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: str = ""
+
     # Base frontend URL used for OAuth redirects
     FRONTEND_URL: str = "http://localhost:3000"
 


### PR DESCRIPTION
## Summary
- allow NEXT_PUBLIC_GOOGLE_MAPS_API_KEY in backend settings
- document the optional backend variable in README

## Testing
- `./scripts/test-all.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687fde1bc3f8832e902a5773123465df