### PR TITLE
Increase search bar width

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -99,7 +99,7 @@ The artists page uses a responsive grid that shows one card per row on mobile,
 two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
-desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper widens from `md:max-w-2xl` up to `md:max-w-3xl lg:max-w-4xl` with a 300ms ease-out transition. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
+desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
 bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. Filters show a tiny pink dot when
 active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -196,7 +196,7 @@ export default function Header({ extraBar }: { extraBar?: ReactNode }) {
 
         {/* Row B */}
         {isHome && (
-          <div className="w-full max-w-2xl mx-auto px-4 pb-3 pt-2">
+          <div className="w-full max-w-4xl mx-auto px-4 pb-3 pt-2">
             <SearchBar
               compact
               category={category}

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`Header renders search bar on home page 1`] = `
         class="relative"
       >
         <form
-          class="flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-md overflow-visible min-h-[48px] text-sm mx-auto w-full md:max-w-2xl"
+          class="flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-md overflow-visible min-h-[48px] text-sm mx-auto w-full md:max-w-4xl"
         >
           <div
             class="flex-1 px-4 flex flex-col text-left py-2"

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -74,8 +74,8 @@ export default function SearchBarInline({
     <div
       ref={wrapperRef}
       className={clsx(
-        'relative w-full max-w-2xl mx-auto px-4 transition-all duration-300 ease-out',
-        expanded && 'max-w-2xl'
+        'relative w-full max-w-4xl mx-auto px-4 transition-all duration-300 ease-out',
+        expanded && 'max-w-4xl'
       )}
     >
       {expanded ? (


### PR DESCRIPTION
## Summary
- expand inline search wrapper to max-w-4xl
- widen homepage header search bar wrapper
- update docs for the new width
- update snapshot

## Testing
- `npm install`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Cannot find module 'react-google-autocomplete/...')*


------
https://chatgpt.com/codex/tasks/task_e_6882455b58d4832eb3ba772a1e1e7527