### PR TITLE
Redesign web filter modal

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -99,9 +99,9 @@ The artists page uses a responsive grid that shows one card per row on mobile,
 two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
-desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition, while the collapsed pill uses a narrower `md:max-w-2xl` so it takes up about 25% less space. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
-bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. Filters show a tiny pink dot when
-active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
+  desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition, while the collapsed pill uses a narrower `md:max-w-2xl` so it takes up about 25% less space. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
+ bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. The desktop filter now opens in a white rounded card with a pink range slider and clear/apply buttons, similar to Airbnb.
+ Filters show a tiny pink dot when active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.
 
 ## Testing

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -47,9 +47,6 @@ export default function ArtistsPage() {
     const w = searchParams.get('when');
     return w ? new Date(w) : null;
   });
-  const [verifiedOnly, setVerifiedOnly] = useState(
-    searchParams.get('verifiedOnly') === 'true'
-  );
   const [minPrice, setMinPrice] = useState<number>(
     searchParams.get('minPrice') ? Number(searchParams.get('minPrice')) : SLIDER_MIN
   );
@@ -74,7 +71,6 @@ export default function ArtistsPage() {
         sort,
         minPrice,
         maxPrice,
-        verifiedOnly,
         page: pageOverride ?? page,
         limit: LIMIT,
       });
@@ -92,7 +88,7 @@ export default function ArtistsPage() {
   useEffect(() => {
     setPage(1);
     fetchArtists({ pageOverride: 1 });
-  }, [category, location, when, sort, minPrice, maxPrice, verifiedOnly]);
+  }, [category, location, when, sort, minPrice, maxPrice]);
 
   const loadMore = () => {
     const next = page + 1;
@@ -116,7 +112,6 @@ export default function ArtistsPage() {
       sort,
       minPrice,
       maxPrice,
-      verifiedOnly,
     });
   };
 
@@ -150,12 +145,10 @@ export default function ArtistsPage() {
             initialSort={sort}
             initialMinPrice={minPrice}
             initialMaxPrice={maxPrice}
-            verifiedOnly={verifiedOnly}
-            onFilterApply={({ sort: s, minPrice: min, maxPrice: max, verifiedOnly: vo }) => {
+            onFilterApply={({ sort: s, minPrice: min, maxPrice: max }) => {
               setSort(s || undefined);
               setMinPrice(min);
               setMaxPrice(max);
-              setVerifiedOnly(vo);
               updateQueryParams(router, pathname, {
                 category,
                 location,
@@ -163,14 +156,12 @@ export default function ArtistsPage() {
                 sort: s,
                 minPrice: min,
                 maxPrice: max,
-                verifiedOnly: vo,
               });
             }}
             onFilterClear={() => {
               setSort(undefined);
               setMinPrice(SLIDER_MIN);
               setMaxPrice(SLIDER_MAX);
-              setVerifiedOnly(false);
               updateQueryParams(router, pathname, {
                 category,
                 location,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -79,22 +79,22 @@ html[data-headlessui-focus-visible] {
     appearance: none;
     width: 16px; /* Size of the thumb */
     height: 16px; /* Size of the thumb */
-    background: #4f46e5; /* Indigo color for the thumb */
-    border: 2px solid #fff; /* White border */
-    border-radius: 50%; /* Make it round */
+    background: #ffffff; /* White thumb */
+    border: 2px solid #d1d5db; /* Gray border */
+    border-radius: 50%;
     cursor: grab;
-    margin-top: -6px; /* Adjust to center vertically on the track */
-    box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.2); /* Ring on focus/active */
+    margin-top: -7px; /* Center on 2px track */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   }
   
   .custom-range-thumb::-moz-range-thumb {
     width: 16px;
     height: 16px;
-    background: #4f46e5;
-    border: 2px solid #fff;
+    background: #ffffff;
+    border: 2px solid #d1d5db;
     border-radius: 50%;
     cursor: grab;
-    box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.2);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   }
   
   .custom-range-thumb:active::-webkit-slider-thumb {

--- a/frontend/src/components/artist/ArtistsPageHeader.tsx
+++ b/frontend/src/components/artist/ArtistsPageHeader.tsx
@@ -21,12 +21,10 @@ export interface ArtistsPageHeaderProps {
   initialSort?: string;
   initialMinPrice: number;
   initialMaxPrice: number;
-  verifiedOnly: boolean;
   onFilterApply: (params: {
     sort?: string;
     minPrice: number;
     maxPrice: number;
-    verifiedOnly: boolean;
   }) => void;
   onFilterClear: () => void;
   /** Render only the filter icon without search button */
@@ -42,7 +40,6 @@ export default function ArtistsPageHeader({
   initialSort,
   initialMinPrice,
   initialMaxPrice,
-  verifiedOnly,
   onFilterApply,
   onFilterClear,
   iconOnly,
@@ -53,11 +50,9 @@ export default function ArtistsPageHeader({
   const [sort, setSort] = useState(initialSort);
   const [minPrice, setMinPrice] = useState(initialMinPrice);
   const [maxPrice, setMaxPrice] = useState(initialMaxPrice);
-  const [onlyVerified, setOnlyVerified] = useState(verifiedOnly);
 
   const filtersActive =
     Boolean(sort) ||
-    onlyVerified ||
     minPrice !== SLIDER_MIN ||
     maxPrice !== SLIDER_MAX;
 
@@ -66,9 +61,8 @@ export default function ArtistsPageHeader({
       setSort(initialSort);
       setMinPrice(initialMinPrice);
       setMaxPrice(initialMaxPrice);
-      setOnlyVerified(verifiedOnly);
     }
-  }, [filterOpen, initialSort, initialMinPrice, initialMaxPrice, verifiedOnly]);
+  }, [filterOpen, initialSort, initialMinPrice, initialMaxPrice]);
 
   const compact = `${categoryLabel || 'All'} · ${location || 'Anywhere'}`;
   const dateStr = when ? format(when, 'd MMM yyyy') : 'Add date';
@@ -98,21 +92,17 @@ export default function ArtistsPageHeader({
             setMinPrice(min);
             setMaxPrice(max);
           }}
-          verifiedOnly={onlyVerified}
-          onVerifiedOnly={(v) => setOnlyVerified(v)}
           onApply={() =>
             onFilterApply({
               sort,
               minPrice,
               maxPrice,
-              verifiedOnly: onlyVerified,
             })
           }
           onClear={() => {
             setSort('');
             setMinPrice(initialMinPrice);
             setMaxPrice(initialMaxPrice);
-            setOnlyVerified(false);
             onFilterClear();
           }}
         />
@@ -165,21 +155,17 @@ export default function ArtistsPageHeader({
           setMinPrice(min);
           setMaxPrice(max);
         }}
-        verifiedOnly={onlyVerified}
-        onVerifiedOnly={(v) => setOnlyVerified(v)}
         onApply={() =>
           onFilterApply({
             sort,
             minPrice,
             maxPrice,
-            verifiedOnly: onlyVerified,
           })
         }
         onClear={() => {
           setSort('');
           setMinPrice(initialMinPrice);
           setMaxPrice(initialMaxPrice);
-          setOnlyVerified(false);
           onFilterClear();
         }}
       />

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useRef } from 'react';
 import type { ChangeEventHandler } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import useMediaQuery from '@/hooks/useMediaQuery';
 import { BottomSheet, Button } from '@/components/ui';
 import {
   SLIDER_MIN,
@@ -12,8 +14,6 @@ import {
 interface FilterSheetProps {
   open: boolean;
   onClose: () => void;
-  verifiedOnly: boolean;
-  onVerifiedOnly: (v: boolean) => void;
   sort?: string;
   onSort: ChangeEventHandler<HTMLSelectElement>;
   onClear: () => void;
@@ -26,8 +26,6 @@ interface FilterSheetProps {
 export default function FilterSheet({
   open,
   onClose,
-  verifiedOnly,
-  onVerifiedOnly,
   sort,
   onSort,
   onClear,
@@ -37,100 +35,109 @@ export default function FilterSheet({
   onPriceChange,
 }: FilterSheetProps) {
   const firstRef = useRef<HTMLInputElement>(null);
-  return (
-    <BottomSheet open={open} onClose={onClose} initialFocus={firstRef}>
-      <div className="p-4 pb-32 space-y-4">
-        <h2 className="text-lg font-medium">Filters</h2>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={verifiedOnly}
-            onChange={(e) => onVerifiedOnly(e.target.checked)}
-            className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
-            ref={firstRef}
-          />
-          <span>Verified Only</span>
-        </label>
-        <div>
-          <label htmlFor="sheet-sort" className="block text-sm font-medium mb-1">
-            Sort
-          </label>
-          <select
-            id="sheet-sort"
-            value={sort}
-            onChange={onSort}
-            className="w-full h-10 px-3 rounded-lg border border-gray-200 bg-white shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300"
-          >
-            <option value="">Sort</option>
-            <option value="top_rated">Top Rated</option>
-            <option value="most_booked">Most Booked</option>
-            <option value="newest">Newest</option>
-          </select>
-        </div>
-        <div className="pt-2">
-          <label className="block text-sm font-medium mb-1">Price Range</label>
-          <div className="relative mt-2 px-2">
-            <div className="h-1 bg-gray-200 rounded-full" />
-            <div
-              className="absolute h-1 bg-indigo-600 rounded-full"
-              style={{
-                left: `${((minPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
-                right: `${100 - ((maxPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
-              }}
-            />
-            <input
-              type="range"
-              min={SLIDER_MIN}
-              max={SLIDER_MAX}
-              step={SLIDER_STEP}
-              value={minPrice}
-              onChange={(e) => {
-                const v = Number(e.target.value);
-                onPriceChange(v, Math.max(v, maxPrice));
-              }}
-              className="absolute inset-0 w-full h-1 appearance-none bg-transparent pointer-events-auto"
-            />
-            <input
-              type="range"
-              min={SLIDER_MIN}
-              max={SLIDER_MAX}
-              step={SLIDER_STEP}
-              value={maxPrice}
-              onChange={(e) => {
-                const v = Number(e.target.value);
-                onPriceChange(Math.min(v, minPrice), v);
-              }}
-              className="absolute inset-0 w-full h-1 appearance-none bg-transparent pointer-events-auto"
-            />
-          </div>
-          <div className="flex justify-between text-xs text-gray-700 mt-1 px-4">
-            <span>{formatCurrency(minPrice)}</span>
-            <span>{formatCurrency(maxPrice)}</span>
-          </div>
-        </div>
-      </div>
-      <div className="fixed bottom-0 left-0 w-full flex gap-2 p-4 border-t bg-white">
+  const isDesktop = useMediaQuery('(min-width:768px)');
+  if (!open) return null;
+
+  const content = (
+    <div className="space-y-6" ref={firstRef}>
+      <div className="flex justify-center relative">
+        <h2 className="text-lg font-bold">Filters</h2>
         <button
           type="button"
-          onClick={() => {
-            onClear();
-          }}
-          className="flex-1 text-sm text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute right-0 top-0"
         >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      </div>
+      <div>
+        <label htmlFor="sheet-sort" className="block text-sm font-medium">
+          Sort
+        </label>
+        <select
+          id="sheet-sort"
+          value={sort}
+          onChange={onSort}
+          className="w-full border border-gray-200 rounded-md px-4 py-2 mt-2"
+        >
+          <option value="">Sort</option>
+          <option value="top_rated">Top Rated</option>
+          <option value="most_booked">Most Booked</option>
+          <option value="newest">Newest</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Price range</label>
+        <p className="text-xs text-gray-500">Trip price, includes all fees.</p>
+        <div className="mt-4 relative">
+          <div className="h-2 bg-gray-200 rounded" />
+          <div
+            className="absolute h-2 bg-pink-500 rounded"
+            style={{
+              left: `${((minPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
+              right: `${100 - ((maxPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
+            }}
+          />
+          <input
+            type="range"
+            min={SLIDER_MIN}
+            max={SLIDER_MAX}
+            step={SLIDER_STEP}
+            value={minPrice}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              onPriceChange(v, Math.max(v, maxPrice));
+            }}
+            className="custom-range-thumb absolute inset-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
+          />
+          <input
+            type="range"
+            min={SLIDER_MIN}
+            max={SLIDER_MAX}
+            step={SLIDER_STEP}
+            value={maxPrice}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              onPriceChange(Math.min(v, minPrice), v);
+            }}
+            className="custom-range-thumb absolute inset-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
+          />
+        </div>
+        <div className="flex justify-between mt-2 text-sm text-gray-600">
+          <span>{formatCurrency(minPrice)}</span>
+          <span>{formatCurrency(maxPrice)}</span>
+        </div>
+      </div>
+      <div className="flex justify-between mt-6">
+        <button type="button" className="text-gray-600" onClick={onClear}>
           Clear all
         </button>
-        <Button
+        <button
           type="button"
+          className="bg-brand text-white px-6 py-2 rounded-md"
           onClick={() => {
             onApply();
             onClose();
           }}
-          className="flex-1"
-          fullWidth
         >
           Apply filters
-        </Button>
+        </button>
       </div>
+    </div>
+  );
+
+  if (isDesktop) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+        <div className="bg-white rounded-2xl p-6 max-w-md mx-auto w-full">{content}</div>
+      </div>
+    );
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} initialFocus={firstRef}>
+      <div className="p-4 pb-32 space-y-4">{content}</div>
     </BottomSheet>
   );
 }

--- a/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
@@ -22,7 +22,6 @@ describe('ArtistsPageHeader iconOnly', () => {
           iconOnly
           initialMinPrice={0}
           initialMaxPrice={100}
-          verifiedOnly={false}
           onFilterApply={jest.fn()}
           onFilterClear={jest.fn()}
           onSearchEdit={jest.fn()}

--- a/frontend/src/lib/urlParams.ts
+++ b/frontend/src/lib/urlParams.ts
@@ -10,7 +10,6 @@ interface Params {
   sort?: string;
   minPrice?: number;
   maxPrice?: number;
-  verifiedOnly?: boolean;
 }
 
 export function updateQueryParams(
@@ -25,7 +24,6 @@ export function updateQueryParams(
   if (params.sort) search.set('sort', params.sort);
   if (params.minPrice != null && params.minPrice > SLIDER_MIN) search.set('minPrice', String(params.minPrice));
   if (params.maxPrice != null && params.maxPrice < SLIDER_MAX) search.set('maxPrice', String(params.maxPrice));
-  if (params.verifiedOnly) search.set('verifiedOnly', 'true');
   const qs = search.toString();
   router.push(qs ? `${pathname}?${qs}` : pathname);
 }


### PR DESCRIPTION
## Summary
- restyle the artist FilterSheet modal on desktop
- drop the verified-only filter option
- update globals.css slider thumb styling
- remove verifiedOnly state throughout artists page components
- document new filter styling in README

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: Maximum call stack size exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_688266885ed0832e805cd2dc045c2c76