### PR TITLE
Fix date serialization bug in booking context

### DIFF
--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -94,7 +94,7 @@ export const BookingProvider = ({ children }: { children: ReactNode }) => {
     if (typeof window === 'undefined') return;
     const data = {
       step,
-      details: { ...details, date: details.date.toISOString() },
+      details: { ...details, date: new Date(details.date).toISOString() },
       serviceId,
       requestId,
     };


### PR DESCRIPTION
## Summary
- fix serialization of booking date when persisting booking progress

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: snapshots and test failures)*
- `scripts/test-backend.sh` *(installation started but aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68847ee0f174832e8ac5cd0ada17fd8f