### PR TITLE
Fix search bar width

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -196,7 +196,7 @@ export default function Header({ extraBar }: { extraBar?: ReactNode }) {
 
         {/* Row B */}
         {isHome && (
-          <div className="pb-3 pt-2">
+          <div className="w-full max-w-2xl mx-auto px-4 pb-3 pt-2">
             <SearchBar
               compact
               category={category}

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -74,10 +74,8 @@ export default function SearchBarInline({
     <div
       ref={wrapperRef}
       className={clsx(
-        'relative w-full mx-auto px-4 transition-all duration-300 ease-out',
-        expanded
-          ? 'max-w-full md:max-w-5xl lg:max-w-6xl'
-          : 'md:max-w-2xl'
+        'relative w-full max-w-2xl mx-auto px-4 transition-all duration-300 ease-out',
+        expanded && 'max-w-2xl'
       )}
     >
       {expanded ? (


### PR DESCRIPTION
## Summary
- enforce consistent width for homepage SearchBar and inline SearchBar

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824156dd88832e94a361b39baaeb1c