### PR TITLE
Fix Next.js image warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * ARIA roles, clearer empty states, optional subtitle/tagline.
 * Shared `Card`, `Tag`, `TextInput` components.
 * Open Graph meta tags and fallback avatars.
+* The placeholder avatar is now square (1:1 aspect ratio) to avoid Next.js console warnings.
 * Profile images across the UI now automatically fall back to `default-avatar.svg` if the requested file cannot be loaded.
 * Missing images now respond with the appropriate `Content-Type` header (`image/jpeg` or `image/png`) so Next.js can display the fallback without warnings.
 * Accessibility and animation improvements.

--- a/backend/app/static/default-avatar.svg
+++ b/backend/app/static/default-avatar.svg
@@ -1,1 +1,5 @@
-<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1155 1000"><path d="m577.3 0 577.4 1000H0z" fill="#fff"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#F3F4F6" />
+  <circle cx="50" cy="34" r="20" fill="#D1D5DB" />
+  <path d="M10 94c0-20 18-36 40-36s40 16 40 36" fill="#D1D5DB" />
+</svg>


### PR DESCRIPTION
## Summary
- update default avatar SVG to use 1:1 aspect ratio
- document square avatar in README

## Testing
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: git fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6884a2c6ca68832eb16b6cd8f5d82316