### PR TITLE
Fix SearchBar expansion in artists page header

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -88,7 +88,7 @@ export default function MainLayout({ children, headerAddon }: Props) {
         <Header
           extraBar={
             pathname.startsWith('/artists') ? (
-              <div className="mx-auto w-full md:max-w-2xl px-4">{headerAddon}</div>
+              <div className="mx-auto w-full px-4">{headerAddon}</div>
             ) : undefined
           }
         />


### PR DESCRIPTION
## Summary
- stop constraining header addon width in MainLayout so SearchBarInline can expand when focused

## Testing
- `./scripts/test-all.sh` *(fails: 39 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882337ee320832e89e5f6fae88aa533