### PR TITLE
Add dashboard profile progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
 * Artists can update or decline booking requests from the dashboard via a new **Update Request** modal.
 * Improved dashboard stats layout. Artists now see a monthly earnings card.
+* A profile completion progress bar now appears above the dashboard stats for artists.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.
 * Streamlined mobile dashboard with collapsible overview and sticky tabs.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -112,7 +112,15 @@ describe('DashboardPage artist stats', () => {
       ],
     });
     (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
-    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({
+      data: {
+        business_name: 'Studio',
+        description: 'desc',
+        location: 'City',
+        profile_picture_url: 'pic',
+        cover_photo_url: 'cover',
+      },
+    });
     (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
 
     container = document.createElement('div');
@@ -158,6 +166,11 @@ describe('DashboardPage artist stats', () => {
   it('renders monthly earnings card', () => {
     expect(container.textContent).toContain('Earnings This Month');
     expect(container.textContent).toContain(formatCurrency(120));
+  });
+
+  it('shows profile progress bar', () => {
+    const bar = container.querySelector('[data-testid="profile-progress"] div') as HTMLDivElement;
+    expect(bar.style.width).toBe('100%');
   });
 });
 

--- a/frontend/src/app/dashboard/__tests__/ProfileProgress.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/ProfileProgress.test.tsx
@@ -1,0 +1,43 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import ProfileProgress, { computeProfileCompletion } from '@/components/dashboard/ProfileProgress';
+import type { ArtistProfile } from '@/types';
+
+describe('ProfileProgress component', () => {
+  it('computes completion percentage correctly', () => {
+    const profile: Partial<ArtistProfile> = {
+      business_name: 'Studio',
+      description: 'desc',
+      location: null,
+      profile_picture_url: 'pic',
+      cover_photo_url: null,
+    };
+    expect(computeProfileCompletion(profile)).toBe(60);
+  });
+
+  it('renders progress bar with width', () => {
+    const profile: Partial<ArtistProfile> = {
+      business_name: 'Studio',
+      description: 'desc',
+      location: 'City',
+      profile_picture_url: 'pic',
+      cover_photo_url: 'cover',
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<ProfileProgress profile={profile} />);
+    });
+
+    const inner = container.querySelector('[data-testid="profile-progress"] div') as HTMLDivElement;
+    expect(inner.style.width).toBe('100%');
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
 import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
 import OverviewAccordion from "@/components/dashboard/OverviewAccordion";
+import ProfileProgress from "@/components/dashboard/ProfileProgress";
 import SectionList from "@/components/dashboard/SectionList";
 import BookingRequestCard from "@/components/dashboard/BookingRequestCard";
 import CollapsibleSection from "@/components/ui/CollapsibleSection";
@@ -337,6 +338,11 @@ export default function DashboardPage() {
         <div className="mx-auto max-w-7xl">
           <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
         </div>
+        {user?.user_type === 'artist' && artistProfile && (
+          <div className="mx-auto max-w-7xl mt-4">
+            <ProfileProgress profile={artistProfile} />
+          </div>
+        )}
         <div className="mx-auto max-w-7xl space-y-4">
           {/* Location Prompt for Artists */}
           {showLocationPrompt && (

--- a/frontend/src/components/dashboard/ProfileProgress.tsx
+++ b/frontend/src/components/dashboard/ProfileProgress.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React, { useMemo } from 'react';
+import type { ArtistProfile } from '@/types';
+
+const fields: (keyof ArtistProfile)[] = [
+  'business_name',
+  'description',
+  'location',
+  'profile_picture_url',
+  'cover_photo_url',
+];
+
+export function computeProfileCompletion(profile?: Partial<ArtistProfile>): number {
+  if (!profile) return 0;
+  const filled = fields.reduce((acc, key) => acc + (profile[key] ? 1 : 0), 0);
+  return Math.round((filled / fields.length) * 100);
+}
+
+interface ProfileProgressProps {
+  profile: Partial<ArtistProfile> | null;
+}
+
+export default function ProfileProgress({ profile }: ProfileProgressProps) {
+  const percentage = useMemo(() => computeProfileCompletion(profile || undefined), [profile]);
+  return (
+    <div className="w-full" data-testid="profile-progress-wrapper">
+      <div className="flex justify-between text-sm mb-1">
+        <span>Profile Completion</span>
+        <span>{percentage}%</span>
+      </div>
+      <div className="w-full bg-gray-200 rounded-full h-2" data-testid="profile-progress">
+        <div
+          className="h-2 rounded-full bg-[var(--color-accent)]"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a progress bar on the dashboard for artists
- compute profile completion percentage from key fields
- display progress using accent color styles
- test the new component and update dashboard tests
- document the new progress bar in README

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: git fetch origin main)*

------
https://chatgpt.com/codex/tasks/task_e_6884b6bb81d4832ea8c1c92fb23de468