### PR TITLE
Fix closing tag typo in FullScreenNotificationModal

### DIFF
--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -178,7 +178,7 @@ export default function FullScreenNotificationModal({
                     </div>
                   );
                 }}
-              </List>
+              </FixedSizeList>
             )}
           </div>
         </Dialog.Panel>


### PR DESCRIPTION
## Summary
- fix typo closing FixedSizeList tag in FullScreenNotificationModal

## Testing
- `./scripts/test-all.sh` *(fails: could not fetch origin)*

------
https://chatgpt.com/codex/tasks/task_e_68821317ab4c832e809b7f37f6448cd4