### PR TITLE
Fix Next.js image domain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ The host portion of `NEXT_PUBLIC_API_URL` is also used by
 `next.config.js` to allow optimized image requests from the backend.
 Set this URL to match your API server so artist profile pictures and
 cover photos load without 400 errors from the `/_next/image` endpoint.
+The `next.config.js` file now explicitly includes `/static/cover_photos/**`
+alongside `/static/profile_pics/**` in its `remotePatterns` list.
 
 The location input now uses the `<gmpx-place-autocomplete>` web component from
 the `@googlemaps/places` package. **Remember to provide an `<input slot="input">` inside the element.** All styling classes belong on this input, not the wrapper. The script is loaded in `layout.tsx` with:

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -9,15 +9,29 @@ const remotePatterns = [
     port: port || '',
     pathname: '/static/profile_pics/**',
   },
+  {
+    protocol: protocol.replace(':', ''),
+    hostname,
+    port: port || '',
+    pathname: '/static/cover_photos/**',
+  },
 ];
 
 if (hostname !== 'localhost') {
-  remotePatterns.push({
-    protocol: 'http',
-    hostname: 'localhost',
-    port: '8000',
-    pathname: '/static/profile_pics/**',
-  });
+  remotePatterns.push(
+    {
+      protocol: 'http',
+      hostname: 'localhost',
+      port: '8000',
+      pathname: '/static/profile_pics/**',
+    },
+    {
+      protocol: 'http',
+      hostname: 'localhost',
+      port: '8000',
+      pathname: '/static/cover_photos/**',
+    },
+  );
 }
 
 const nextConfig = {


### PR DESCRIPTION
## Summary
- allow `/static/cover_photos/**` in `next.config.js`
- document cover photo image host configuration in README

## Testing
- `SKIP_BACKEND=1 VERBOSE=1 ./scripts/test-all.sh` *(fails: jest not found)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 13 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68800794c6a4832eb1f77bfd3c7c33d0