### PR TITLE
Fix NotificationDrawer syntax

### DIFF
--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -178,7 +178,7 @@ export default function NotificationDrawer({
                           </div>
                         );
                       }}
-                    </List>
+                    </FixedSizeList>
                   </div>
 
                   <footer className="sticky bottom-0 z-10 px-3 py-2 bg-white bg-opacity-90 backdrop-filter backdrop-blur-xs border-t flex gap-2">


### PR DESCRIPTION
## Summary
- correct closing tag for `FixedSizeList` component

## Testing
- `./scripts/test-all.sh` *(fails: Cannot find module 'react-google-autocomplete/lib/usePlacesAutocompleteService' and other jest parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_688213fc7a48832ea291fb0cdcf6511f