### PR TITLE
Update accent color utilities

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -64,11 +64,14 @@ colors: {
   --brand-color: #6366f1;
   --brand-color-dark: #4f46e5;
   --brand-color-light: #a5b4fc;
+  --color-accent: #ec4899;
 }
 ```
 
 Updating these values automatically updates button variants and any classes such
-as `bg-brand` or `bg-brand-dark`.
+as `bg-brand` or `bg-brand-dark`. The accent color is exposed as `--color-accent`
+and can be referenced with utilities like `bg-[var(--color-accent)]` or
+`text-[var(--color-accent)]`.
 
 ### Fonts & Global Styles
 

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -69,7 +69,7 @@ export default function SearchBar({
       />
       <button
         type="submit"
-        className="bg-pink-600 hover:bg-pink-700 px-5 py-3 flex items-center justify-center text-white rounded-r-full"
+        className="bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/90 px-5 py-3 flex items-center justify-center text-white rounded-r-full"
       >
         <MagnifyingGlassIcon className="h-5 w-5" />
         <span className="sr-only">Search</span>

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -93,7 +93,7 @@ export default function SearchBarInline({
         <button
           type="button"
           onClick={expand}
-          className="flex items-center bg-white border border-gray-200 rounded-full shadow-sm divide-x divide-gray-200 overflow-hidden w-full hover:ring-2 hover:ring-pink-500 focus:outline-none focus:ring-2 focus:ring-pink-500 transition-all duration-300 ease-out"
+          className="flex items-center bg-white border border-gray-200 rounded-full shadow-sm divide-x divide-gray-200 overflow-hidden w-full hover:ring-2 hover:ring-[var(--color-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] transition-all duration-300 ease-out"
         >
           <div className="flex-1 px-4 py-2 text-sm text-gray-700">
             {category.label}
@@ -104,7 +104,7 @@ export default function SearchBarInline({
           <div className="flex-1 px-4 py-2 text-sm text-gray-700">
             {when ? format(when, 'd\u00A0MMM\u00A0yyyy') : 'Add\u00A0date'}
           </div>
-          <div className="p-2 bg-pink-600 text-white rounded-r-full">
+          <div className="p-2 bg-[var(--color-accent)] text-white rounded-r-full">
             <MagnifyingGlassIcon className="h-5 w-5" />
           </div>
         </button>

--- a/frontend/src/components/ui/PriceFilter.tsx
+++ b/frontend/src/components/ui/PriceFilter.tsx
@@ -237,9 +237,9 @@ export default function PriceFilter({
           props.onBlur?.(e);
         }}
         className={clsx(
-          'absolute -top-2.5 w-5 h-5 rounded-full border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-pink-500 transition-shadow duration-200 ease-in-out',
+          'absolute -top-2.5 w-5 h-5 rounded-full border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] transition-shadow duration-200 ease-in-out',
           props.className,
-          { 'shadow-lg ring-4 ring-pink-200': activeHandle === idx }
+          { 'shadow-lg ring-4 ring-[var(--color-accent)]/50': activeHandle === idx }
         )}
         style={{
           ...props.style,
@@ -257,7 +257,7 @@ export default function PriceFilter({
   };
 
   const Progress = ({ style }: { style: React.CSSProperties }) => (
-    <div className="absolute bottom-0 h-2 bg-pink-500 rounded" style={style} />
+    <div className="absolute bottom-0 h-2 bg-[var(--color-accent)] rounded" style={style} />
   );
 
   const Background = () => (
@@ -311,7 +311,7 @@ export default function PriceFilter({
               aria-haspopup="listbox"
               aria-expanded={isSortDropdownOpen}
               aria-labelledby="sort-label sort-dropdown-button"
-              className="w-full border border-gray-300 rounded-lg pl-4 pr-10 py-2 bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition-all duration-200 cursor-pointer flex justify-between items-center"
+              className="w-full border border-gray-300 rounded-lg pl-4 pr-10 py-2 bg-white text-gray-800 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)] transition-all duration-200 cursor-pointer flex justify-between items-center"
               onClick={() => setIsSortDropdownOpen(!isSortDropdownOpen)}
             >
               <span>{sortOptions.find(opt => opt.value === localSortValue)?.label || "Sort"}</span>
@@ -354,7 +354,7 @@ export default function PriceFilter({
                         "hover:bg-gray-100 hover:text-gray-900",
                         "focus:outline-none  focus:bg-gray-100",
                         {
-                          "bg-pink-50 text-pink-700 font-semibold": opt.value === localSortValue,
+                          "bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-semibold": opt.value === localSortValue,
                         }
                       )}
                       tabIndex={0}
@@ -412,7 +412,7 @@ export default function PriceFilter({
                   id="min-price"
                   value={localMinPrice.toLocaleString()}
                   onChange={handleMinPriceChange}
-                  className="w-full border border-gray-300 rounded-lg pl-8 pr-3 py-2 text-gray-900 font-medium focus:ring-pink-500 focus:border-pink-500"
+                  className="w-full border border-gray-300 rounded-lg pl-8 pr-3 py-2 text-gray-900 font-medium focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)]"
                 />
               </div>
             </div>
@@ -428,7 +428,7 @@ export default function PriceFilter({
                   id="max-price"
                   value={localMaxPrice.toLocaleString()}
                   onChange={handleMaxPriceChange}
-                  className="w-full border border-gray-300 rounded-lg pl-8 pr-3 py-2 text-gray-900 font-medium focus:ring-pink-500 focus:border-pink-500"
+                  className="w-full border border-gray-300 rounded-lg pl-8 pr-3 py-2 text-gray-900 font-medium focus:ring-[var(--color-accent)] focus:border-[var(--color-accent)]"
                 />
               </div>
             </div>
@@ -446,7 +446,7 @@ export default function PriceFilter({
           </button>
           <button
             type="button"
-            className="px-6 py-2 rounded-lg bg-pink-500 text-white font-semibold hover:bg-pink-600 transition-colors shadow-md"
+            className="px-6 py-2 rounded-lg bg-[var(--color-accent)] text-white font-semibold hover:bg-[var(--color-accent)]/90 transition-colors shadow-md"
             onClick={handleApplyClick}
           >
             Apply

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -42,14 +42,14 @@ export default function Stepper({
               className={clsx(
                 'w-4 h-4 rounded-full z-10',
                 isCompleted || isActive
-                  ? 'bg-indigo-600 text-white'
+                  ? 'bg-[var(--brand-color)] text-white'
                   : 'bg-gray-200',
               )}
             />
             {isActive && (
               <motion.div
                 layout
-                className="absolute inset-0 rounded-full ring-2 ring-indigo-400 animate-ping"
+                className="absolute inset-0 rounded-full ring-2 ring-[var(--brand-color-dark)] animate-ping"
               />
             )}
           </div>
@@ -73,7 +73,7 @@ export default function Stepper({
               disabled={!isClickable}
               aria-disabled={isClickable ? undefined : true}
               className={clsx(
-                'flex flex-col items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400',
+                'flex flex-col items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-color-dark)]',
                 isClickable ? 'cursor-pointer' : 'cursor-default',
               )}
             >

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -126,6 +126,6 @@ describe('Stepper progress bar', () => {
       button.focus();
     });
     expect(button.className).toContain('focus-visible:ring-2');
-    expect(button.className).toContain('focus-visible:ring-indigo-400');
+    expect(button.className).toContain('focus-visible:ring-[var(--brand-color-dark)]');
   });
 });


### PR DESCRIPTION
## Summary
- apply `--color-accent` variable in search bars and price filter
- use brand color variables for stepper progress
- document accent color in the frontend README
- update stepper tests for new classes

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: git fetch origin main)*

------
https://chatgpt.com/codex/tasks/task_e_6884b254f6ec832eb1ab65e6534b78d0