### PR TITLE
Integrate price distribution into artist listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,13 +942,13 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 `GET /api/v1/artist-profiles/` supports pagination and optional filters:
 
 ```
-page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&includePriceDistribution=<true|false>
+page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&include_price_distribution=<true|false>
 ```
 
 `minPrice` and `maxPrice` filter by the prices of services in the selected
 `category`. If no category is provided, the range applies to any service the
 artist offers. Additional service categories are supported automatically without
-code changes. Pass `includePriceDistribution=true` to return histogram data for
+code changes. Pass `include_price_distribution=true` to return histogram data for
 the filter modal.
 
 Profiles include `rating`, `rating_count`, and `is_available` fields. A new

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -56,8 +56,8 @@ export default function ArtistsPage() {
   );
   const [priceDistribution, setPriceDistribution] = useState<PriceBucket[]>([]);
 
-  const debouncedMinPrice = useDebounce(minPrice, 500);
-  const debouncedMaxPrice = useDebounce(maxPrice, 500);
+  const debouncedMinPrice = useDebounce(minPrice, 300);
+  const debouncedMaxPrice = useDebounce(maxPrice, 300);
 
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -156,7 +156,7 @@ export default function FilterSheet({
               <div
                 key={index}
                 className="bg-gray-300 w-1 rounded-t-sm"
-                style={{ height: `${(bucket.count / (maxCount || 1)) * 70}%` }}
+                style={{ height: `${(bucket.count / (maxCount || 1)) * 60}%` }}
               />
             ))}
           </div>

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -270,3 +270,18 @@ describe('review helpers', () => {
     spy.mockRestore();
   });
 });
+
+describe('getArtists', () => {
+  it('passes include_price_distribution param when requested', async () => {
+    const spy = jest
+      .spyOn(api, 'get')
+      .mockResolvedValue({
+        data: { data: [], total: 0, price_distribution: [] },
+      } as unknown as { data: unknown });
+    await getArtists({ includePriceDistribution: true, page: 2 });
+    expect(spy).toHaveBeenCalledWith('/api/v1/artist-profiles/', {
+      params: { page: 2, include_price_distribution: true },
+    });
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -156,8 +156,14 @@ export const getArtists = async (params?: {
   limit?: number;
   includePriceDistribution?: boolean;
 }): Promise<GetArtistsResponse> => {
+  const { includePriceDistribution, ...rest } = params || {};
+  const query = { ...rest } as Record<string, unknown>;
+  if (includePriceDistribution) {
+    query.include_price_distribution = true;
+  }
+
   const res = await api.get<GetArtistsResponse>(`${API_V1}/artist-profiles/`, {
-    params,
+    params: query,
   });
   return {
     ...res.data,


### PR DESCRIPTION
## Summary
- expose `include_price_distribution` query flag in the artists API helper
- debounce price range by 300ms and store histogram data in artists page
- document new query parameter in the README
- test API helper adds the flag when requested
- scale histogram bars to 60% height

## Testing
- `./scripts/test-all.sh` *(failed: repository has no `origin` remote)*
- ❌ `git fetch origin main` *(fails: repository not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68833f952aec832e8c6c3c76586d74c5