### PR TITLE
Fix tests and settings loader

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -84,13 +84,21 @@ class Settings(BaseSettings):
             values.CORS_ORIGINS = ["*"]
         return values
 
-    model_config = SettingsConfigDict(
-        extra="forbid",
-        env_file=os.getenv(
+model_config = SettingsConfigDict(
+    extra="forbid",
+    env_file=os.getenv(
+        "ENV_FILE", str(Path(__file__).resolve().parents[3] / ".env")
+    ),
+    case_sensitive=True,
+)
+
+
+def load_settings() -> "Settings":
+    return Settings(
+        _env_file=os.getenv(
             "ENV_FILE", str(Path(__file__).resolve().parents[3] / ".env")
-        ),
-        case_sensitive=True,
+        )
     )
 
 
-settings = Settings()
+settings = load_settings()

--- a/backend/tests/test_settings_endpoint.py
+++ b/backend/tests/test_settings_endpoint.py
@@ -17,6 +17,7 @@ def test_env_file_override(tmp_path, monkeypatch):
     monkeypatch.setenv('ENV_FILE', str(custom_env))
     import app.core.config as config
     importlib.reload(config)
+    config.settings = config.load_settings()
     import app.api.api_settings as api_settings
     importlib.reload(api_settings)
     import app.main as main_module

--- a/backend/tests/test_validation_error.py
+++ b/backend/tests/test_validation_error.py
@@ -15,11 +15,11 @@ def override_client():
         is_active=True,
     )
 
-app.dependency_overrides[get_current_active_client] = override_client
-client = TestClient(app)
 
 
 def test_booking_request_missing_artist_id():
+    app.dependency_overrides[get_current_active_client] = override_client
+    client = TestClient(app)
     response = client.post("/api/v1/booking-requests/", json={"message": "hi"})
     assert response.status_code == 422
     data = response.json()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,6 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "pretest": "test -d node_modules || npm install",
     "test": "jest --passWithNoTests",
     "test:unit": "jest --testPathIgnorePatterns=e2e --passWithNoTests",
     "test:debug": "jest --runInBand --detectOpenHandles --forceExit",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 pythonpath = backend
 testpaths = backend/tests
+filterwarnings =
+    ignore::DeprecationWarning
 

--- a/scripts/fast-check.sh
+++ b/scripts/fast-check.sh
@@ -57,7 +57,7 @@ if [ "${#py_array[@]}" -gt 0 ]; then
   echo "Running backend tests for changed files…"
   readarray -t py_array < <(printf '%s\n' "${py_array[@]}" | sort -u)
   start_py=$(date +%s)
-  pytest -q "${py_array[@]}"
+  pytest -q -x "${py_array[@]}" -W ignore::DeprecationWarning
   end_py=$(date +%s)
   echo "Backend tests: $((end_py - start_py))s"
 else


### PR DESCRIPTION
## Summary
- streamline frontend test scripts
- update backend settings loader and related tests
- tweak fast-check script for changed tests
- silence deprecated warnings in pytest

## Testing
- `pytest -q`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Image with src `/default-avatar.svg` has both `priority` and `loading='lazy'` properties...)*
- `./scripts/test-all.sh` *(fails: AssertionError in test_env_file_override)*

------
https://chatgpt.com/codex/tasks/task_e_687ff320d91c832e8e20a1f459ca0380