### PR TITLE
Update booking request card

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,7 +898,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   `POST /api/v1/quotes/{id}/confirm-booking` allow updates and confirmations.
 * The dashboard stats section now includes a **View All Quotes** link so artists can quickly jump to their quotes list.
 * Booking request cards now show a **Quote accepted** label linking directly to the accepted quote.
-* Artists can update or decline booking requests from the dashboard via a new **Update Request** modal.
+* Booking request cards now include a **Manage Request** link that opens the request details page.
 * Improved dashboard stats layout. Artists now see a monthly earnings card.
 
 * Dashboard overview now also shows **New Inquiries This Month**, **Profile Views**, and **Response Rate**.

--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -160,6 +160,7 @@ export default function BookingRequestsPage() {
               {filtered.map((r) => {
                 const count = unreadCounts[r.id] ?? 0;
                 const unread = count > 0;
+                const isNew = r.status === 'pending_quote';
                 return (
                   <li
                     key={r.id}
@@ -170,7 +171,11 @@ export default function BookingRequestsPage() {
                     onKeyPress={() => handleRowClick(r.id)}
                     className={clsx(
                       'relative cursor-pointer p-2 rounded-md hover:bg-gray-50 focus:outline-none',
-                      unread ? 'bg-brand-light border-l-4 border-brand' : 'bg-white',
+                      unread
+                        ? 'bg-brand-light border-l-4 border-brand'
+                        : isNew
+                          ? 'bg-blue-50'
+                          : 'bg-white',
                     )}
                   >
                     {count > 0 && (
@@ -181,7 +186,7 @@ export default function BookingRequestsPage() {
                         {count > 99 ? '99+' : count}
                       </span>
                     )}
-                    <BookingRequestCard req={r} user={user} onUpdate={() => {}} />
+                    <BookingRequestCard req={r} />
                   </li>
                 );
               })}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -498,12 +498,7 @@ export default function DashboardPage() {
                 defaultOpen={false}
                 emptyState={<span>No bookings yet</span>}
                 renderItem={(req) => (
-                  <BookingRequestCard
-                    key={req.id}
-                    req={req}
-                    user={user as any}
-                    onUpdate={() => setRequestToUpdate(req)}
-                  />
+                  <BookingRequestCard key={req.id} req={req} />
                 )}
                 footer={
                   bookingRequests.length > visibleRequests.length ? (

--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -4,8 +4,6 @@ import React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import {
-  ChatBubbleLeftEllipsisIcon,
-  ArrowPathIcon,
   CalendarIcon,
   MicrophoneIcon,
   MusicalNoteIcon,
@@ -14,15 +12,23 @@ import { BookingRequest, User } from '@/types';
 import { formatStatus } from '@/lib/utils';
 import { Avatar } from '../ui';
 
-const STATUS_COLORS: Record<'pending' | 'quoted' | 'booked' | 'declined', string> = {
+const STATUS_COLORS: Record<
+  'pending' | 'pendingAction' | 'quoted' | 'booked' | 'declined',
+  string
+> = {
   pending: 'bg-yellow-100 text-yellow-800',
+  pendingAction: 'bg-orange-100 text-orange-800',
   quoted: 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]',
   booked: 'bg-brand-light text-brand-dark',
   declined: 'bg-red-100 text-red-800',
 };
 
 const getStatusColor = (status: string): string => {
-  if (status.includes('declined') || status.includes('rejected') || status.includes('withdrawn')) {
+  if (
+    status.includes('declined') ||
+    status.includes('rejected') ||
+    status.includes('withdrawn')
+  ) {
     return STATUS_COLORS.declined;
   }
   if (status.includes('confirmed') || status.includes('accepted')) {
@@ -31,20 +37,17 @@ const getStatusColor = (status: string): string => {
   if (status !== 'pending_quote' && status.includes('quote')) {
     return STATUS_COLORS.quoted;
   }
+  if (status !== 'pending_quote' && status.includes('pending')) {
+    return STATUS_COLORS.pendingAction;
+  }
   return STATUS_COLORS.pending;
 };
 
 export interface BookingRequestCardProps {
   req: BookingRequest;
-  user: User;
-  onUpdate: () => void;
 }
 
-export default function BookingRequestCard({
-  req,
-  user,
-  onUpdate,
-}: BookingRequestCardProps) {
+export default function BookingRequestCard({ req }: BookingRequestCardProps) {
   const avatarSrc = req.client?.profile_picture_url || null;
   const clientName = req.client
     ? `${req.client.first_name} ${req.client.last_name}`
@@ -77,25 +80,12 @@ export default function BookingRequestCard({
         >
           {formatStatus(req.status)}
         </span>
-        <div className="flex gap-2">
-          <Link
-            href={`/booking-requests/${req.id}`}
-            className="inline-flex items-center gap-1 rounded bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 text-sm"
-          >
-            <ChatBubbleLeftEllipsisIcon className="w-4 h-4" />
-            Chat
-          </Link>
-          {user.user_type === 'artist' && (
-            <button
-              type="button"
-              onClick={onUpdate}
-              className="inline-flex items-center gap-1 rounded bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 text-sm"
-            >
-              <ArrowPathIcon className="w-4 h-4" />
-              Update
-            </button>
-          )}
-        </div>
+        <Link
+          href={`/booking-requests/${req.id}`}
+          className="inline-flex items-center gap-1 rounded bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 text-sm"
+        >
+          Manage Request
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -2,7 +2,7 @@ import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
 import BookingRequestCard from '../BookingRequestCard';
-import type { BookingRequest, User, Service } from '@/types';
+import type { BookingRequest, Service } from '@/types';
 
 const baseReq: BookingRequest = {
   id: 1,
@@ -26,18 +26,6 @@ const baseReq: BookingRequest = {
   service: { id: 9, artist_id: 3, title: 'Live Musiek' } as Service,
 } as BookingRequest;
 
-const artistUser: User = {
-  id: 3,
-  email: 'a@example.com',
-  user_type: 'artist',
-  first_name: 'Art',
-  last_name: 'Ist',
-  phone_number: '',
-  is_active: true,
-  is_verified: true,
-};
-
-const clientUser: User = { ...artistUser, user_type: 'client' };
 
 describe('BookingRequestCard', () => {
   let container: HTMLDivElement;
@@ -56,46 +44,19 @@ describe('BookingRequestCard', () => {
     container.remove();
   });
 
-  it('calls onUpdate when update button clicked', () => {
-    const onUpdate = jest.fn();
+  it('renders manage link with correct href', () => {
     act(() => {
-      root.render(
-        React.createElement(BookingRequestCard, {
-          req: baseReq,
-          user: artistUser,
-          onUpdate,
-        }),
-      );
+      root.render(React.createElement(BookingRequestCard, { req: baseReq }));
     });
-    const btn = container.querySelector('button');
-    expect(btn).not.toBeNull();
-    act(() => {
-      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(onUpdate).toHaveBeenCalled();
+    const link = container.querySelector('a') as HTMLAnchorElement | null;
+    expect(link?.getAttribute('href')).toBe('/booking-requests/1');
   });
 
-  it('hides update button for client user', () => {
+  it('shows formatted date and manage link', () => {
     act(() => {
       root.render(
         React.createElement(BookingRequestCard, {
           req: baseReq,
-          user: clientUser,
-          onUpdate: jest.fn(),
-        }),
-      );
-    });
-    const btn = container.querySelector('button');
-    expect(btn).toBeNull();
-  });
-
-  it('shows formatted date and chat link', () => {
-    act(() => {
-      root.render(
-        React.createElement(BookingRequestCard, {
-          req: baseReq,
-          user: artistUser,
-          onUpdate: jest.fn(),
         }),
       );
     });
@@ -109,8 +70,6 @@ describe('BookingRequestCard', () => {
       root.render(
         React.createElement(BookingRequestCard, {
           req: baseReq,
-          user: artistUser,
-          onUpdate: jest.fn(),
         }),
       );
     });
@@ -121,6 +80,7 @@ describe('BookingRequestCard', () => {
   it('applies different badge colors based on status', () => {
     const cases: [string, string][] = [
       ['pending_quote', 'bg-yellow-100'],
+      ['pending_artist_confirmation', 'bg-orange-100'],
       ['quote_provided', 'bg-[var(--color-accent)]/10'],
       ['request_confirmed', 'bg-brand-light'],
       ['request_declined', 'bg-red-100'],
@@ -130,8 +90,6 @@ describe('BookingRequestCard', () => {
         root.render(
           React.createElement(BookingRequestCard, {
             req: { ...baseReq, status } as BookingRequest,
-            user: artistUser,
-            onUpdate: jest.fn(),
           }),
         );
       });


### PR DESCRIPTION
## Summary
- restyle BookingRequestCard badge and link
- show new request highlight on booking requests page
- simplify BookingRequestCard props and update tests
- document Manage Request link in README

## Testing
- `npm --prefix frontend install`
- `./scripts/test-all.sh` *(fails: 20 failed, 1 skipped, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884d48eb13c832ea0dd4b72f0240771