### PR TITLE
Improve range slider styling

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -73,10 +73,20 @@ html[data-headlessui-focus-visible] {
   padding-right: 0 !important;
 }
 
+.custom-range-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 1.5rem; /* larger click target */
+  background: transparent;
+}
+
 .custom-range-thumb::-webkit-slider-runnable-track {
   -webkit-appearance: none;
-  height: 0.5rem;
+  height: 2px;
+  background: transparent;
 }
+
 .custom-range-thumb::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
@@ -87,11 +97,18 @@ html[data-headlessui-focus-visible] {
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   cursor: grab;
-  margin-top: -4px;
+  margin-top: -7px; /* center on 2px track */
 }
+
 .custom-range-thumb:active::-webkit-slider-thumb {
   cursor: grabbing;
 }
+
+.custom-range-thumb::-moz-range-track {
+  height: 2px;
+  background: transparent;
+}
+
 .custom-range-thumb::-moz-range-thumb {
   width: 16px;
   height: 16px;
@@ -100,11 +117,31 @@ html[data-headlessui-focus-visible] {
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   cursor: grab;
+  margin-top: -7px;
 }
-.custom-range-thumb::-moz-range-track {
-  height: 0.5rem;
-  background: transparent;
-}
+
 .custom-range-thumb:active::-moz-range-thumb {
+  cursor: grabbing;
+}
+
+.custom-range-thumb::-ms-track {
+  height: 2px;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+
+.custom-range-thumb::-ms-thumb {
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border: 2px solid #d1d5db;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  cursor: grab;
+  margin-top: -7px;
+}
+
+.custom-range-thumb:active::-ms-thumb {
   cursor: grabbing;
 }


### PR DESCRIPTION
## Summary
- style slider thumbs to sit on a 2px track
- enlarge the thumb hit area and add vendor-prefixed rules

## Testing
- `./scripts/test-all.sh` *(fails: could not fetch `origin/main`)*

------
https://chatgpt.com/codex/tasks/task_e_68833cb23350832e96f5e0b51f4df24a