### PR TITLE
Fix Google Maps autocomplete by loading places library

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ the `@googlemaps/places` package. **Remember to provide an `<input slot="input">
   crossorigin="anonymous"
   strategy="afterInteractive"
 ></script>
-<gmpx-api-loader api-key="YOUR_GOOGLE_MAPS_KEY"></gmpx-api-loader>
+<gmpx-api-loader api-key="YOUR_GOOGLE_MAPS_KEY" libraries="places"></gmpx-api-loader>
 ```
 This `<gmpx-api-loader>` element loads the Maps JavaScript SDK using the same
 `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` value defined in your `.env.local` file.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -36,7 +36,10 @@ export default function RootLayout({
           strategy="afterInteractive"
           crossOrigin="anonymous"
         />
-        <gmpx-api-loader api-key={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ''} />
+        <gmpx-api-loader
+          api-key={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || ''}
+          libraries="places"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- ensure gmpx loader requests the Places library
- document the required attribute in README

## Testing
- `./scripts/test-all.sh` *(fails: 13 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6880745f01f4832eb1aa1ac01f15206e