### PR TITLE
Fix date-time filters for artist listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,15 +945,11 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 
 ```
 page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&include_price_distribution=<true|false>
-&when=<YYYY-MM-DD>
+&when=<YYYY-MM-DD-or-ISO-datetime>
 ```
 
-When building query strings in JavaScript, format dates as pure `YYYY-MM-DD`
-values to avoid validation errors:
-
-```javascript
-params.set('when', date.toISOString().split('T')[0]);
-```
+`when` can be either a plain date (`YYYY-MM-DD`) or a full ISO 8601 datetime.
+Any time component will be ignored by the API when checking availability.
 
 `minPrice` and `maxPrice` filter by the prices of services in the selected
 `category`. If no category is provided, the range applies to any service the

--- a/backend/app/api/v1/api_artist.py
+++ b/backend/app/api/v1/api_artist.py
@@ -400,14 +400,19 @@ def read_all_artist_profiles(
     category: Optional[ServiceType] = Query(None),
     location: Optional[str] = Query(None),
     sort: Optional[str] = Query(None, pattern="^(top_rated|most_booked|newest)$"),
-    when: Optional[date] = Query(None),
+    when: Optional[datetime] = Query(None),
     min_price: Optional[float] = Query(None, alias="minPrice", ge=0),
     max_price: Optional[float] = Query(None, alias="maxPrice", ge=0),
     page: int = Query(1, ge=1),
     limit: int = Query(20, ge=1, le=100),
     include_price_distribution: bool = Query(False, alias="include_price_distribution"),
 ):
-    """Return a list of all artist profiles with optional filters."""
+    """Return a list of all artist profiles with optional filters.
+
+    The ``when`` query parameter accepts either a plain ``YYYY-MM-DD`` date or
+    a full ISO 8601 datetime. Any supplied time component is ignored when
+    checking availability.
+    """
 
     # FastAPI's Query objects appear when this function is called directly in tests.
     # Normalize them to plain values for compatibility.
@@ -426,9 +431,11 @@ def read_all_artist_profiles(
     if hasattr(when, "default"):
         when = None
 
+    when_date = when.date() if isinstance(when, datetime) else None
+
     cache_category = category.value if isinstance(category, ServiceType) else category
     cached = None
-    if not include_price_distribution and when is None:
+    if not include_price_distribution and when_date is None:
         cached = get_cached_artist_list(
             page=page,
             limit=limit,
@@ -557,20 +564,20 @@ def read_all_artist_profiles(
         )
         availability = read_artist_availability(
             artist.user_id,
-            when=when,
+            when=when_date,
             db=db,
         )
-        if when:
-            profile.is_available = when.isoformat() not in availability["unavailable_dates"]
+        if when_date:
+            profile.is_available = when_date.isoformat() not in availability["unavailable_dates"]
         else:
             profile.is_available = len(availability["unavailable_dates"]) == 0
         profiles.append(profile)
 
-    if when:
+    if when_date:
         profiles = [p for p in profiles if p.is_available]
         total_count = len(profiles)
 
-    if not include_price_distribution and when is None:
+    if not include_price_distribution and when_date is None:
         cache_artist_list(
             [
                 {**profile.model_dump(), "user_id": profile.user_id}
@@ -602,10 +609,16 @@ def read_artist_profile_by_id(artist_id: int, db: Session = Depends(get_db)):
 @router.get("/{artist_id}/availability", response_model=ArtistAvailabilityResponse)
 def read_artist_availability(
     artist_id: int,
-    when: Optional[date] = Query(None),
+    when: Optional[datetime] = Query(None),
     db: Session = Depends(get_db),
 ):
-    """Return dates the artist is unavailable."""
+    """Return dates the artist is unavailable.
+
+    ``when`` may be a full ISO 8601 datetime. Any provided time component is
+    ignored when matching bookings and calendar events.
+    """
+    when_date = when.date() if isinstance(when, datetime) else None
+
     bookings_query = (
         db.query(Booking)
         .filter(
@@ -613,8 +626,8 @@ def read_artist_availability(
             Booking.status.in_([BookingStatus.PENDING, BookingStatus.CONFIRMED]),
         )
     )
-    if when:
-        day_start = datetime.combine(when, datetime.min.time())
+    if when_date:
+        day_start = datetime.combine(when_date, datetime.min.time())
         day_end = day_start + timedelta(days=1)
         bookings_query = bookings_query.filter(
             Booking.start_time >= day_start, Booking.start_time < day_end
@@ -628,7 +641,7 @@ def read_artist_availability(
             BookingRequest.status != BookingRequestStatus.REQUEST_DECLINED,
         )
     )
-    if when:
+    if when_date:
         requests_query = requests_query.filter(
             (
                 (BookingRequest.proposed_datetime_1 >= day_start)
@@ -650,8 +663,8 @@ def read_artist_availability(
         if r.proposed_datetime_2:
             dates.add(r.proposed_datetime_2.date().isoformat())
 
-    if when:
-        start = datetime.combine(when, datetime.min.time())
+    if when_date:
+        start = datetime.combine(when_date, datetime.min.time())
         end = start + timedelta(days=1)
     else:
         start = datetime.utcnow()

--- a/backend/tests/test_artist_endpoint.py
+++ b/backend/tests/test_artist_endpoint.py
@@ -56,3 +56,27 @@ def test_artist_profiles_endpoint_returns_paginated(monkeypatch):
     assert body["data"][0]["business_name"] == "Test Artist"
     assert isinstance(body["price_distribution"], list)
     app.dependency_overrides.pop(get_db, None)
+
+
+def test_artist_profiles_accepts_datetime(monkeypatch):
+    """Endpoint should parse ISO datetimes for the 'when' query parameter."""
+    Session = setup_app(monkeypatch)
+    db = Session()
+    user = User(
+        email="b@test.com",
+        password="x",
+        first_name="B",
+        last_name="C",
+        user_type=UserType.ARTIST,
+    )
+    profile = ArtistProfileV2(user_id=1, business_name="Time Test")
+    db.add(user)
+    db.add(profile)
+    db.commit()
+    client = TestClient(app)
+    res = client.get(
+        "/api/v1/artist-profiles/",
+        params={"when": "2025-08-29T22:00:00.000Z"},
+    )
+    assert res.status_code == 200
+    app.dependency_overrides.pop(get_db, None)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -786,7 +786,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"
@@ -955,7 +955,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "format": "date"
+                  "format": "date-time"
                 },
                 {
                   "type": "null"


### PR DESCRIPTION
## Summary
- allow `when` parameter to accept datetimes for artist listings and availability
- document the new behaviour in README and OpenAPI docs
- add regression test for datetime filter

## Testing
- `PYTHONPATH=backend backend/venv/bin/pytest backend/tests/test_artist_endpoint.py -k accepts_datetime -q`

------
https://chatgpt.com/codex/tasks/task_e_688389c319dc832ea44a9e67fd838faf