### PR TITLE
Fix portfolio image hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,9 @@ The host portion of `NEXT_PUBLIC_API_URL` is also used by
 `next.config.js` to allow optimized image requests from the backend.
 Set this URL to match your API server so artist profile pictures and
 cover photos load without 400 errors from the `/_next/image` endpoint.
-The `next.config.js` file now explicitly includes `/static/cover_photos/**`
-alongside `/static/profile_pics/**` in its `remotePatterns` list.
+The `next.config.js` file now explicitly includes `/static/cover_photos/**` and
+`/static/portfolio_images/**` alongside `/static/profile_pics/**` in its
+`remotePatterns` list.
 
 The location input now reuses the `LocationInput` component powered by the
 `react-google-autocomplete` package. It matches the styling and behaviour of the

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,6 +15,12 @@ const remotePatterns = [
     port: port || '',
     pathname: '/static/cover_photos/**',
   },
+  {
+    protocol: protocol.replace(':', ''),
+    hostname,
+    port: port || '',
+    pathname: '/static/portfolio_images/**',
+  },
 ];
 
 if (hostname !== 'localhost') {
@@ -30,6 +36,12 @@ if (hostname !== 'localhost') {
       hostname: 'localhost',
       port: '8000',
       pathname: '/static/cover_photos/**',
+    },
+    {
+      protocol: 'http',
+      hostname: 'localhost',
+      port: '8000',
+      pathname: '/static/portfolio_images/**',
     },
   );
 }


### PR DESCRIPTION
## Summary
- allow `/static/portfolio_images` via `next.config.js`
- document new remote pattern in the README

## Testing
- `npm run lint` *(fails: multiple existing ESLint errors)*
- `./scripts/test-all.sh` *(fails: OperationalError during backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_6884a4514148832eb60e8eb1d108e13e