### PR TITLE
Fix price slider min handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   filters, skeleton loaders and a hover "Book Now" overlay for a modern,
   accessible look.
 - Price filter now displays a histogram and accepts numeric input for precise ranges. Slider handles no longer overlap, improving usability.
+- Fixed an issue where the left price slider could not be grabbed when both handles overlapped.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
 - Search categories now map **Musician / Band** to the `Live Performance` service

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -127,7 +127,12 @@ export default function FilterSheet({
             onTouchStart={() => setActiveThumb('min')}
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
-            style={{ zIndex: activeThumb === 'min' ? 20 : 10 }}
+            style={{
+              // Keep the minimum slider on top by default so it can be grabbed
+              // even when its handle overlaps with the maximum slider. Whichever
+              // slider is active gets a higher z-index to ensure it's draggable.
+              zIndex: activeThumb === 'min' ? 30 : 20,
+            }}
             className="custom-range-thumb absolute inset-x-0 bottom-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
           />
           <input
@@ -144,7 +149,11 @@ export default function FilterSheet({
             onTouchStart={() => setActiveThumb('max')}
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
-            style={{ zIndex: activeThumb === 'max' ? 20 : 10 }}
+            style={{
+              // Lower base z-index so the minimum slider remains clickable when
+              // both handles overlap. Elevate when this slider is active.
+              zIndex: activeThumb === 'max' ? 30 : 10,
+            }}
             className="custom-range-thumb absolute inset-x-0 bottom-0 w-full h-2 appearance-none bg-transparent pointer-events-auto"
           />
         </div>


### PR DESCRIPTION
## Summary
- fix minimum price slider not being clickable
- document price slider bug fix

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: KeyboardInterrupt)*
- `FAST=1 ./scripts/test-all.sh` *(fails: missing ESLint packages)*


------
https://chatgpt.com/codex/tasks/task_e_6883153f9514832e8819b655f1fe30a2