### PR TITLE
Fix stats endpoint path

### DIFF
--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -173,7 +173,7 @@ def read_my_artist_booking_requests(
             setattr(req, "accepted_quote_id", accepted.id)
     return requests
 
-@router.get("/{request_id}", response_model=schemas.BookingRequestResponse)
+@router.get("/{request_id:int}", response_model=schemas.BookingRequestResponse)
 def read_booking_request(
     request_id: int,
     db: Session = Depends(get_db),
@@ -219,7 +219,7 @@ def read_booking_request(
         setattr(db_request, "accepted_quote_id", accepted.id)
     return db_request
 
-@router.put("/{request_id}/client", response_model=schemas.BookingRequestResponse)
+@router.put("/{request_id:int}/client", response_model=schemas.BookingRequestResponse)
 def update_booking_request_by_client(
     request_id: int,
     request_update: schemas.BookingRequestUpdateByClient,
@@ -326,7 +326,7 @@ def update_booking_request_by_client(
 
     return updated
 
-@router.put("/{request_id}/artist", response_model=schemas.BookingRequestResponse)
+@router.put("/{request_id:int}/artist", response_model=schemas.BookingRequestResponse)
 def update_booking_request_by_artist(
     request_id: int,
     request_update: schemas.BookingRequestUpdateByArtist,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1976,51 +1976,6 @@
         }
       }
     },
-    "/api/v1/booking-requests/stats": {
-      "get": {
-        "tags": [
-          "booking-requests",
-          "Booking Requests"
-        ],
-        "summary": "Get Dashboard Stats",
-        "description": "Return monthly inquiries, profile views, and response rate for the artist.",
-        "operationId": "get_dashboard_stats_api_v1_booking_requests_stats_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "monthly_new_inquiries": { "type": "integer" },
-                    "profile_views": { "type": "integer" },
-                    "response_rate": { "type": "number" }
-                  },
-                  "required": ["monthly_new_inquiries", "profile_views", "response_rate"],
-                  "title": "Response Get Dashboard Stats Api V1 Booking Requests Stats Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/booking-requests/{request_id}": {
       "get": {
         "tags": [
@@ -2186,6 +2141,32 @@
             }
           }
         }
+      }
+    },
+    "/api/v1/booking-requests/stats": {
+      "get": {
+        "tags": [
+          "booking-requests",
+          "Booking Requests"
+        ],
+        "summary": "Get dashboard stats",
+        "description": "Return monthly inquiries, profile views, and response rate for the artist.",
+        "operationId": "get_dashboard_stats_api_v1_booking_requests_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
       }
     },
     "/api/v1/quotes": {


### PR DESCRIPTION
## Summary
- avoid 422 error when calling stats endpoint by restricting booking request id paths
- regenerate OpenAPI docs

## Testing
- `./scripts/test-backend.sh` *(fails: TypeError combine() argument 1 must be datetime.date, not Query)*

------
https://chatgpt.com/codex/tasks/task_e_6884c3b56338832eb72125697b090988