### PR TITLE
Fix price filter sort handler

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -156,7 +156,7 @@ export default function ArtistsPage() {
           location={location}
           onLocation={setLocation}
           sort={sort}
-          onSort={(e) => setSort(e.target.value || undefined)}
+          onSort={(value) => setSort(value || undefined)}
           onClear={clearFilters}
           onApply={applyFilters}
           filtersActive={filtersActive}


### PR DESCRIPTION
## Summary
- handle sort value directly on artists page

## Testing
- `./scripts/test-all.sh` *(fails: sqlalchemy OperationalError: table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6880f151353c832eb662cbd4f60f172f