### PR TITLE
feat(artists): single expandable inline search bar matching homepage

### DIFF
--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -58,18 +58,13 @@ export default function SearchBarInline({
       {({ close }) => (
         <>
           <Popover.Button
-            className="flex items-center bg-white border border-gray-200 rounded-full shadow-lg divide-x divide-gray-200 overflow-hidden"
+            data-testid="inline-trigger"
+            className="flex items-center bg-white border border-gray-200 rounded-full shadow-sm divide-x divide-gray-200 overflow-hidden w-full md:max-w-2xl mx-auto px-4"
           >
-            <div className="flex-1 px-4 py-2 text-sm text-gray-700">
-              {category.label}
-            </div>
-            <div className="flex-1 px-4 py-2 text-sm text-gray-700">
-              {location || 'Anywhere'}
-            </div>
-            <div className="flex-1 px-4 py-2 text-sm text-gray-700">
-              {when ? format(when, 'd MMM yyyy') : 'Add date'}
-            </div>
-            <div className="p-2 bg-pink-600 hover:bg-pink-700 text-white">
+            <div className="flex-1 py-2 text-sm text-gray-700">{category.label}</div>
+            <div className="flex-1 py-2 text-sm text-gray-700">{location || 'Anywhere'}</div>
+            <div className="flex-1 py-2 text-sm text-gray-700">{when ? format(when, 'd\u00A0MMM\u00A0yyyy') : 'Add\u00A0date'}</div>
+            <div className="p-2 bg-pink-600 hover:bg-pink-700 text-white rounded-r-full">
               <MagnifyingGlassIcon className="h-5 w-5" />
             </div>
           </Popover.Button>
@@ -77,7 +72,7 @@ export default function SearchBarInline({
             className="absolute z-10 top-full left-0 right-0 mt-2 px-4 sm:px-6 lg:px-8"
             onKeyDown={(e) => handleKeyDown(e, close)}
           >
-            <div className="bg-white rounded-lg shadow-xl p-4">
+            <div className="bg-white rounded-lg shadow-xl p-4 w-full md:max-w-2xl mx-auto">
               <SearchFields
                 category={category}
                 setCategory={setCategory}
@@ -89,6 +84,7 @@ export default function SearchBarInline({
               <div className="flex justify-end mt-4">
                 <button
                   type="button"
+                  data-testid="inline-search-btn"
                   className="bg-pink-600 hover:bg-pink-700 text-white font-medium px-5 py-2 rounded-full"
                   onClick={() => {
                     applyAndClose();

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import SearchBarInline from '../SearchBarInline';
+
+describe('SearchBarInline', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens popover and triggers onSearch', () => {
+    const onSearch = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<SearchBarInline onSearch={onSearch} />);
+    });
+
+    const trigger = container.querySelector('[data-testid="inline-trigger"]') as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const searchBtn = container.querySelector('[data-testid="inline-search-btn"]') as HTMLButtonElement;
+    expect(searchBtn).not.toBeNull();
+
+    act(() => {
+      searchBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSearch).toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- refine SearchBarInline popover styles and centering

## Testing
- `npm run type-check` *(fails: numerous type errors)*
- `npm run lint --max-warnings=0` *(fails with lint errors)*
- `npm run build` *(fails: Module not found 'react-google-autocomplete/lib/usePlacesAutocompleteService')*
- `npm test` *(fails: Jest couldn't parse CSS imports)*
- `./scripts/test-all.sh` *(failed: git fetch origin main)*

------
https://chatgpt.com/codex/tasks/task_e_68820b8df8e8832eba46d1e33e0dca41