### PR TITLE
Fix overlapping price sliders

### DIFF
--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -191,7 +191,10 @@ export default function FilterSheet({
             onMouseUp={() => setActiveThumb(null)}
             onTouchEnd={() => setActiveThumb(null)}
             className="absolute inset-0 w-full h-full appearance-none bg-transparent pointer-events-auto"
-            style={{ zIndex: activeThumb === 'min' ? 30 : 10 }}
+            style={{
+              zIndex:
+                activeThumb === 'min' || localMinPrice === localMaxPrice ? 30 : 10,
+            }}
           />
 
           {/* Max thumb */}

--- a/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
+++ b/frontend/src/components/artist/__tests__/FilterSheet.test.tsx
@@ -99,6 +99,17 @@ describe('FilterSheet sliders', () => {
     expect(minInput.style.zIndex).toBe('30');
     expect(maxInput.style.zIndex).toBe('20');
 
+    // when thumbs overlap the min thumb should be on top
+    act(() => {
+      minInput.value = '50';
+      maxInput.value = '50';
+      minInput.dispatchEvent(new Event('input', { bubbles: true }));
+      minInput.dispatchEvent(new Event('change', { bubbles: true }));
+      maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+      maxInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(minInput.style.zIndex).toBe('30');
+
     act(() => {
       maxInput.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     });


### PR DESCRIPTION
## Summary
- ensure min slider can be grabbed when overlapped
- cover overlapping thumbs in FilterSheet tests

## Testing
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: git fetch origin main)*

------
https://chatgpt.com/codex/tasks/task_e_6883567cccfc832ea26f9ff6f7e99eb5