### PR TITLE
Add filter icon beside artists search bar

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -100,7 +100,7 @@ two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
 desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper widens from `md:max-w-2xl` up to `md:max-w-3xl lg:max-w-4xl` with a 300ms ease-out transition. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
-bottom sheet while **Filters** opens `FilterSheet`. Filters show a tiny pink dot when
+bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. Filters show a tiny pink dot when
 active. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.
 

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -120,51 +120,54 @@ export default function ArtistsPage() {
   };
 
   const header = (
-    <>
+    <div className="relative flex items-center justify-center">
       <SearchBarInline
         initialCategory={uiValue}
         initialLocation={location}
         initialWhen={when}
         onSearch={handleSearchEdit}
       />
-      <ArtistsPageHeader
-        categoryLabel={uiLabel}
-        categoryValue={uiValue}
-        location={location}
-        when={when}
-        onSearchEdit={handleSearchEdit}
-        initialSort={sort}
-        initialMinPrice={minPrice}
-        initialMaxPrice={maxPrice}
-        verifiedOnly={verifiedOnly}
-        onFilterApply={({ sort: s, minPrice: min, maxPrice: max, verifiedOnly: vo }) => {
-          setSort(s || undefined);
-          setMinPrice(min);
-          setMaxPrice(max);
-          setVerifiedOnly(vo);
-          updateQueryParams(router, pathname, {
-            category,
-            location,
-            when,
-            sort: s,
-            minPrice: min,
-            maxPrice: max,
-            verifiedOnly: vo,
-          });
-        }}
-        onFilterClear={() => {
-          setSort(undefined);
-          setMinPrice(SLIDER_MIN);
-          setMaxPrice(SLIDER_MAX);
-          setVerifiedOnly(false);
-          updateQueryParams(router, pathname, {
-            category,
-            location,
-            when,
-          });
-        }}
-      />
-    </>
+      <div className="absolute right-4 top-1/2 -translate-y-1/2">
+        <ArtistsPageHeader
+          iconOnly
+          categoryLabel={uiLabel}
+          categoryValue={uiValue}
+          location={location}
+          when={when}
+          onSearchEdit={handleSearchEdit}
+          initialSort={sort}
+          initialMinPrice={minPrice}
+          initialMaxPrice={maxPrice}
+          verifiedOnly={verifiedOnly}
+          onFilterApply={({ sort: s, minPrice: min, maxPrice: max, verifiedOnly: vo }) => {
+            setSort(s || undefined);
+            setMinPrice(min);
+            setMaxPrice(max);
+            setVerifiedOnly(vo);
+            updateQueryParams(router, pathname, {
+              category,
+              location,
+              when,
+              sort: s,
+              minPrice: min,
+              maxPrice: max,
+              verifiedOnly: vo,
+            });
+          }}
+          onFilterClear={() => {
+            setSort(undefined);
+            setMinPrice(SLIDER_MIN);
+            setMaxPrice(SLIDER_MAX);
+            setVerifiedOnly(false);
+            updateQueryParams(router, pathname, {
+              category,
+              location,
+              when,
+            });
+          }}
+        />
+      </div>
+    </div>
   );
 
   return (

--- a/frontend/src/components/artist/ArtistsPageHeader.tsx
+++ b/frontend/src/components/artist/ArtistsPageHeader.tsx
@@ -29,6 +29,8 @@ export interface ArtistsPageHeaderProps {
     verifiedOnly: boolean;
   }) => void;
   onFilterClear: () => void;
+  /** Render only the filter icon without search button */
+  iconOnly?: boolean;
 }
 
 export default function ArtistsPageHeader({
@@ -43,6 +45,7 @@ export default function ArtistsPageHeader({
   verifiedOnly,
   onFilterApply,
   onFilterClear,
+  iconOnly,
 }: ArtistsPageHeaderProps) {
   const isDesktop = useMediaQuery('(min-width:768px)');
   const [searchOpen, setSearchOpen] = useState(false);
@@ -69,6 +72,53 @@ export default function ArtistsPageHeader({
 
   const compact = `${categoryLabel || 'All'} · ${location || 'Anywhere'}`;
   const dateStr = when ? format(when, 'd MMM yyyy') : 'Add date';
+
+  if (iconOnly) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setFilterOpen(true)}
+          className="relative p-2"
+          aria-label="Filters"
+        >
+          <FunnelIcon className="h-5 w-5" />
+          {filtersActive && (
+            <span className="absolute top-0 right-0 h-2 w-2 bg-pink-500 rounded-full" />
+          )}
+        </button>
+        <FilterSheet
+          open={filterOpen}
+          onClose={() => setFilterOpen(false)}
+          sort={sort}
+          onSort={(e) => setSort(e.target.value)}
+          minPrice={minPrice}
+          maxPrice={maxPrice}
+          onPriceChange={(min, max) => {
+            setMinPrice(min);
+            setMaxPrice(max);
+          }}
+          verifiedOnly={onlyVerified}
+          onVerifiedOnly={(v) => setOnlyVerified(v)}
+          onApply={() =>
+            onFilterApply({
+              sort,
+              minPrice,
+              maxPrice,
+              verifiedOnly: onlyVerified,
+            })
+          }
+          onClear={() => {
+            setSort('');
+            setMinPrice(initialMinPrice);
+            setMaxPrice(initialMaxPrice);
+            setOnlyVerified(false);
+            onFilterClear();
+          }}
+        />
+      </>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
@@ -1,0 +1,42 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ArtistsPageHeader from '../ArtistsPageHeader';
+
+jest.mock('@/hooks/useMediaQuery', () => jest.fn(() => true));
+
+describe('ArtistsPageHeader iconOnly', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  it('renders only the funnel icon when iconOnly', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ArtistsPageHeader
+          iconOnly
+          initialMinPrice={0}
+          initialMaxPrice={100}
+          verifiedOnly={false}
+          onFilterApply={jest.fn()}
+          onFilterClear={jest.fn()}
+          onSearchEdit={jest.fn()}
+        />,
+      );
+    });
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe('');
+    const icon = button?.querySelector('svg');
+    expect(icon).not.toBeNull();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add `iconOnly` mode to `ArtistsPageHeader`
- position filter icon next to inline search bar on artist page
- document placement of filter icon in README
- test `ArtistsPageHeader` icon-only rendering

## Testing
- `./scripts/test-frontend.sh` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_6882399763d0832e8d5b0dc39ae50de3