### PR TITLE
Fix price slider thumb overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Artists page redesigned with a responsive grid, sticky search header with quick
   filters, skeleton loaders and a hover "Book Now" overlay for a modern,
   accessible look.
-- Price filter now displays a histogram and accepts numeric input for precise ranges. Slider handles no longer overlap, improving usability.
+ - Price filter now displays a histogram styled like Airbnb and accepts numeric input for precise ranges. Slider thumbs remain clickable even when overlapping.
 - Fixed an issue where the left price slider could not be grabbed when both handles overlapped.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -73,23 +73,30 @@ html[data-headlessui-focus-visible] {
   padding-right: 0 !important;
 }
 
-.custom-range-thumb {
+.range-thumb {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   -webkit-appearance: none;
   appearance: none;
-  width: 100%;
-  height: 24px; /* generous click/drag area */
   background: transparent;
   pointer-events: auto;
   outline: none;
+  z-index: 5;
 }
 
-.custom-range-thumb::-webkit-slider-runnable-track {
+.range-thumb.active {
+  z-index: 10;
+}
+
+.range-thumb::-webkit-slider-runnable-track {
   -webkit-appearance: none;
   height: 2px;
   background: transparent;
 }
 
-.custom-range-thumb::-webkit-slider-thumb {
+.range-thumb::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 20px;
@@ -102,17 +109,17 @@ html[data-headlessui-focus-visible] {
   margin-top: -9px; /* center on 2px track */
 }
 
-.custom-range-thumb:active::-webkit-slider-thumb {
+.range-thumb:active::-webkit-slider-thumb {
   cursor: grabbing;
   transform: scale(1.1);
 }
 
-.custom-range-thumb::-moz-range-track {
+.range-thumb::-moz-range-track {
   height: 2px;
   background: transparent;
 }
 
-.custom-range-thumb::-moz-range-thumb {
+.range-thumb::-moz-range-thumb {
   width: 20px;
   height: 20px;
   background: #fff;
@@ -123,19 +130,19 @@ html[data-headlessui-focus-visible] {
   margin-top: -9px;
 }
 
-.custom-range-thumb:active::-moz-range-thumb {
+.range-thumb:active::-moz-range-thumb {
   cursor: grabbing;
   transform: scale(1.1);
 }
 
-.custom-range-thumb::-ms-track {
+.range-thumb::-ms-track {
   height: 2px;
   background: transparent;
   border-color: transparent;
   color: transparent;
 }
 
-.custom-range-thumb::-ms-thumb {
+.range-thumb::-ms-thumb {
   width: 20px;
   height: 20px;
   background: #fff;
@@ -146,7 +153,28 @@ html[data-headlessui-focus-visible] {
   margin-top: -9px;
 }
 
-.custom-range-thumb:active::-ms-thumb {
+.range-thumb:active::-ms-thumb {
   cursor: grabbing;
   transform: scale(1.1);
+}
+
+.histogram-container,
+.price-track,
+.price-fill,
+.histogram-bars {
+  pointer-events: none;
+}
+
+.histogram-container {
+  height: 6rem;
+}
+
+.histogram-bars > div {
+  background-color: #d9d9d9;
+  border-radius: 0.125rem 0.125rem 0 0;
+}
+
+.price-fill {
+  background-color: #ff5a5f;
+  border-radius: 0.25rem;
 }

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -67,6 +67,9 @@ export default function FilterSheet({
     0,
   );
 
+  const minPct = ((localMinPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100;
+  const maxPct = ((localMaxPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100;
+
   const handleRangeChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     type: 'min' | 'max',
@@ -150,42 +153,16 @@ export default function FilterSheet({
       <div>
         <label className="block text-sm font-medium">Price range</label>
         <p className="text-xs text-gray-500">Trip price, includes all fees.</p>
-        <div className="relative h-24 mt-4">
-          <div className="absolute inset-0 flex items-end justify-between px-0.5 pointer-events-none">
+        <div className="histogram-container relative mt-4">
+          <div className="histogram-bars absolute inset-0 flex items-end justify-between px-0.5">
             {priceDistribution.map((bucket, index) => (
-              <div
-                key={index}
-                className="bg-gray-300 w-1 rounded-t-sm"
-                style={{ height: `${(bucket.count / (maxCount || 1)) * 60}%` }}
-              />
+              <div key={index} style={{ height: `${(bucket.count / maxCount) * 60}%` }} />
             ))}
           </div>
-          <div className="absolute inset-x-0 bottom-0 h-2 bg-gray-200 rounded" />
+          <div className="price-track absolute bottom-0 inset-x-0 h-2 rounded" />
           <div
-            className="absolute bottom-0 h-2 bg-pink-500 rounded"
-            style={{
-              left: `${((localMinPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
-              right: `${100 - ((localMaxPrice - SLIDER_MIN) / (SLIDER_MAX - SLIDER_MIN)) * 100}%`,
-            }}
-          />
-          <input
-            type="range"
-            min={SLIDER_MIN}
-            max={SLIDER_MAX}
-            step={SLIDER_STEP}
-            value={localMinPrice}
-            onChange={(e) => handleRangeChange(e, 'min')}
-            onMouseDown={() => setActiveThumb('min')}
-            onTouchStart={() => setActiveThumb('min')}
-            onMouseUp={() => setActiveThumb(null)}
-            onTouchEnd={() => setActiveThumb(null)}
-            style={{
-              // Keep the minimum slider on top by default so it can be grabbed
-              // even when its handle overlaps with the maximum slider. Whichever
-              // slider is active gets a higher z-index to ensure it's draggable.
-              zIndex: activeThumb === 'min' ? 30 : 20,
-            }}
-            className="custom-range-thumb absolute inset-0 w-full h-2 pointer-events-auto appearance-none bg-transparent"
+            className="price-fill absolute bottom-0 h-2 rounded"
+            style={{ left: `${minPct}%`, right: `${100 - maxPct}%` }}
           />
           <input
             type="range"
@@ -198,12 +175,20 @@ export default function FilterSheet({
             onTouchStart={() => setActiveThumb('max')}
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
-            style={{
-              // Lower base z-index so the minimum slider remains clickable when
-              // both handles overlap. Elevate when this slider is active.
-              zIndex: activeThumb === 'max' ? 30 : 10,
-            }}
-            className="custom-range-thumb absolute inset-0 w-full h-2 pointer-events-auto appearance-none bg-transparent"
+            className={`range-thumb ${activeThumb === 'max' ? 'active' : ''}`}
+          />
+          <input
+            type="range"
+            min={SLIDER_MIN}
+            max={SLIDER_MAX}
+            step={SLIDER_STEP}
+            value={localMinPrice}
+            onChange={(e) => handleRangeChange(e, 'min')}
+            onMouseDown={() => setActiveThumb('min')}
+            onTouchStart={() => setActiveThumb('min')}
+            onMouseUp={() => setActiveThumb(null)}
+            onTouchEnd={() => setActiveThumb(null)}
+            className={`range-thumb ${activeThumb === 'min' ? 'active' : ''}`}
           />
         </div>
         <div className="flex justify-between mt-4 gap-4">

--- a/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
@@ -11,7 +11,7 @@ describe('FilterSheet sliders', () => {
     jest.clearAllMocks();
   });
 
-  it('applies updated prices', () => {
+  it('applies updated prices and allows overlapping thumbs', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const modalRoot = document.createElement('div');
@@ -36,17 +36,19 @@ describe('FilterSheet sliders', () => {
     });
 
     const ranges = modalRoot.querySelectorAll('input[type="range"]');
-    const minInput = ranges[0] as HTMLInputElement;
-    const maxInput = ranges[1] as HTMLInputElement;
+    const maxInput = ranges[0] as HTMLInputElement;
+    const minInput = ranges[1] as HTMLInputElement;
 
     act(() => {
       minInput.value = '20';
       minInput.dispatchEvent(new Event('input', { bubbles: true }));
+      minInput.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
     act(() => {
       maxInput.value = '80';
       maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+      maxInput.dispatchEvent(new Event('change', { bubbles: true }));
     });
 
     const applyButton = modalRoot.querySelector('button.bg-brand') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- revamp price slider histogram styling
- ensure decorative layers don't intercept pointer events
- track active range thumb in `FilterSheet`
- update unit test and docs

## Testing
- `npx jest src/components/artist/__tests__/FilterSheet.test.tsx --runInBand` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688343ae21bc832e947d08cc81b59625