### PR TITLE
Update booking request badge colors

### DIFF
--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -14,6 +14,26 @@ import { BookingRequest, User } from '@/types';
 import { formatStatus } from '@/lib/utils';
 import { Avatar } from '../ui';
 
+const STATUS_COLORS: Record<'pending' | 'quoted' | 'booked' | 'declined', string> = {
+  pending: 'bg-yellow-100 text-yellow-800',
+  quoted: 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]',
+  booked: 'bg-brand-light text-brand-dark',
+  declined: 'bg-red-100 text-red-800',
+};
+
+const getStatusColor = (status: string): string => {
+  if (status.includes('declined') || status.includes('rejected') || status.includes('withdrawn')) {
+    return STATUS_COLORS.declined;
+  }
+  if (status.includes('confirmed') || status.includes('accepted')) {
+    return STATUS_COLORS.booked;
+  }
+  if (status !== 'pending_quote' && status.includes('quote')) {
+    return STATUS_COLORS.quoted;
+  }
+  return STATUS_COLORS.pending;
+};
+
 export interface BookingRequestCardProps {
   req: BookingRequest;
   user: User;
@@ -50,7 +70,11 @@ export default function BookingRequestCard({
         </div>
       </div>
       <div className="flex flex-col items-end gap-2">
-        <span className="inline-flex rounded-full px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800">
+        <span
+          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${getStatusColor(
+            req.status,
+          )}`}
+        >
           {formatStatus(req.status)}
         </span>
         <div className="flex gap-2">

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -21,6 +21,7 @@ const baseReq: BookingRequest = {
     is_active: true,
     is_verified: true,
     profile_picture_url: null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any,
   service: { id: 9, artist_id: 3, title: 'Live Musiek' } as Service,
 } as BookingRequest;
@@ -115,5 +116,27 @@ describe('BookingRequestCard', () => {
     });
     const img = container.querySelector('img');
     expect(img).toBeNull();
+  });
+
+  it('applies different badge colors based on status', () => {
+    const cases: [string, string][] = [
+      ['pending_quote', 'bg-yellow-100'],
+      ['quote_provided', 'bg-[var(--color-accent)]/10'],
+      ['request_confirmed', 'bg-brand-light'],
+      ['request_declined', 'bg-red-100'],
+    ];
+    cases.forEach(([status, expected]) => {
+      act(() => {
+        root.render(
+          React.createElement(BookingRequestCard, {
+            req: { ...baseReq, status } as BookingRequest,
+            user: artistUser,
+            onUpdate: jest.fn(),
+          }),
+        );
+      });
+      const badge = container.querySelector('span.inline-flex') as HTMLSpanElement;
+      expect(badge.className).toContain(expected);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- map booking request statuses to color classes
- ensure BookingRequestCard uses brand/accent styles per status
- test badge color logic

## Testing
- `npm test -- src/components/dashboard/__tests__/BookingRequestCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6884bf3fec44832eac19eb29193ad288