### PR TITLE
Fix location autocomplete in booking wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ cover photos load without 400 errors from the `/_next/image` endpoint.
 The `next.config.js` file now explicitly includes `/static/cover_photos/**`
 alongside `/static/profile_pics/**` in its `remotePatterns` list.
 
-The location input now uses the `<gmpx-place-autocomplete>` web component from
-the `@googlemaps/places` package. **Remember to provide an `<input slot="input">`
-inside the element.** All styling classes belong on this input, not the wrapper.
-The Google Maps script loads lazily via the `loadPlaces()` helper so it is only
-injected once and avoids the "API included multiple times" warning.
+The location input now reuses the `LocationInput` component powered by the
+`react-google-autocomplete` package. It matches the styling and behaviour of the
+homepage and artist page search bars. The Google Maps script still loads lazily
+via the `loadPlaces()` helper so it is only injected once and avoids the "API
+included multiple times" warning.
 
 The previous built-in autocomplete is deprecated. The location picker still
 opens a minimalist modal when the **Map** button is clicked. The modal contains

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -4,6 +4,7 @@
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import dynamic from 'next/dynamic';
 import { loadPlaces } from '@/lib/loadPlaces';
+import LocationInput from '../../ui/LocationInput';
 const GoogleMap = dynamic(
   () => import('@react-google-maps/api').then((m) => m.GoogleMap),
   { ssr: false },
@@ -64,54 +65,6 @@ function GoogleMapsLoader({
   return children(loaded);
 }
 
-interface AutocompleteProps {
-  value: string | undefined;
-  onChange: (v: string) => void;
-  onSelect: (loc: LatLng) => void;
-}
-
-function AutocompleteInput({ value, onChange, onSelect }: AutocompleteProps) {
-  const autoRef = useRef<Element | null>(null);
-
-  useEffect(() => {
-    const el = autoRef.current as HTMLElement | null;
-    if (!el) return;
-    function handleChange(e: Event) {
-      const place = (e as any).detail?.place;
-      if (place?.geometry?.location) {
-        onSelect({
-          lat: place.geometry.location.lat(),
-          lng: place.geometry.location.lng(),
-        });
-      }
-      if (place?.formatted_address) onChange(place.formatted_address);
-    }
-    el.addEventListener('placechange', handleChange);
-    el.addEventListener('gmpx-placechange', handleChange);
-    return () => {
-      el.removeEventListener('placechange', handleChange);
-      el.removeEventListener('gmpx-placechange', handleChange);
-    };
-  }, [onChange, onSelect]);
-
-  useEffect(() => {
-    if (autoRef.current) {
-      // @ts-ignore - value is writable on the web component
-      (autoRef.current as any).value = value ?? '';
-    }
-  }, [value]);
-
-  return (
-    <gmpx-place-autocomplete ref={autoRef} data-testid="autocomplete-input">
-      <input
-        slot="input"
-        type="text"
-        placeholder="Search address"
-        className="block w-full rounded-md border border-gray-300 focus:border-brand focus:ring-brand sm:text-sm p-2"
-      />
-    </gmpx-place-autocomplete>
-  );
-}
 
 export default function LocationStep({
   control,
@@ -182,10 +135,19 @@ export default function LocationStep({
                   name="location"
                   control={control}
                   render={({ field }) => (
-                    <AutocompleteInput
-                      value={field.value}
-                      onChange={field.onChange}
-                      onSelect={(loc) => setMarker(loc)}
+                    <LocationInput
+                      value={field.value ?? ''}
+                      onValueChange={field.onChange}
+                      onPlaceSelect={(place) => {
+                        if (place.geometry?.location) {
+                          setMarker({
+                            lat: place.geometry.location.lat(),
+                            lng: place.geometry.location.lng(),
+                          });
+                        }
+                      }}
+                      placeholder="Search address"
+                      className="block w-full rounded-md border border-gray-300 focus-within:border-brand focus-within:ring-brand sm:text-sm p-2"
                     />
                   )}
                 />
@@ -204,10 +166,19 @@ export default function LocationStep({
               name="location"
               control={control}
               render={({ field }) => (
-                <AutocompleteInput
-                  value={field.value}
-                  onChange={field.onChange}
-                  onSelect={(loc) => setMarker(loc)}
+                <LocationInput
+                  value={field.value ?? ''}
+                  onValueChange={field.onChange}
+                  onPlaceSelect={(place) => {
+                    if (place.geometry?.location) {
+                      setMarker({
+                        lat: place.geometry.location.lat(),
+                        lng: place.geometry.location.lng(),
+                      });
+                    }
+                  }}
+                  placeholder="Search address"
+                  className="block w-full rounded-md border border-gray-300 focus-within:border-brand focus-within:ring-brand sm:text-sm p-2"
                 />
               )}
             />

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -4,6 +4,31 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import LocationStep from '../LocationStep';
 
+jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => {
+  const React = require('react');
+  return () => {
+    const [preds, setPreds] = React.useState<any[]>([]);
+    return {
+      placesService: {
+        getDetails: (_opts: any, cb: (p: any) => void) =>
+          cb({
+            geometry: { location: { lat: () => 1, lng: () => 2 } },
+            formatted_address: 'Test',
+          }),
+      },
+      placePredictions: preds,
+      getPlacePredictions: () =>
+        setPreds([
+          {
+            place_id: '1',
+            description: 'Test',
+            structured_formatting: { main_text: 'Test', secondary_text: 'SA' },
+          },
+        ]),
+    };
+  };
+});
+
 function Wrapper() {
   const { control } = useForm();
   return (
@@ -41,14 +66,14 @@ describe('LocationStep selection', () => {
     await act(async () => {
       root.render(React.createElement(Wrapper));
     });
-    const mock = (global as { mockAutocomplete: jest.Mock }).mockAutocomplete;
-    const instance = mock.mock.instances[0];
-    instance.getPlace.mockReturnValue({
-      geometry: { location: { lat: () => 1, lng: () => 2 } },
-      formatted_address: 'Test',
-    });
+    const input = container.querySelector('input') as HTMLInputElement;
     await act(async () => {
-      instance._cb();
+      input.value = 'Test';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const option = container.querySelector('[data-testid="location-option"]') as HTMLDivElement;
+    await act(async () => {
+      option.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.querySelector('[data-testid="map"]')).not.toBeNull();
   });

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -140,6 +140,7 @@ export default function CustomLocationInput({
               key={prediction.place_id}
               onClick={() => handleSelect(prediction)}
               className="flex items-center px-4 py-2 text-sm cursor-pointer hover:bg-indigo-50"
+              data-testid="location-option"
             >
               <MapPinIcon className="h-5 w-5 text-gray-400 mr-3 shrink-0" />
               <div>


### PR DESCRIPTION
## Summary
- replace gmpx web component with shared `LocationInput`
- update docs on how location autocomplete works
- adapt unit tests for new component
- surface location dropdown items to tests

## Testing
- `npm test` *(fails: 16 failed, 1 skipped, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68849eb0abc4832ea23a9213c803c136