### PR TITLE
Fix search bar popover width

### DIFF
--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -92,7 +92,11 @@ export default function SearchBarInline({
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
-                className="absolute z-50 left-0 top-full mt-2 w-full bg-white rounded-lg shadow-xl p-4"
+                className="
+                  absolute z-50 left-0 top-full mt-2
+                  w-full max-w-md
+                  bg-white rounded-lg shadow-xl p-4
+                "
                 onKeyDown={(e) => handleKey(e, close)}
               >
                 <Listbox value={category} onChange={setCategory}>
@@ -146,13 +150,19 @@ export default function SearchBarInline({
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
-                className="absolute z-50 left-0 top-full mt-2 w-full bg-white rounded-lg shadow-xl p-4"
+                className="
+                  absolute z-50 left-0 top-full mt-2
+                  w-full max-w-md
+                  bg-white rounded-lg shadow-xl p-4
+                "
                 onKeyDown={(e) => handleKey(e, close)}
               >
                 <LocationInput
                   value={loc}
                   onValueChange={setLoc}
                   onPlaceSelect={() => {}}
+                  className="w-full"
+                  inputClassName="w-full"
                 />
                 <div className="flex justify-end pt-2">
                   <button

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -3,19 +3,24 @@
 import { useState, useEffect, useRef } from 'react';
 import usePlacesService from 'react-google-autocomplete/lib/usePlacesAutocompleteService';
 import { MapPinIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
 
 interface CustomLocationInputProps {
   value: string;
   onValueChange: (value: string) => void;
   onPlaceSelect: (place: google.maps.places.PlaceResult) => void;
   placeholder?: string;
+  className?: string;
+  inputClassName?: string;
 }
 
 export default function CustomLocationInput({
   value,
   onValueChange,
   onPlaceSelect,
-  placeholder = "Search location",
+  placeholder = 'Search location',
+  className,
+  inputClassName,
 }: CustomLocationInputProps) {
   const [predictions, setPredictions] = useState<google.maps.places.AutocompletePrediction[]>([]);
   const [isDropdownVisible, setDropdownVisible] = useState(false);
@@ -113,7 +118,7 @@ export default function CustomLocationInput({
   };
 
   return (
-    <div ref={containerRef} className="relative w-full">
+    <div ref={containerRef} className={clsx('relative w-full', className)}>
       <input
         type="text"
         value={value}
@@ -122,7 +127,10 @@ export default function CustomLocationInput({
           if (predictions.length > 0) setDropdownVisible(true);
         }}
         placeholder={placeholder}
-        className="w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none"
+        className={clsx(
+          'w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none',
+          inputClassName,
+        )}
       />
 
       {isDropdownVisible && predictions.length > 0 && (


### PR DESCRIPTION
## Summary
- align category and location popovers under their segments
- allow LocationInput to accept `className` and `inputClassName`
- make location input fill the popover

## Testing
- `./scripts/test-all.sh` *(fails: Jest encountered unexpected tokens and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688201565cbc832eb8ca2be14c5b79f0