### PR TITLE
Speed up Jest & finalize flushPromises cleanup

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
   transform: {
@@ -26,5 +25,6 @@ module.exports = {
     '\\.module\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts', '<rootDir>/test/setup-network.ts'],
+  reporters: ['default', ['jest-slow-test-reporter', { threshold: 5000 }]],
   testTimeout: 30000,
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "pretest": "test -d node_modules || npm install",
-    "test": "jest --passWithNoTests --detectOpenHandles --forceExit",
-    "test:unit": "jest --testPathIgnorePatterns=e2e --detectOpenHandles --forceExit",
+    "test": "jest --passWithNoTests",
+    "test:unit": "jest --testPathIgnorePatterns=e2e --passWithNoTests",
+    "test:debug": "jest --runInBand --detectOpenHandles --forceExit",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/frontend/test/utils/flush.ts
+++ b/frontend/test/utils/flush.ts
@@ -4,8 +4,7 @@ export async function flushPromises() {
   await act(async () => {
     await Promise.resolve();
   });
-  // If fake timers are active, run pending timers once
-  if (jest?.isMockFunction?.(setTimeout)) {
+  if (jest.isMockFunction(setTimeout)) {
     act(() => {
       jest.runOnlyPendingTimers();
     });

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -55,10 +55,9 @@ fi
 
 if [ -z "${SKIP_FRONTEND:-}" ]; then
   echo "🧪 Running frontend tests…"
+  (cd frontend && npm test -- --maxWorkers=${JEST_WORKERS:-50%} --passWithNoTests)
   if [ "$run_e2e" = 1 ]; then
-    FAST=${FAST:-} LINT=${LINT:-} ./scripts/test-frontend.sh --unit --e2e
-  else
-    FAST=${FAST:-} LINT=${LINT:-} ./scripts/test-frontend.sh --unit
+    (cd frontend && npx playwright test --reporter=line)
   fi
 fi
 


### PR DESCRIPTION
## Summary
- remove ts-jest preset and add slow-test reporter for Jest
- streamline flushPromises helper
- simplify fast-check and test-all scripts
- drop open handle flags from npm test and add a test:debug script

## Testing
- `FAST=1 ./scripts/test-all.sh` *(fails: ModuleNotFoundError: pydantic_settings)*
- `./scripts/test-all.sh` *(fails: AssertionError in backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_687feb95b4a8832e9d5b181f27b360b4