### PR TITLE
Fix Filter modal using portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ bar now sits directly beneath the global navigation whenever you visit
 `useMediaQuery('(min-width:768px)')` hook picks between this inline bar and the
 mobile `SearchModal`. On mobile a compact summary displays the selected values;
 tapping it opens the modal prefilled with those values. A **Filters** button
-opens `FilterSheet` for sort and price range. The button
+opens `FilterSheet` for sort and price range. On desktop the filter modal uses a React portal to keep its fixed overlay centered. The button
 shows a tiny pink dot when any filter is active. The page
 rests on a soft gradient background from the brand color to white. When no
 results match the current filters the page shows "No artists found" beneath the

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -30,8 +30,8 @@ export default function RootLayout({
             <Toaster position="top-right" />
           </NotificationsProvider>
         </AuthProvider>
+        <div id="modal-root"></div>
 
-    
       </body>
     </html>
   );

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useEffect, useState } from "react";
 import type { ChangeEventHandler } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import { BottomSheet } from "@/components/ui";
+import { createPortal } from "react-dom";
 import {
   SLIDER_MIN,
   SLIDER_MAX,
@@ -36,7 +37,14 @@ export default function FilterSheet({
 }: FilterSheetProps) {
   const firstRef = useRef<HTMLInputElement>(null);
   const isDesktop = useMediaQuery("(min-width:768px)");
-  if (!open) return null;
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!open || !mounted) return null;
 
   const content = (
     <div className="space-y-6" ref={firstRef}>
@@ -128,12 +136,13 @@ export default function FilterSheet({
   );
 
   if (isDesktop) {
-    return (
+    return createPortal(
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
         <div className="bg-white rounded-2xl p-6 max-w-md mx-auto w-full">
           {content}
         </div>
-      </div>
+      </div>,
+      document.getElementById('modal-root')!
     );
   }
 


### PR DESCRIPTION
## Summary
- allow modals to render in a portal root
- mount `FilterSheet` in a portal so the overlay remains centered
- document the portal in README

## Testing
- `./scripts/test-all.sh` *(fails: TypeError `(0 , _navigation.useRouter) is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_688283c1e3b4832ea255689403df1c2a