### PR TITLE
Fix missing JSX fragment closure in FilterSheet

### DIFF
--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -219,6 +219,7 @@ export default function FilterSheet({
           Apply filters
         </button>
       </div>
+    </>
   );
 
   if (isDesktop) {


### PR DESCRIPTION
## Summary
- close JSX fragment in `FilterSheet`

## Testing
- `npm run type-check`
- `npx eslint src/components/artist/FilterSheet.tsx`
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68832b2a39f4832e9d824b5272e2a8e1