### PR TITLE
Fix booking request avatar loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Clients can upload and crop a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
 - The client user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
 - Artist profile picture uploads now update the account avatar so the image persists after logout and page refreshes. When logged in as an artist, the profile picture from **Edit Profile** is shown across the site, including the top navigation menu.
+- Booking request cards now show the client's profile picture when available so requests are easier to identify.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -25,7 +25,7 @@ export default function BookingRequestCard({
   user,
   onUpdate,
 }: BookingRequestCardProps) {
-  const avatarSrc = req.client?.profile_photo_url || null;
+  const avatarSrc = req.client?.profile_picture_url || null;
   const clientName = req.client
     ? `${req.client.first_name} ${req.client.last_name}`
     : 'Unknown Client';

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -20,7 +20,7 @@ const baseReq: BookingRequest = {
     phone_number: '',
     is_active: true,
     is_verified: true,
-    profile_photo_url: null,
+    profile_picture_url: null,
   } as any,
   service: { id: 9, artist_id: 3, title: 'Live Musiek' } as Service,
 } as BookingRequest;


### PR DESCRIPTION
## Summary
- load client avatars in `BookingRequestCard`
- update BookingRequestCard test accordingly
- document that booking request cards display client profile pictures

## Testing
- `npm test -- --runTestsByPath src/components/dashboard/__tests__/BookingRequestCard.test.tsx --maxWorkers=50%`

------
https://chatgpt.com/codex/tasks/task_e_6884a7b170e0832ea817a28d1879a47c