### PR TITLE
Fix overlapping slider click zone

### DIFF
--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -187,7 +187,7 @@ export default function FilterSheet({
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
             className="absolute inset-0 w-full h-full appearance-none bg-transparent pointer-events-auto"
-            style={{ zIndex: activeThumb === 'min' ? 30 : 20 }}
+            style={{ zIndex: activeThumb === 'min' ? 30 : 10 }}
           />
 
           {/* Max thumb */}
@@ -203,7 +203,7 @@ export default function FilterSheet({
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
             className="absolute inset-0 w-full h-full appearance-none bg-transparent pointer-events-auto"
-            style={{ zIndex: activeThumb === 'max' ? 30 : 10 }}
+            style={{ zIndex: activeThumb === 'max' ? 30 : 20 }}
           />
         </div>
         <div className="flex justify-between mt-4 gap-4">

--- a/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
@@ -62,4 +62,51 @@ describe('FilterSheet sliders', () => {
     container.remove();
     modalRoot.remove();
   });
+
+  it('sets correct z-index stacking order for thumbs', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const modalRoot = document.createElement('div');
+    modalRoot.id = 'modal-root';
+    document.body.appendChild(modalRoot);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <FilterSheet
+          open
+          onClose={jest.fn()}
+          initialSort=""
+          initialMinPrice={0}
+          initialMaxPrice={100}
+          onApply={jest.fn()}
+          onClear={jest.fn()}
+          priceDistribution={[]}
+        />,
+      );
+    });
+
+    const ranges = modalRoot.querySelectorAll('input[type="range"]');
+    const minInput = ranges[0] as HTMLInputElement;
+    const maxInput = ranges[1] as HTMLInputElement;
+
+    expect(minInput.style.zIndex).toBe('10');
+    expect(maxInput.style.zIndex).toBe('20');
+
+    act(() => {
+      minInput.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(minInput.style.zIndex).toBe('30');
+    expect(maxInput.style.zIndex).toBe('20');
+
+    act(() => {
+      maxInput.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(minInput.style.zIndex).toBe('10');
+    expect(maxInput.style.zIndex).toBe('30');
+
+    act(() => root.unmount());
+    container.remove();
+    modalRoot.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure max slider sits above min by default
- test z-index stacking order for overlapping thumbs

## Testing
- `./scripts/test-all.sh` *(fails: 26 failed, 1 skipped, 58 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688352433da4832e9aab33a90b80e3c5