### PR TITLE
Add dashboard request sorting/filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.
 * Streamlined mobile dashboard with collapsible overview and sticky tabs.
-  ![Mobile dashboard states](docs/mobile_dashboard_states.svg)
+* Booking requests on the dashboard can now be **sorted and filtered** client-side.
+![Mobile dashboard states](docs/mobile_dashboard_states.svg)
 
 ### Artist Availability
 

--- a/frontend/src/app/dashboard/__tests__/RequestSortFilter.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/RequestSortFilter.test.tsx
@@ -1,0 +1,114 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import DashboardPage from '../page';
+import { flushPromises } from '@/test/utils/flush';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import type { BookingRequest, User } from '@/types';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/dashboard'),
+}));
+
+describe('DashboardPage booking request sort and filter', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  const baseUser: User = {
+    id: 1,
+    email: 'a@example.com',
+    user_type: 'artist',
+    first_name: 'A',
+    last_name: 'B',
+    phone_number: '',
+    is_active: true,
+    is_verified: true,
+  };
+  const requests: BookingRequest[] = [
+    {
+      id: 1,
+      client_id: 2,
+      artist_id: 1,
+      status: 'pending_quote',
+      created_at: '2025-05-01T00:00:00.000Z',
+      updated_at: '2025-05-01T00:00:00.000Z',
+      client: { ...baseUser, id: 2, first_name: 'C1' },
+      artist: baseUser,
+    } as BookingRequest,
+    {
+      id: 2,
+      client_id: 3,
+      artist_id: 1,
+      status: 'quote_provided',
+      created_at: '2025-07-01T00:00:00.000Z',
+      updated_at: '2025-07-01T00:00:00.000Z',
+      client: { ...baseUser, id: 3, first_name: 'C2' },
+      artist: baseUser,
+    } as BookingRequest,
+    {
+      id: 3,
+      client_id: 4,
+      artist_id: 1,
+      status: 'pending_quote',
+      created_at: '2025-06-01T00:00:00.000Z',
+      updated_at: '2025-06-01T00:00:00.000Z',
+      client: { ...baseUser, id: 4, first_name: 'C3' },
+      artist: baseUser,
+    } as BookingRequest,
+  ];
+
+  beforeEach(async () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useAuth as jest.Mock).mockReturnValue({ user: baseUser });
+    (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistServices as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getArtistProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+    (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: requests });
+    (api.getDashboardStats as jest.Mock).mockResolvedValue({ data: { monthly_new_inquiries: 0, profile_views: 0, response_rate: 0 } });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<DashboardPage />);
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    jest.clearAllMocks();
+  });
+
+  it('sorts booking requests by oldest first', async () => {
+    const select = container.querySelector('select[data-testid="request-sort"]') as HTMLSelectElement;
+    await act(async () => {
+      select.value = 'oldest';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flushPromises();
+    const first = container.querySelector('li');
+    expect(first?.textContent).toContain('C1');
+  });
+
+  it('filters booking requests by status', async () => {
+    const select = container.querySelector('select[data-testid="request-status"]') as HTMLSelectElement;
+    await act(async () => {
+      select.value = 'quote_provided';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flushPromises();
+    const items = container.querySelectorAll('li');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('C2');
+  });
+});


### PR DESCRIPTION
## Summary
- allow sorting & filtering of booking requests
- compute visible requests on the client
- add integration tests for sort & filter interactions
- document dashboard improvements

## Testing
- `./scripts/test-all.sh` *(fails: `git fetch origin` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884c11d35e4832e91a06626ce7e1833