### PR TITLE
Add price range histogram and numeric inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists page redesigned with a responsive grid, sticky search header with quick
   filters, skeleton loaders and a hover "Book Now" overlay for a modern,
   accessible look.
+- Price filter now displays a histogram and accepts numeric input for precise ranges.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
 - Search categories now map **Musician / Band** to the `Live Performance` service

--- a/backend/tests/test_artist_filters.py
+++ b/backend/tests/test_artist_filters.py
@@ -77,7 +77,7 @@ def test_price_range_filter(monkeypatch):
         lambda *args, **kwargs: None,
     )
 
-    results = read_all_artist_profiles(
+    res = read_all_artist_profiles(
         category=ServiceType.LIVE_PERFORMANCE,
         min_price=300,
         max_price=800,
@@ -85,9 +85,9 @@ def test_price_range_filter(monkeypatch):
         page=1,
         limit=20,
     )
-    assert len(results) == 1
-    assert results[0].business_name == 'Mid'
-    assert float(results[0].service_price) == 500
+    assert len(res["data"]) == 1
+    assert res["data"][0].business_name == 'Mid'
+    assert float(res["data"][0].service_price) == 500
 
 
 def test_price_visible_default_true():
@@ -117,7 +117,7 @@ def test_filters_and_sorting(monkeypatch):
         lambda *args, **kwargs: None,
     )
 
-    results = read_all_artist_profiles(
+    res = read_all_artist_profiles(
         category=ServiceType.OTHER,
         location='San',
         sort='most_booked',
@@ -125,10 +125,10 @@ def test_filters_and_sorting(monkeypatch):
         page=1,
         limit=20,
     )
-    assert len(results) == 1
-    assert results[0].business_name == 'Beta'
-    assert results[0].rating == 5
-    assert results[0].rating_count == 1
+    assert len(res["data"]) == 1
+    assert res["data"][0].business_name == 'Beta'
+    assert res["data"][0].rating == 5
+    assert res["data"][0].rating_count == 1
 
 
 def test_service_price_none_without_category(monkeypatch):
@@ -143,7 +143,7 @@ def test_service_price_none_without_category(monkeypatch):
         lambda *args, **kwargs: None,
     )
 
-    results = read_all_artist_profiles(db=db, page=1, limit=20)
-    assert len(results) == 1
-    assert results[0].service_price is None
+    res = read_all_artist_profiles(db=db, page=1, limit=20)
+    assert len(res["data"]) == 1
+    assert res["data"][0].service_price is None
 

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -144,8 +144,9 @@ def test_read_all_artist_profiles_uses_cache(monkeypatch):
         sort=None,
         page=1,
         limit=20,
+        include_price_distribution=False,
     )
-    assert len(first) == 1
+    assert len(first["data"]) == 1
 
     # Use failing DB to ensure cache is consulted on second call
     second = api_artist.read_all_artist_profiles(
@@ -155,6 +156,7 @@ def test_read_all_artist_profiles_uses_cache(monkeypatch):
         sort=None,
         page=1,
         limit=20,
+        include_price_distribution=False,
     )
     assert second == first
 
@@ -186,5 +188,6 @@ def test_fallback_when_redis_unavailable(monkeypatch):
         sort=None,
         page=1,
         limit=20,
+        include_price_distribution=False,
     )
-    assert len(result) == 1
+    assert len(result["data"]) == 1

--- a/frontend/src/components/artist/ArtistsPageHeader.tsx
+++ b/frontend/src/components/artist/ArtistsPageHeader.tsx
@@ -6,6 +6,7 @@ import useMediaQuery from '@/hooks/useMediaQuery';
 import { format } from 'date-fns';
 import FilterSheet from './FilterSheet';
 import { SLIDER_MIN, SLIDER_MAX } from '@/lib/filter-constants';
+import type { PriceBucket } from '@/lib/api';
 
 export interface ArtistsPageHeaderProps {
   categoryLabel?: string;
@@ -21,6 +22,7 @@ export interface ArtistsPageHeaderProps {
   initialSort?: string;
   initialMinPrice: number;
   initialMaxPrice: number;
+  priceDistribution: PriceBucket[];
   onFilterApply: (params: {
     sort?: string;
     minPrice: number;
@@ -40,6 +42,7 @@ export default function ArtistsPageHeader({
   initialSort,
   initialMinPrice,
   initialMaxPrice,
+  priceDistribution,
   onFilterApply,
   onFilterClear,
   iconOnly,
@@ -88,6 +91,7 @@ export default function ArtistsPageHeader({
           onSort={(e) => setSort(e.target.value)}
           minPrice={minPrice}
           maxPrice={maxPrice}
+          priceDistribution={priceDistribution}
           onPriceChange={(min, max) => {
             setMinPrice(min);
             setMaxPrice(max);
@@ -152,6 +156,7 @@ export default function ArtistsPageHeader({
         onSort={(e) => setSort(e.target.value)}
         minPrice={minPrice}
         maxPrice={maxPrice}
+        priceDistribution={priceDistribution}
         onPriceChange={(min, max) => {
           setMinPrice(min);
           setMaxPrice(max);

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,18 @@ const normalizeArtistProfile = (
 
 // ─── ARTISTS ───────────────────────────────────────────────────────────────────
 
+export interface PriceBucket {
+  min: number;
+  max: number;
+  count: number;
+}
+
+export interface GetArtistsResponse {
+  data: ArtistProfile[];
+  total: number;
+  price_distribution: PriceBucket[];
+}
+
 export const getArtists = async (params?: {
   category?: string;
   location?: string;
@@ -142,11 +154,15 @@ export const getArtists = async (params?: {
   maxPrice?: number;
   page?: number;
   limit?: number;
-}) => {
-  const res = await api.get<ArtistProfile[]>(`${API_V1}/artist-profiles/`, {
+  includePriceDistribution?: boolean;
+}): Promise<GetArtistsResponse> => {
+  const res = await api.get<GetArtistsResponse>(`${API_V1}/artist-profiles/`, {
     params,
   });
-  return { ...res, data: res.data.map(normalizeArtistProfile) };
+  return {
+    ...res.data,
+    data: res.data.data.map(normalizeArtistProfile),
+  };
 };
 
 export const getArtist = async (userId: number) => {


### PR DESCRIPTION
## Summary
- enhance price filter backend with histogram buckets
- expose price distribution to frontend API
- add debounced price sliders with histogram bars and inputs
- update artists page and header for new filter data
- add useDebounce hook
- document price histogram feature

## Testing
- `./scripts/test-all.sh` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688286f6e840832eb72bf5df62bf65a5