### PR TITLE
Fix filter slider overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists page redesigned with a responsive grid, sticky search header with quick
   filters, skeleton loaders and a hover "Book Now" overlay for a modern,
   accessible look.
-- Price filter now displays a histogram and accepts numeric input for precise ranges.
+- Price filter now displays a histogram and accepts numeric input for precise ranges. Slider handles no longer overlap, improving usability.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
 - Search categories now map **Musician / Band** to the `Live Performance` service

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -48,6 +48,7 @@ export default function FilterSheet({
 }: FilterSheetProps) {
   const firstRef = useRef<HTMLInputElement>(null);
   const isDesktop = useMediaQuery("(min-width:768px)");
+  const [activeThumb, setActiveThumb] = useState<"min" | "max" | null>(null);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -94,9 +95,6 @@ export default function FilterSheet({
       </div>
       <div>
         <label className="block text-sm font-medium">Price range</label>
-        <p className="text-xs text-gray-500">
-          Artist/Service price, includes all fees.
-        </p>
         <div className="mt-4 relative h-20">
           <div className="absolute inset-0 flex items-end justify-between px-0.5 pointer-events-none">
             {priceDistribution.map((bucket, index) => (
@@ -125,7 +123,11 @@ export default function FilterSheet({
               const v = Number(e.target.value);
               onPriceChange(v, Math.max(v, maxPrice));
             }}
-            style={{ zIndex: 20 }}
+            onMouseDown={() => setActiveThumb('min')}
+            onTouchStart={() => setActiveThumb('min')}
+            onMouseUp={() => setActiveThumb(null)}
+            onTouchEnd={() => setActiveThumb(null)}
+            style={{ zIndex: activeThumb === 'min' ? 20 : 10 }}
             className="custom-range-thumb absolute inset-x-0 bottom-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
           />
           <input
@@ -138,7 +140,11 @@ export default function FilterSheet({
               const v = Number(e.target.value);
               onPriceChange(Math.min(v, minPrice), v);
             }}
-            style={{ zIndex: 10 }}
+            onMouseDown={() => setActiveThumb('max')}
+            onTouchStart={() => setActiveThumb('max')}
+            onMouseUp={() => setActiveThumb(null)}
+            onTouchEnd={() => setActiveThumb(null)}
+            style={{ zIndex: activeThumb === 'max' ? 20 : 10 }}
             className="custom-range-thumb absolute inset-x-0 bottom-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
           />
         </div>

--- a/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
@@ -1,0 +1,60 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import FilterSheet from '../FilterSheet';
+
+jest.mock('@/hooks/useMediaQuery', () => jest.fn(() => true));
+
+describe('FilterSheet sliders', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  it('calls onPriceChange when sliders move', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const modalRoot = document.createElement('div');
+    modalRoot.id = 'modal-root';
+    document.body.appendChild(modalRoot);
+    const root = createRoot(container);
+    const onPriceChange = jest.fn();
+
+    act(() => {
+      root.render(
+        <FilterSheet
+          open
+          onClose={jest.fn()}
+          sort=""
+          onSort={jest.fn()}
+          onClear={jest.fn()}
+          onApply={jest.fn()}
+          minPrice={0}
+          maxPrice={100}
+          onPriceChange={onPriceChange}
+          priceDistribution={[]}
+        />,
+      );
+    });
+
+    const ranges = modalRoot.querySelectorAll('input[type="range"]');
+    const minInput = ranges[0] as HTMLInputElement;
+    const maxInput = ranges[1] as HTMLInputElement;
+
+    act(() => {
+      minInput.value = '20';
+      minInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onPriceChange).toHaveBeenCalledWith(20, 100);
+
+    act(() => {
+      maxInput.value = '80';
+      maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onPriceChange).toHaveBeenLastCalledWith(20, 80);
+
+    act(() => root.unmount());
+    container.remove();
+    modalRoot.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- fix price range slider handles overlapping
- remove outdated 'all fees included' text
- document slider fix in README
- add regression test for FilterSheet slider

## Testing
- `./scripts/test-all.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68829fc461d8832eaa8ea57d97ac53c1