### PR TITLE
Fix when date handling in artist search

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,13 @@ page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<to
 &when=<YYYY-MM-DD>
 ```
 
+When building query strings in JavaScript, format dates as pure `YYYY-MM-DD`
+values to avoid validation errors:
+
+```javascript
+params.set('when', date.toISOString().split('T')[0]);
+```
+
 `minPrice` and `maxPrice` filter by the prices of services in the selected
 `category`. If no category is provided, the range applies to any service the
 artist offers. Additional service categories are supported automatically without

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -284,4 +284,17 @@ describe('getArtists', () => {
     });
     spy.mockRestore();
   });
+
+  it('forwards the when parameter', async () => {
+    const spy = jest
+      .spyOn(api, 'get')
+      .mockResolvedValue({
+        data: { data: [], total: 0, price_distribution: [] },
+      } as unknown as { data: unknown });
+    await getArtists({ when: '2025-07-25' });
+    expect(spy).toHaveBeenCalledWith('/api/v1/artist-profiles/', {
+      params: { when: '2025-07-25' },
+    });
+    spy.mockRestore();
+  });
 });

--- a/frontend/src/lib/__tests__/urlParams.test.ts
+++ b/frontend/src/lib/__tests__/urlParams.test.ts
@@ -1,0 +1,15 @@
+import { updateQueryParams, type RouterLike } from '../urlParams';
+
+const router: RouterLike = { push: jest.fn() };
+
+afterEach(() => {
+  (router.push as jest.Mock).mockClear();
+});
+
+describe('updateQueryParams', () => {
+  it('formats Date objects as YYYY-MM-DD', () => {
+    const d = new Date('2025-07-25T22:00:00.000Z');
+    updateQueryParams(router, '/artists', { when: d });
+    expect(router.push).toHaveBeenCalledWith('/artists?when=2025-07-25');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -149,6 +149,7 @@ export interface GetArtistsResponse {
 export const getArtists = async (params?: {
   category?: string;
   location?: string;
+  when?: string;
   sort?: string;
   minPrice?: number;
   maxPrice?: number;

--- a/frontend/src/lib/urlParams.ts
+++ b/frontend/src/lib/urlParams.ts
@@ -20,7 +20,8 @@ export function updateQueryParams(
   const search = new URLSearchParams();
   if (params.category) search.set('category', params.category);
   if (params.location) search.set('location', params.location);
-  if (params.when) search.set('when', params.when.toISOString());
+  if (params.when)
+    search.set('when', params.when.toISOString().split('T')[0]);
   if (params.sort) search.set('sort', params.sort);
   if (params.minPrice != null && params.minPrice > SLIDER_MIN) search.set('minPrice', String(params.minPrice));
   if (params.maxPrice != null && params.maxPrice < SLIDER_MAX) search.set('maxPrice', String(params.maxPrice));


### PR DESCRIPTION
## Summary
- include `when` parameter in `getArtists`
- format `when` dates as `YYYY-MM-DD` in `updateQueryParams`
- document date formatting requirement
- test `updateQueryParams` and `getArtists` date handling

## Testing
- `./scripts/test-all.sh` *(fails: TypeError in `test_unavailable_dates_include_calendar`)*

------
https://chatgpt.com/codex/tasks/task_e_688383635a98832eb0601bf2f2643586