### PR TITLE
Fix filter icon placement

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -139,7 +139,7 @@ export default function ArtistsPage() {
         onExpandedChange={setSearchExpanded}
       />
       {!searchExpanded && (
-        <div className="absolute right-2 top-1/2 -translate-y-1/2">
+        <div className="absolute left-full ml-2 top-1/2 -translate-y-1/2">
           <ArtistsPageHeader
             iconOnly
             categoryLabel={uiLabel}


### PR DESCRIPTION
## Summary
- keep the search bar centered and place the filter icon flush to its right

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Cannot find module 'react-google-autocomplete/lib/usePlacesAutocompleteService')*
- `pytest -q` *(fails: pydantic_settings.exceptions.SettingsError)*

------
https://chatgpt.com/codex/tasks/task_e_688242759c7c832ebdcd905eb928b5f5