### PR TITLE
Refactor FilterSheet state flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ bar now sits directly beneath the global navigation whenever you visit
 `useMediaQuery('(min-width:768px)')` hook picks between this inline bar and the
 mobile `SearchModal`. On mobile a compact summary displays the selected values;
 tapping it opens the modal prefilled with those values. A **Filters** button
-opens `FilterSheet` for sort and price range. On desktop the filter modal uses a React portal to keep its fixed overlay centered. The button
+opens `FilterSheet` for sort and price range. On desktop the filter modal uses a React portal to keep its fixed overlay centered. The button stores chosen values locally until **Apply filters** is clicked, updating the URL and results. It then
 shows a tiny pink dot when any filter is active. The page
 rests on a soft gradient background from the brand color to white. When no
 results match the current filters the page shows "No artists found" beneath the

--- a/frontend/src/components/artist/ArtistsPageHeader.tsx
+++ b/frontend/src/components/artist/ArtistsPageHeader.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { FunnelIcon } from '@heroicons/react/24/outline';
 import SearchModal from '@/components/search/SearchModal';
 import useMediaQuery from '@/hooks/useMediaQuery';
@@ -50,22 +50,11 @@ export default function ArtistsPageHeader({
   const isDesktop = useMediaQuery('(min-width:768px)');
   const [searchOpen, setSearchOpen] = useState(false);
   const [filterOpen, setFilterOpen] = useState(false);
-  const [sort, setSort] = useState(initialSort);
-  const [minPrice, setMinPrice] = useState(initialMinPrice);
-  const [maxPrice, setMaxPrice] = useState(initialMaxPrice);
 
   const filtersActive =
-    Boolean(sort) ||
-    minPrice !== SLIDER_MIN ||
-    maxPrice !== SLIDER_MAX;
-
-  useEffect(() => {
-    if (filterOpen) {
-      setSort(initialSort);
-      setMinPrice(initialMinPrice);
-      setMaxPrice(initialMaxPrice);
-    }
-  }, [filterOpen, initialSort, initialMinPrice, initialMaxPrice]);
+    Boolean(initialSort) ||
+    initialMinPrice !== SLIDER_MIN ||
+    initialMaxPrice !== SLIDER_MAX;
 
   const compact = `${categoryLabel || 'All'} · ${location || 'Anywhere'}`;
   const dateStr = when ? format(when, 'd MMM yyyy') : 'Add date';
@@ -87,28 +76,12 @@ export default function ArtistsPageHeader({
         <FilterSheet
           open={filterOpen}
           onClose={() => setFilterOpen(false)}
-          sort={sort}
-          onSort={(e) => setSort(e.target.value)}
-          minPrice={minPrice}
-          maxPrice={maxPrice}
+          initialSort={initialSort}
+          initialMinPrice={initialMinPrice}
+          initialMaxPrice={initialMaxPrice}
           priceDistribution={priceDistribution}
-          onPriceChange={(min, max) => {
-            setMinPrice(min);
-            setMaxPrice(max);
-          }}
-          onApply={() =>
-            onFilterApply({
-              sort,
-              minPrice,
-              maxPrice,
-            })
-          }
-          onClear={() => {
-            setSort('');
-            setMinPrice(initialMinPrice);
-            setMaxPrice(initialMaxPrice);
-            onFilterClear();
-          }}
+          onApply={onFilterApply}
+          onClear={onFilterClear}
         />
       </>
     );
@@ -152,28 +125,12 @@ export default function ArtistsPageHeader({
       <FilterSheet
         open={filterOpen}
         onClose={() => setFilterOpen(false)}
-        sort={sort}
-        onSort={(e) => setSort(e.target.value)}
-        minPrice={minPrice}
-        maxPrice={maxPrice}
+        initialSort={initialSort}
+        initialMinPrice={initialMinPrice}
+        initialMaxPrice={initialMaxPrice}
         priceDistribution={priceDistribution}
-        onPriceChange={(min, max) => {
-          setMinPrice(min);
-          setMaxPrice(max);
-        }}
-        onApply={() =>
-          onFilterApply({
-            sort,
-            minPrice,
-            maxPrice,
-          })
-        }
-        onClear={() => {
-          setSort('');
-          setMinPrice(initialMinPrice);
-          setMaxPrice(initialMaxPrice);
-          onFilterClear();
-        }}
+        onApply={onFilterApply}
+        onClear={onFilterClear}
       />
     </>
   );

--- a/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistsPageHeader.test.tsx
@@ -22,6 +22,7 @@ describe('ArtistsPageHeader iconOnly', () => {
           iconOnly
           initialMinPrice={0}
           initialMaxPrice={100}
+          priceDistribution={[]}
           onFilterApply={jest.fn()}
           onFilterClear={jest.fn()}
           onSearchEdit={jest.fn()}

--- a/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
@@ -11,27 +11,25 @@ describe('FilterSheet sliders', () => {
     jest.clearAllMocks();
   });
 
-  it('calls onPriceChange when sliders move', () => {
+  it('applies updated prices', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const modalRoot = document.createElement('div');
     modalRoot.id = 'modal-root';
     document.body.appendChild(modalRoot);
     const root = createRoot(container);
-    const onPriceChange = jest.fn();
+    const onApply = jest.fn();
 
     act(() => {
       root.render(
         <FilterSheet
           open
           onClose={jest.fn()}
-          sort=""
-          onSort={jest.fn()}
+          initialSort=""
+          initialMinPrice={0}
+          initialMaxPrice={100}
+          onApply={onApply}
           onClear={jest.fn()}
-          onApply={jest.fn()}
-          minPrice={0}
-          maxPrice={100}
-          onPriceChange={onPriceChange}
           priceDistribution={[]}
         />,
       );
@@ -45,13 +43,18 @@ describe('FilterSheet sliders', () => {
       minInput.value = '20';
       minInput.dispatchEvent(new Event('input', { bubbles: true }));
     });
-    expect(onPriceChange).toHaveBeenCalledWith(20, 100);
 
     act(() => {
       maxInput.value = '80';
       maxInput.dispatchEvent(new Event('input', { bubbles: true }));
     });
-    expect(onPriceChange).toHaveBeenLastCalledWith(20, 80);
+
+    const applyButton = modalRoot.querySelector('button.bg-brand') as HTMLButtonElement;
+    act(() => {
+      applyButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onApply).toHaveBeenCalledWith({ sort: undefined, minPrice: 20, maxPrice: 80 });
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- refactor FilterSheet to manage its own state and emit values on apply
- update ArtistsPageHeader to pass initial filter values
- adjust tests for new FilterSheet API
- document FilterSheet behaviour in README

## Testing
- `npm install` *(fails: Maximum call stack size exceeded during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68833336a730832e939188cdaa435b22