### PR TITLE
Fix Google autocomplete input wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Set this URL to match your API server so artist profile pictures and
 cover photos load without 400 errors from the `/_next/image` endpoint.
 
 The location input now uses the `<gmpx-place-autocomplete>` web component from
-the `@googlemaps/places` package. The script is loaded in `layout.tsx` with:
+the `@googlemaps/places` package. **Remember to provide an `<input slot="input">` inside the element.** All styling classes belong on this input, not the wrapper. The script is loaded in `layout.tsx` with:
 
 ```html
 <script

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -94,12 +94,14 @@ function AutocompleteInput({ value, onChange, onSelect }: AutocompleteProps) {
   }, [value]);
 
   return (
-    <gmpx-place-autocomplete
-      ref={autoRef}
-      placeholder="Search address"
-      className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2"
-      data-testid="autocomplete-input"
-    />
+    <gmpx-place-autocomplete ref={autoRef} data-testid="autocomplete-input">
+      <input
+        slot="input"
+        type="text"
+        placeholder="Search address"
+        className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2"
+      />
+    </gmpx-place-autocomplete>
   );
 }
 

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -270,10 +270,15 @@ exports[`Header renders search bar on home page 1`] = `
               class="relative"
             >
               <gmpx-place-autocomplete
-                classname="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none border-none shadow-none rounded-none bg-transparent p-0 focus:ring-0 pr-8 block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm"
                 data-testid="location-input"
-                placeholder="City or venue"
-              />
+              >
+                <input
+                  slot="input"
+                  type="text"
+                  placeholder="City or venue"
+                  class="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none pr-8 block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm"
+                />
+              </gmpx-place-autocomplete>
               <button
                 class="absolute inset-y-0 right-1 flex items-center text-gray-500 hover:text-gray-700 text-sm"
                 data-testid="open-map-modal"

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -48,15 +48,17 @@ export default function LocationInput({
   return (
     <>
       <div className="relative">
-        <gmpx-place-autocomplete
-          ref={autoRef}
-          placeholder={placeholder}
-          className={clsx(
-            className,
-            'pr-8 block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
-          )}
-          data-testid="location-input"
-        />
+        <gmpx-place-autocomplete ref={autoRef} data-testid="location-input">
+          <input
+            slot="input"
+            type="text"
+            placeholder={placeholder}
+            className={clsx(
+              className,
+              'pr-8 block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
+            )}
+          />
+        </gmpx-place-autocomplete>
         <button
           type="button"
           onClick={() => setModalOpen(true)}

--- a/frontend/src/components/ui/LocationMapModal.tsx
+++ b/frontend/src/components/ui/LocationMapModal.tsx
@@ -82,11 +82,16 @@ export default function LocationMapModal({
               <Dialog.Title className="text-lg font-medium text-gray-900">Select Location</Dialog.Title>
               <gmpx-place-autocomplete
                 ref={autoRef}
-                placeholder="Search address"
-                className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2 bg-white text-black"
                 style={{ minHeight: '44px', display: 'block' }}
                 data-testid="map-autocomplete"
-              />
+              >
+                <input
+                  slot="input"
+                  type="text"
+                  placeholder="Search address"
+                  className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2 bg-white text-black"
+                />
+              </gmpx-place-autocomplete>
               <button
                 onClick={() => {
                   const el = autoRef.current as HTMLElement | null;


### PR DESCRIPTION
## Summary
- render an `<input slot="input">` inside `gmpx-place-autocomplete`
- style the input directly in location components
- update documentation on using the Google Places web component
- update Header snapshot

## Testing
- `./scripts/test-backend.sh` *(fails: Could not install dependencies)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800629434c832e81bafbbfa80c5912