### PR TITLE
Adjust search bar padding and header color

### DIFF
--- a/frontend/__mocks__/react-google-autocomplete/lib/usePlacesAutocompleteService.js
+++ b/frontend/__mocks__/react-google-autocomplete/lib/usePlacesAutocompleteService.js
@@ -1,0 +1,5 @@
+module.exports = () => ({
+  placesService: null,
+  placePredictions: [],
+  getPlacePredictions: jest.fn(),
+});

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -60,7 +60,7 @@ export default function Header({ extraBar }: { extraBar?: ReactNode }) {
   }
 
   return (
-    <header className="sticky top-0 z-40 bg-gray-50">
+    <header className="sticky top-0 z-40 bg-gray-100">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {/* Row A */}
         <div className="h-16 grid grid-cols-[auto,1fr,auto] items-center">
@@ -196,7 +196,7 @@ export default function Header({ extraBar }: { extraBar?: ReactNode }) {
 
         {/* Row B */}
         {isHome && (
-          <div className="w-full max-w-4xl mx-auto px-4 pb-3 pt-2">
+          <div className="w-full max-w-4xl mx-auto px-4 pb-5 pt-2">
             <SearchBar
               compact
               category={category}

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -75,7 +75,7 @@ export default function SearchBarInline({
       ref={wrapperRef}
       className={clsx(
         'relative w-full max-w-4xl mx-auto px-4 transition-all duration-300 ease-out',
-        expanded && 'max-w-4xl'
+        expanded && 'max-w-4xl pb-2'
       )}
     >
       {expanded ? (


### PR DESCRIPTION
## Summary
- add small bottom padding when SearchBarInline expands
- increase padding under homepage search bar
- darken header slightly
- stub usePlacesAutocompleteService for tests

## Testing
- `./setup.sh` *(fails: Setup complete)*
- `./scripts/test-all.sh` *(fails: jest errors and missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68825164cbe0832e9128fbb2308a28cc