### PR TITLE
Center search bar with adjacent filter icon

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import clsx from 'clsx';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import { getArtists } from '@/lib/api';
@@ -122,7 +123,14 @@ export default function ArtistsPage() {
   const [searchExpanded, setSearchExpanded] = useState(false);
 
   const header = (
-    <div className="relative flex items-center justify-center">
+    <div
+      className={clsx(
+        'relative mx-auto transition-all duration-300 ease-out',
+        searchExpanded
+          ? 'max-w-full md:max-w-5xl lg:max-w-6xl'
+          : 'max-w-2xl'
+      )}
+    >
       <SearchBarInline
         initialCategory={uiValue}
         initialLocation={location}


### PR DESCRIPTION
## Summary
- keep the inline search bar centered
- position the filter button snug to the search bar

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Cannot find module 'react-google-autocomplete/lib/usePlacesAutocompleteService')*

------
https://chatgpt.com/codex/tasks/task_e_68823f68dce4832e90d93e61caff5c50