### PR TITLE
Fix Google Maps loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,10 @@ the `@googlemaps/places` package. **Remember to provide an `<input slot="input">
   crossorigin="anonymous"
   strategy="afterInteractive"
 ></script>
+<gmpx-api-loader api-key="YOUR_GOOGLE_MAPS_KEY"></gmpx-api-loader>
 ```
+This `<gmpx-api-loader>` element loads the Maps JavaScript SDK using the same
+`NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` value defined in your `.env.local` file.
 
 The previous built-in autocomplete is deprecated. The location picker still
 opens a minimalist modal when the **Map** button is clicked. The modal contains

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -36,6 +36,7 @@ export default function RootLayout({
           strategy="afterInteractive"
           crossOrigin="anonymous"
         />
+        <gmpx-api-loader api-key={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ''} />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- load gmpx-api-loader in layout
- mention gmpx-api-loader in README

## Testing
- `FAST=1 ./scripts/test-all.sh` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68800ba498d4832e9666fb5ba3a4b2ef