### PR TITLE
Adjust artist search UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,7 +101,7 @@ displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
 desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper widens from `md:max-w-2xl` up to `md:max-w-3xl lg:max-w-4xl` with a 300ms ease-out transition. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
 bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. Filters show a tiny pink dot when
-active. All search options and filters persist in the URL so pages can be shared
+active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.
 
 ## Testing

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -119,6 +119,8 @@ export default function ArtistsPage() {
     });
   };
 
+  const [searchExpanded, setSearchExpanded] = useState(false);
+
   const header = (
     <div className="relative flex items-center justify-center">
       <SearchBarInline
@@ -126,47 +128,50 @@ export default function ArtistsPage() {
         initialLocation={location}
         initialWhen={when}
         onSearch={handleSearchEdit}
+        onExpandedChange={setSearchExpanded}
       />
-      <div className="absolute right-4 top-1/2 -translate-y-1/2">
-        <ArtistsPageHeader
-          iconOnly
-          categoryLabel={uiLabel}
-          categoryValue={uiValue}
-          location={location}
-          when={when}
-          onSearchEdit={handleSearchEdit}
-          initialSort={sort}
-          initialMinPrice={minPrice}
-          initialMaxPrice={maxPrice}
-          verifiedOnly={verifiedOnly}
-          onFilterApply={({ sort: s, minPrice: min, maxPrice: max, verifiedOnly: vo }) => {
-            setSort(s || undefined);
-            setMinPrice(min);
-            setMaxPrice(max);
-            setVerifiedOnly(vo);
-            updateQueryParams(router, pathname, {
-              category,
-              location,
-              when,
-              sort: s,
-              minPrice: min,
-              maxPrice: max,
-              verifiedOnly: vo,
-            });
-          }}
-          onFilterClear={() => {
-            setSort(undefined);
-            setMinPrice(SLIDER_MIN);
-            setMaxPrice(SLIDER_MAX);
-            setVerifiedOnly(false);
-            updateQueryParams(router, pathname, {
-              category,
-              location,
-              when,
-            });
-          }}
-        />
-      </div>
+      {!searchExpanded && (
+        <div className="absolute right-2 top-1/2 -translate-y-1/2">
+          <ArtistsPageHeader
+            iconOnly
+            categoryLabel={uiLabel}
+            categoryValue={uiValue}
+            location={location}
+            when={when}
+            onSearchEdit={handleSearchEdit}
+            initialSort={sort}
+            initialMinPrice={minPrice}
+            initialMaxPrice={maxPrice}
+            verifiedOnly={verifiedOnly}
+            onFilterApply={({ sort: s, minPrice: min, maxPrice: max, verifiedOnly: vo }) => {
+              setSort(s || undefined);
+              setMinPrice(min);
+              setMaxPrice(max);
+              setVerifiedOnly(vo);
+              updateQueryParams(router, pathname, {
+                category,
+                location,
+                when,
+                sort: s,
+                minPrice: min,
+                maxPrice: max,
+                verifiedOnly: vo,
+              });
+            }}
+            onFilterClear={() => {
+              setSort(undefined);
+              setMinPrice(SLIDER_MIN);
+              setMaxPrice(SLIDER_MAX);
+              setVerifiedOnly(false);
+              updateQueryParams(router, pathname, {
+                category,
+                location,
+                when,
+              });
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -14,6 +14,11 @@ interface Props {
   initialLocation?: string;
   initialWhen?: Date | null;
   onSearch: (p: { category?: string; location?: string; when?: Date | null }) => void;
+  /**
+   * Fired whenever the bar expands or collapses.
+   * Use to hide surrounding UI like filter buttons.
+   */
+  onExpandedChange?: (expanded: boolean) => void;
 }
 
 export default function SearchBarInline({
@@ -21,6 +26,7 @@ export default function SearchBarInline({
   initialLocation,
   initialWhen,
   onSearch,
+  onExpandedChange,
 }: Props) {
   // pick a default category object
   const initialCat = initialCategory
@@ -33,15 +39,25 @@ export default function SearchBarInline({
   const [expanded, setExpanded] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  const collapse = () => {
+    setExpanded(false);
+    onExpandedChange?.(false);
+  };
+
+  const expand = () => {
+    setExpanded(true);
+    onExpandedChange?.(true);
+  };
+
   // close when clicking outside
-  useClickOutside(wrapperRef, () => setExpanded(false));
+  useClickOutside(wrapperRef, collapse);
 
   // close on Escape key
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        setExpanded(false);
+        collapse();
       }
     };
     document.addEventListener('keydown', handler);
@@ -51,7 +67,7 @@ export default function SearchBarInline({
   // run search and collapse
   const handleSearch = (params: { category?: string; location?: string; when?: Date | null }) => {
     onSearch(params);
-    setExpanded(false);
+    collapse();
   };
 
   return (
@@ -73,12 +89,12 @@ export default function SearchBarInline({
           when={when}
           setWhen={setWhen}
           onSearch={handleSearch}
-          onCancel={() => setExpanded(false)}
+          onCancel={collapse}
         />
       ) : (
         <button
           type="button"
-          onClick={() => setExpanded(true)}
+          onClick={expand}
           className="flex items-center bg-white border border-gray-200 rounded-full shadow-sm divide-x divide-gray-200 overflow-hidden w-full hover:ring-2 hover:ring-pink-500 focus:outline-none focus:ring-2 focus:ring-pink-500 transition-all duration-300 ease-out"
         >
           <div className="flex-1 px-4 py-2 text-sm text-gray-700">

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -16,18 +16,20 @@ describe('SearchBarInline', () => {
 
   it('expands and triggers onSearch', () => {
     const onSearch = jest.fn();
+    const onChange = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
     act(() => {
-      root.render(<SearchBarInline onSearch={onSearch} />);
+      root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
     });
 
     const trigger = container.querySelector('button') as HTMLButtonElement;
     act(() => {
       trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
+    expect(onChange).toHaveBeenLastCalledWith(true);
 
     const searchBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
     expect(searchBtn).not.toBeNull();
@@ -35,6 +37,7 @@ describe('SearchBarInline', () => {
     act(() => {
       searchBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
+    expect(onChange).toHaveBeenLastCalledWith(false);
 
     expect(onSearch).toHaveBeenCalled();
 
@@ -44,22 +47,25 @@ describe('SearchBarInline', () => {
 
   it('closes on Escape without searching', () => {
     const onSearch = jest.fn();
+    const onChange = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
     act(() => {
-      root.render(<SearchBarInline onSearch={onSearch} />);
+      root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
     });
 
     const trigger = container.querySelector('button') as HTMLButtonElement;
     act(() => {
       trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
+    expect(onChange).toHaveBeenLastCalledWith(true);
 
     act(() => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     });
+    expect(onChange).toHaveBeenLastCalledWith(false);
 
     const searchBtn = container.querySelector('button[type="submit"]');
     expect(searchBtn).toBeNull();


### PR DESCRIPTION
## Summary
- let parents react when SearchBarInline expands or collapses
- hide filter icon when expanded and move it closer to the search bar
- document new filter behavior
- update tests for SearchBarInline

## Testing
- `npm install`
- `npm test -- --maxWorkers=50%` *(fails: Cannot find module 'react-google-autocomplete/lib/usePlacesAutocompleteService')*
- `pytest -q` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68823c0b648c832e9f70e05b7325914e