### PR TITLE
Fix avatar fallback paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,7 +859,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Shared `Card`, `Tag`, `TextInput` components.
 * Open Graph meta tags and fallback avatars.
 * The placeholder avatar is now square (1:1 aspect ratio) to avoid Next.js console warnings.
-* Profile images across the UI now automatically fall back to `default-avatar.svg` if the requested file cannot be loaded.
+* Profile images across the UI now automatically fall back to `/static/default-avatar.svg` if the requested file cannot be loaded.
 * Missing images now respond with the appropriate `Content-Type` header (`image/jpeg` or `image/png`) so Next.js can display the fallback without warnings.
 * Accessibility and animation improvements.
 * Dashboard stats now animate on load using **framer-motion**.

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -216,7 +216,7 @@ export default function ArtistProfilePage() {
                     alt={artist.business_name || 'Artist'}
                     priority
                     onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+                      (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
                     }}
                   />
                 ) : (

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -92,12 +92,12 @@ export default function ArtistCard({
               priority={priority}
               onLoad={() => setImgLoaded(true)}
               onError={(e) => {
-                (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+                (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
               }}
             />
           ) : (
             <Image
-              src="/default-avatar.svg"
+              src="/static/default-avatar.svg"
               alt={name}
               width={512}
               height={512}

--- a/frontend/src/components/artist/ArtistCardCompact.tsx
+++ b/frontend/src/components/artist/ArtistCardCompact.tsx
@@ -57,12 +57,12 @@ export default function ArtistCardCompact({
             className="object-cover w-full h-full group-hover:scale-105 transition-transform"
             onLoad={() => setLoaded(true)}
             onError={(e) => {
-              (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+              (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
             }}
           />
         ) : (
           <Image
-            src="/default-avatar.svg"
+            src="/static/default-avatar.svg"
             alt={name}
             fill
             sizes="(max-width:768px) 50vw, 33vw"

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -80,7 +80,7 @@ describe('ArtistCard optional fields', () => {
       act(() => {
         img.dispatchEvent(new Event('error'));
       });
-      expect(img.src).toContain('/default-avatar.svg');
+      expect(img.src).toContain('/static/default-avatar.svg');
     }
     act(() => root.unmount());
     container.remove();
@@ -91,7 +91,7 @@ describe('ArtistCard optional fields', () => {
     const img = container.querySelector('img') as HTMLImageElement | null;
     expect(img).not.toBeNull();
     if (img) {
-      expect(img.src).toContain('/default-avatar.svg');
+      expect(img.src).toContain('/static/default-avatar.svg');
     }
     act(() => root.unmount());
     container.remove();

--- a/frontend/src/components/artist/__tests__/__snapshots__/ArtistCardCompact.test.tsx.snap
+++ b/frontend/src/components/artist/__tests__/__snapshots__/ArtistCardCompact.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ArtistCardCompact matches snapshot 1`] = `
       data-nimg="fill"
       decoding="async"
       loading="lazy"
-      src="/default-avatar.svg"
+      src="/static/default-avatar.svg"
       style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
     />
   </div>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -468,7 +468,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
                 loading="lazy"
                 className="h-8 w-8 rounded-full object-cover"
                 onError={(e) => {
-                  (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+                  (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
                 }}
               />
             </Link>
@@ -481,7 +481,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
               loading="lazy"
               className="h-8 w-8 rounded-full object-cover"
               onError={(e) => {
-                (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+                (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
               }}
             />
           )}

--- a/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
+++ b/frontend/src/components/home/__tests__/__snapshots__/ArtistsSection.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`ArtistsSection matches snapshot 1`] = `
           data-nimg="fill"
           decoding="async"
           loading="lazy"
-          src="/default-avatar.svg"
+          src="/static/default-avatar.svg"
           style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
         />
       </div>

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -147,7 +147,7 @@ export default function NotificationListItem({
   const p = parseItem(n);
   // Use a fallback avatar image when the notification does not include one so
   // all notifications show a consistent profile picture.
-  const avatarSrc = p.avatarUrl || '/default-avatar.svg';
+  const avatarSrc = p.avatarUrl || '/static/default-avatar.svg';
 
   return (
     <div

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -37,7 +37,7 @@ export default function Avatar({
           height={size}
           className="object-cover rounded-full"
           onError={(e) => {
-            (e.currentTarget as HTMLImageElement).src = '/default-avatar.svg';
+            (e.currentTarget as HTMLImageElement).src = '/static/default-avatar.svg';
           }}
         />
       ) : initials ? (

--- a/frontend/src/components/ui/NotificationCard.tsx
+++ b/frontend/src/components/ui/NotificationCard.tsx
@@ -65,7 +65,7 @@ export default function NotificationCard({
   // Always display an image avatar; fall back to a generic placeholder when
   // the sender has not uploaded a profile picture. This ensures notifications
   // consistently show a profile photo rather than initials.
-  const avatarSrc = avatarUrl || '/default-avatar.svg';
+  const avatarSrc = avatarUrl || '/static/default-avatar.svg';
 
   return (
     <div

--- a/frontend/src/components/ui/__tests__/NotificationCard.test.tsx
+++ b/frontend/src/components/ui/__tests__/NotificationCard.test.tsx
@@ -33,7 +33,7 @@ describe('NotificationCard', () => {
       );
     });
     const img = container.querySelector('img');
-    expect(img?.getAttribute('src')).toContain('/default-avatar.svg');
+    expect(img?.getAttribute('src')).toContain('/static/default-avatar.svg');
   });
 
   it('applies unread styling', () => {


### PR DESCRIPTION
## Summary
- ensure profile images load fallback correctly by using `/static/default-avatar.svg`
- document the correct path for default avatars

## Testing
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884aa510ca8832e900191ca6da5bdf5