### PR TITLE
Fix /artists search bar popovers

### DIFF
--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -76,7 +76,7 @@ export default function SearchBarInline({
 
   return (
     <div className="flex items-stretch bg-white border border-gray-200 rounded-full shadow-sm divide-x divide-gray-200 overflow-visible">
-      <Popover as="div" className="relative flex-none">
+      <Popover as="div" className="relative flex-1">
         {({ close }) => (
           <>
             <Popover.Button className="flex-none px-4 py-2 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none">
@@ -94,8 +94,7 @@ export default function SearchBarInline({
               <Popover.Panel
                 className="
                   absolute z-50 left-0 top-full mt-2
-                  w-full max-w-md
-                  bg-white rounded-lg shadow-xl p-4
+                  w-full bg-white rounded-lg shadow-xl p-4
                 "
                 onKeyDown={(e) => handleKey(e, close)}
               >
@@ -134,7 +133,7 @@ export default function SearchBarInline({
           </>
         )}
       </Popover>
-      <Popover as="div" className="relative flex-none">
+      <Popover as="div" className="relative flex-1">
         {({ close }) => (
           <>
             <Popover.Button className="flex-none px-4 py-2 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none">
@@ -152,8 +151,7 @@ export default function SearchBarInline({
               <Popover.Panel
                 className="
                   absolute z-50 left-0 top-full mt-2
-                  w-full max-w-md
-                  bg-white rounded-lg shadow-xl p-4
+                  w-full bg-white rounded-lg shadow-xl p-4
                 "
                 onKeyDown={(e) => handleKey(e, close)}
               >
@@ -178,7 +176,7 @@ export default function SearchBarInline({
           </>
         )}
       </Popover>
-      <Popover as="div" className="relative flex-none">
+      <Popover as="div" className="relative flex-1">
         {({ close }) => (
           <>
             <Popover.Button className="flex-none px-4 py-2 flex items-center gap-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none">
@@ -194,7 +192,10 @@ export default function SearchBarInline({
               leaveTo="opacity-0 translate-y-1"
             >
               <Popover.Panel
-                className="absolute z-50 mt-2 bg-white rounded-lg shadow-xl p-4 w-auto"
+                className="
+                  absolute z-50 left-0 top-full mt-2
+                  w-full bg-white rounded-lg shadow-xl p-4
+                "
                 onKeyDown={(e) => handleKey(e, close)}
               >
                 <ReactDatePicker


### PR DESCRIPTION
## Summary
- adjust inline search pill widths
- ensure popover panels span the full pill width

## Testing
- `./scripts/test-all.sh` *(fails: cannot find module 'react-google-autocomplete/lib/usePlacesAutocompleteService' and other Jest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882033203f4832e8499fd71f491225c