### PR TITLE
Add sticky mobile stepper

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Collapsible sections ensure only the active step is expanded on phones.
 * Mobile devices use native date and time pickers for faster input.
 * Each step appears in a white card with rounded corners and a subtle shadow.
-* The progress bar sticks below the header so progress is always visible while scrolling.
+* The progress bar now stays pinned just below the header on phones so progress remains visible while scrolling through each step.
 * Venue picker uses a reusable `<BottomSheet>` component on small screens to
   avoid keyboard overlap. The sheet traps focus for accessibility and closes when
   you press `Escape` or tap outside.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -316,13 +316,26 @@ export default function BookingWizard({
 
   return (
     <div className="px-4 py-16">
-      <div className="sticky top-0 z-10 bg-white">
+      <div
+        className="sticky z-20 bg-white"
+        style={{ top: isMobile ? '4rem' : 0 }}
+        data-testid="progress-container"
+      >
         <Stepper
           steps={steps}
           currentStep={step}
           maxStepCompleted={maxStepCompleted}
           onStepClick={handleStepClick}
+          ariaLabel={`Progress: step ${step + 1} of ${steps.length}`}
         />
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+          data-testid="progress-status"
+        >
+          {`Step ${step + 1} of ${steps.length}`}
+        </div>
       </div>
       {isMobile ? (
         <div className="space-y-4">

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -159,8 +159,21 @@ describe('BookingWizard flow', () => {
   });
 
   it('renders a sticky progress indicator', () => {
-    const wrapper = container.querySelector('[aria-label="Progress"]')?.parentElement;
+    const wrapper = container.querySelector('[data-testid="progress-container"]') as HTMLDivElement | null;
     expect(wrapper?.className).toContain('sticky');
+    expect(wrapper?.style.top).toBe('4rem');
+  });
+
+  it('announces progress updates for screen readers', async () => {
+    const progress = () =>
+      container.querySelector('[data-testid="progress-status"]')?.textContent;
+    expect(progress()).toBe('Step 1 of 7');
+    const next = getButton('Next');
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushPromises();
+    expect(progress()).toBe('Step 2 of 7');
   });
 
   it('disables dates returned from Google Calendar', async () => {

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -7,6 +7,7 @@ interface StepperProps {
   currentStep: number;
   maxStepCompleted?: number;
   onStepClick?: (index: number) => void;
+  ariaLabel?: string;
 }
 
 export default function Stepper({
@@ -14,6 +15,7 @@ export default function Stepper({
   currentStep,
   maxStepCompleted,
   onStepClick,
+  ariaLabel,
 }: StepperProps) {
   const maxStep =
     typeof maxStepCompleted === 'number' ? maxStepCompleted : currentStep;
@@ -21,7 +23,7 @@ export default function Stepper({
     <motion.div
       layout
       role="list"
-      aria-label="Progress"
+      aria-label={ariaLabel || 'Progress'}
       className="relative flex items-center justify-between px-2 mb-8"
     >
       <motion.div

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -32,6 +32,14 @@ describe('Stepper progress bar', () => {
     expect(items[0].getAttribute('aria-disabled')).toBe('true');
   });
 
+  it('uses custom aria-label when provided', () => {
+    act(() => {
+      root.render(<Stepper steps={["One", "Two"]} currentStep={0} ariaLabel="Booking progress" />);
+    });
+    const wrapper = container.querySelector('div[role="list"]');
+    expect(wrapper?.getAttribute('aria-label')).toBe('Booking progress');
+  });
+
   it('calls onStepClick when clicking completed steps', () => {
     const clickSpy = jest.fn();
     act(() => {


### PR DESCRIPTION
## Summary
- keep the booking stepper visible on mobile using a sticky container
- announce progress updates for screen readers
- expose ariaLabel in Stepper component
- update unit tests for BookingWizard and Stepper
- document new behaviour in README

## Testing
- `npm ci`
- `npm test BookingWizard.test.tsx Stepper.test.tsx -- --maxWorkers=50%` *(fails: shows numerous failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68847cd203d4832e8404602a51316dde