### PR TITLE
Add orange/yellow palettes

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,6 +44,7 @@ Brand colors are declared in `tailwind.config.js` and exposed as CSS variables i
 
 ```javascript
 // tailwind.config.js
+const colors = require('tailwindcss/colors');
 colors: {
   brand: {
     DEFAULT: '#6366f1',
@@ -55,6 +56,9 @@ colors: {
     600: '#4F46E5',
     700: '#4338CA',
   },
+  // default Tailwind palettes used for status badges
+  orange: colors.orange,
+  yellow: colors.yellow,
 }
 ```
 
@@ -71,7 +75,8 @@ colors: {
 Updating these values automatically updates button variants and any classes such
 as `bg-brand` or `bg-brand-dark`. The accent color is exposed as `--color-accent`
 and can be referenced with utilities like `bg-[var(--color-accent)]` or
-`text-[var(--color-accent)]`.
+`text-[var(--color-accent)]`. Default Tailwind shades for `orange` and `yellow`
+are also included for status badges and warnings.
 
 ### Fonts & Global Styles
 

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header hides search bar on other pages 1`] = `
+exports[`Header hides search bar on other pages without extraBar 1`] = `
 <header
-  class="sticky top-0 z-40 bg-gray-50"
+  class="sticky top-0 z-40 bg-gray-100"
 >
   <div
     class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
@@ -104,7 +104,7 @@ exports[`Header hides search bar on other pages 1`] = `
 
 exports[`Header renders artists header when extraBar provided 1`] = `
 <header
-  class="sticky top-0 z-40 bg-gray-50"
+  class="sticky top-0 z-40 bg-gray-100"
 >
   <div
     class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
@@ -203,16 +203,20 @@ exports[`Header renders artists header when extraBar provided 1`] = `
     <div
       class="pb-3 pt-2"
     >
-      bar
+      <div>
+        bar
+      </div>
     </div>
   </div>
-  <div class="border-t border-gray-200" />
+  <div
+    class="border-t border-gray-200"
+  />
 </header>
 `;
 
 exports[`Header renders search bar on home page 1`] = `
 <header
-  class="sticky top-0 z-40 bg-gray-50"
+  class="sticky top-0 z-40 bg-gray-100"
 >
   <div
     class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8"
@@ -314,136 +318,118 @@ exports[`Header renders search bar on home page 1`] = `
       </button>
     </div>
     <div
-      class="pb-3 pt-2"
+      class="w-full max-w-4xl mx-auto px-4 pb-5 pt-2"
     >
-      <div
-        class="relative"
+      <form
+        class="flex items-stretch bg-white rounded-full shadow-lg overflow-visible text-sm"
       >
-        <form
-          class="flex items-stretch bg-white rounded-full ring-1 ring-gray-200 shadow-md overflow-visible min-h-[48px] text-sm mx-auto w-full md:max-w-4xl"
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
         >
-          <div
-            class="flex-1 px-4 flex flex-col text-left py-2"
+          <span
+            class="text-xs text-gray-500"
           >
-            <span
-              class="text-xs text-gray-500"
-            >
-              Category
-            </span>
-            <div
-              class="relative w-full"
-            >
-              <button
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                class="mt-1 w-full flex justify-between items-center text-sm text-gray-700 focus:outline-none"
-                data-headlessui-state=""
-                id="headlessui-listbox-button-:r0:"
-                type="button"
-              >
-                <span>
-                  Musician / Band
-                </span>
-                <svg
-                  aria-hidden="true"
-                  class="h-4 w-4 text-gray-400"
-                  data-slot="icon"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </button>
-            </div>
-          </div>
+            Category
+          </span>
           <div
-            class="border-l border-gray-200"
-          />
-          <div
-            class="flex-1 px-4 flex flex-col text-left py-2"
+            class="relative w-full"
           >
-            <span
-              class="text-xs text-gray-500"
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="mt-1 w-full flex justify-between items-center text-sm text-gray-700 focus:outline-none"
+              data-headlessui-state=""
+              id="headlessui-listbox-button-:r0:"
+              type="button"
             >
-              Where
-            </span>
-            <div
-              class="relative"
-            >
-              <gmpx-place-autocomplete
-                data-testid="location-input"
+              <span>
+                Musician / Band
+              </span>
+              <svg
+                aria-hidden="true"
+                class="h-4 w-4 text-gray-400"
+                data-slot="icon"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <input
-                  slot="input"
-                  type="text"
-                  placeholder="City or venue"
-                  class="mt-1 w-full text-sm text-gray-700 placeholder-gray-400 focus:outline-none pr-8 block w-full rounded-md border border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm"
+                <path
+                  d="m19.5 8.25-7.5 7.5-7.5-7.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
                 />
-              </gmpx-place-autocomplete>
-              <button
-                class="absolute inset-y-0 right-1 flex items-center text-gray-500 hover:text-gray-700 text-sm"
-                data-testid="open-map-modal"
-                type="button"
-              >
-                Map
-              </button>
-            </div>
+              </svg>
+            </button>
           </div>
-          <div
-            class="border-l border-gray-200"
-          />
-          <div
-            class="flex-1 px-4 flex flex-col text-left py-2"
+        </div>
+        <div
+          class="border-l border-gray-200"
+        />
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
+        >
+          <span
+            class="text-xs text-gray-500"
           >
-            <span
-              class="text-xs text-gray-500"
-            >
-              When
-            </span>
+            Where
+          </span>
+          <div
+            class="relative w-full"
+          >
             <input
-              class="mt-1 w-full text-sm text-gray-700 focus:outline-none"
-              dateformat="MMM d, yyyy h:mm aa"
-              placeholdertext="Add date & time"
+              class="w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none"
+              placeholder="City or venue"
+              type="text"
+              value=""
             />
           </div>
-          <button
-            class="bg-pink-600 hover:bg-pink-700 text-white flex items-center justify-center h-full aspect-square md:w-12 md:h-auto"
-            type="submit"
-          >
-            <svg
-              aria-hidden="true"
-              class="w-5 h-5"
-              data-slot="icon"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <span
-              class="sr-only"
-            >
-              Search
-            </span>
-          </button>
-        </form>
+        </div>
         <div
-          class="pointer-events-none absolute inset-x-6 -bottom-2 h-2 rounded-full bg-black/10 blur-md opacity-30"
+          class="border-l border-gray-200"
         />
-      </div>
+        <div
+          class="flex-1 px-4 py-3 flex flex-col text-left"
+        >
+          <span
+            class="text-xs text-gray-500"
+          >
+            When
+          </span>
+          <input
+            class="mt-1 w-full text-sm text-gray-700 focus:outline-none"
+            dateformat="MMM d, yyyy"
+            placeholdertext="Add date"
+          />
+        </div>
+        <button
+          class="bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/90 px-5 py-3 flex items-center justify-center text-white rounded-r-full"
+          type="submit"
+        >
+          <svg
+            aria-hidden="true"
+            class="h-5 w-5"
+            data-slot="icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <span
+            class="sr-only"
+          >
+            Search
+          </span>
+        </button>
+      </form>
     </div>
   </div>
   <div

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+const colors = require('tailwindcss/colors');
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -36,6 +37,8 @@ module.exports = {
         border: 'var(--color-border)',
         background: 'var(--color-background)',
         foreground: 'var(--color-foreground)',
+        orange: colors.orange,
+        yellow: colors.yellow,
       },
       ringOffsetWidth: {
         default: '1px',


### PR DESCRIPTION
## Summary
- expose tailwind orange/yellow color scales
- document use of these in the README
- update header component snapshot

## Testing
- `npm run build` *(fails: Module not found)*
- `./scripts/test-frontend.sh` *(fails: 20 failed, 1 skipped, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884d6853974832e8a0284db4ddec836