### PR TITLE
Fix Next.js Image priority conflict

### DIFF
--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -87,8 +87,11 @@ export default function ArtistCard({
               alt={name}
               width={512}
               height={512}
-              loading="lazy"
               className="object-cover w-full h-full"
+              {
+                /* Avoid Next.js warning: cannot combine `priority` with lazy loading */
+              }
+              {...(priority ? {} : { loading: 'lazy' })}
               priority={priority}
               onLoad={() => setImgLoaded(true)}
               onError={(e) => {
@@ -101,8 +104,11 @@ export default function ArtistCard({
               alt={name}
               width={512}
               height={512}
-              loading="lazy"
               className="object-cover w-full h-full"
+              {
+                /* Spread lazy loading only when the image is not prioritized */
+              }
+              {...(priority ? {} : { loading: 'lazy' })}
               priority={priority}
               onLoad={() => setImgLoaded(true)}
             />


### PR DESCRIPTION
## Summary
- avoid using priority and lazy loading together for artist cards

## Testing
- `./scripts/test-all.sh` *(fails: test_settings_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_688001aa9418832eaa448bdaebd0a567