### PR TITLE
Fix artist profiles filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,13 +941,14 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 `GET /api/v1/artist-profiles/` supports pagination and optional filters:
 
 ```
-page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>
+page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&includePriceDistribution=<true|false>
 ```
 
 `minPrice` and `maxPrice` filter by the prices of services in the selected
 `category`. If no category is provided, the range applies to any service the
 artist offers. Additional service categories are supported automatically without
-code changes.
+code changes. Pass `includePriceDistribution=true` to return histogram data for
+the filter modal.
 
 Profiles include `rating`, `rating_count`, and `is_available` fields. A new
 `price_visible` boolean on each artist controls whether the hourly rate is

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,12 +6,12 @@ export default function HomePage() {
     <MainLayout>
       <ArtistsSection
         title="Popular Musicians"
-        query={{ sort: 'most_booke' }}
+        query={{ sort: 'most_booked' }}
         hideIfEmpty
       />
       <ArtistsSection
         title="Top Rated"
-        query={{ sort: 'top_rate' }}
+        query={{ sort: 'top_rated' }}
         hideIfEmpty
       />
       <ArtistsSection

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -13,6 +13,14 @@ import {
 } from "@/lib/filter-constants";
 import type { PriceBucket } from "@/lib/api";
 
+// Available sort values must exactly match the backend pattern.
+const SORT_OPTIONS = [
+  { value: "", label: "Sort" },
+  { value: "top_rated", label: "Top Rated" },
+  { value: "most_booked", label: "Most Booked" },
+  { value: "newest", label: "Newest" },
+];
+
 interface FilterSheetProps {
   open: boolean;
   onClose: () => void;
@@ -48,7 +56,7 @@ export default function FilterSheet({
   }, []);
 
   const maxCount = priceDistribution.reduce(
-    (max, b) => Math.max(max, b.count),
+    (max, bucket) => Math.max(max, bucket.count),
     0,
   );
 
@@ -77,22 +85,25 @@ export default function FilterSheet({
           onChange={onSort}
           className="w-full border border-gray-200 rounded-md px-4 py-2 mt-2"
         >
-          <option value="">Sort</option>
-          <option value="top_rated">Top Rated</option>
-          <option value="most_booked">Most Booked</option>
-          <option value="newest">Newest</option>
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
         </select>
       </div>
       <div>
         <label className="block text-sm font-medium">Price range</label>
-        <p className="text-xs text-gray-500">Trip price, includes all fees.</p>
+        <p className="text-xs text-gray-500">
+          Artist/Service price, includes all fees.
+        </p>
         <div className="mt-4 relative h-20">
           <div className="absolute inset-0 flex items-end justify-between px-0.5 pointer-events-none">
             {priceDistribution.map((bucket, index) => (
               <div
                 key={index}
-                className="bg-gray-300 w-1 rounded-t-sm"
-                style={{ height: `${(bucket.count / (maxCount || 1)) * 60}%` }}
+                className="bg-gray-400 w-2 rounded-t-sm"
+                style={{ height: `${(bucket.count / (maxCount || 1)) * 70}%` }}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- correct artist sort values in HomePage and filter sheet
- make price range histogram more visible
- document includePriceDistribution query param

## Testing
- `./scripts/test-all.sh` *(fails: OperationalError table users already exists)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882913338f8832e8acd6a0b34dc941f