### PR TITLE
Update SearchBarInline width animation

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -99,7 +99,7 @@ The artists page uses a responsive grid that shows one card per row on mobile,
 two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
-desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
+desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper widens from `md:max-w-2xl` up to `md:max-w-3xl lg:max-w-4xl` with a 300ms ease-out transition. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
 bottom sheet while **Filters** opens `FilterSheet`. Filters show a tiny pink dot when
 active. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useRef, useEffect } from 'react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
 import { format } from 'date-fns';
 import SearchBar from './SearchBar';
 import { type Category } from './SearchFields';
@@ -49,7 +50,10 @@ export default function SearchBarInline({
   return (
     <div
       ref={wrapperRef}
-      className="relative w-full md:max-w-2xl mx-auto px-4 transition-all duration-300"
+      className={clsx(
+        'relative w-full mx-auto px-4 transition-all duration-300 ease-out',
+        expanded ? 'md:max-w-3xl lg:max-w-4xl' : 'md:max-w-2xl',
+      )}
     >
       {expanded ? (
         <SearchBar

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -4,7 +4,7 @@ import { forwardRef, Fragment } from 'react';
 import ReactDatePicker, {
   type ReactDatePickerCustomHeaderProps as HeaderProps,
 } from 'react-datepicker';
-import '@/styles/datepicker.css';
+import '../../styles/datepicker.css';
 import { Listbox, Transition } from '@headlessui/react';
 import {
   ChevronDownIcon,

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -3,6 +3,12 @@ import { act } from 'react-dom/test-utils';
 import { createRoot } from 'react-dom/client';
 import SearchBarInline from '../SearchBarInline';
 
+jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => () => ({
+  placesService: null,
+  placePredictions: [],
+  getPlacePredictions: jest.fn(),
+}));
+
 describe('SearchBarInline', () => {
   afterEach(() => {
     document.body.innerHTML = '';
@@ -52,7 +58,7 @@ describe('SearchBarInline', () => {
     });
 
     act(() => {
-      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
 
     const searchBtn = container.querySelector('button[type="submit"]');


### PR DESCRIPTION
## Summary
- animate SearchBarInline max-width on desktop
- clarify SearchBarInline width change in README
- use relative CSS import in SearchFields
- mock autocomplete hook in SearchBarInline tests
- update Escape key test to dispatch on document

## Testing
- `npm test -- --runTestsByPath src/components/search/__tests__/SearchBarInline.test.tsx`
- `./scripts/test-all.sh` *(fails: RangeError in useNotifications)*

------
https://chatgpt.com/codex/tasks/task_e_68822a9725d0832e96bd3412dbfa735b