### PR TITLE
Improve profile progress guidance

### DIFF
--- a/frontend/src/components/dashboard/ProfileProgress.tsx
+++ b/frontend/src/components/dashboard/ProfileProgress.tsx
@@ -1,6 +1,8 @@
 'use client';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
 import type { ArtistProfile } from '@/types';
+import CollapsibleSection from '../ui/CollapsibleSection';
 
 const fields: (keyof ArtistProfile)[] = [
   'business_name',
@@ -10,10 +12,26 @@ const fields: (keyof ArtistProfile)[] = [
   'cover_photo_url',
 ];
 
+const fieldLabels: Record<keyof ArtistProfile, string> = {
+  business_name: 'Business name',
+  description: 'Description',
+  location: 'Location',
+  profile_picture_url: 'Profile picture',
+  cover_photo_url: 'Cover photo',
+  user_id: 'User',
+  created_at: 'Created at',
+  updated_at: 'Updated at',
+};
+
 export function computeProfileCompletion(profile?: Partial<ArtistProfile>): number {
   if (!profile) return 0;
   const filled = fields.reduce((acc, key) => acc + (profile[key] ? 1 : 0), 0);
   return Math.round((filled / fields.length) * 100);
+}
+
+export function getMissingProfileFields(profile?: Partial<ArtistProfile>): (keyof ArtistProfile)[] {
+  if (!profile) return fields;
+  return fields.filter((key) => !profile[key]);
 }
 
 interface ProfileProgressProps {
@@ -21,7 +39,10 @@ interface ProfileProgressProps {
 }
 
 export default function ProfileProgress({ profile }: ProfileProgressProps) {
+  const [open, setOpen] = useState(false);
   const percentage = useMemo(() => computeProfileCompletion(profile || undefined), [profile]);
+  const missing = useMemo(() => getMissingProfileFields(profile || undefined), [profile]);
+
   return (
     <div className="w-full" data-testid="profile-progress-wrapper">
       <div className="flex justify-between text-sm mb-1">
@@ -29,11 +50,27 @@ export default function ProfileProgress({ profile }: ProfileProgressProps) {
         <span>{percentage}%</span>
       </div>
       <div className="w-full bg-gray-200 rounded-full h-2" data-testid="profile-progress">
-        <div
-          className="h-2 rounded-full bg-[var(--color-accent)]"
-          style={{ width: `${percentage}%` }}
-        />
+        <div className="h-2 rounded-full bg-[var(--color-accent)]" style={{ width: `${percentage}%` }} />
       </div>
+      {percentage < 100 && missing.length > 0 && (
+        <CollapsibleSection
+          className="mt-2 border border-gray-200"
+          title="Finish setting up your profile"
+          open={open}
+          onToggle={() => setOpen(!open)}
+          testId="profile-progress-details"
+        >
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            {missing.map((field) => (
+              <li key={field}>
+                <Link href="/dashboard/profile/edit" className="text-brand-dark hover:underline">
+                  {fieldLabels[field]}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </CollapsibleSection>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/__tests__/ProfileProgress.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/ProfileProgress.test.tsx
@@ -1,13 +1,20 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
-import ProfileProgress, { computeProfileCompletion } from '../ProfileProgress';
+import ProfileProgress, { computeProfileCompletion, getMissingProfileFields } from '../ProfileProgress';
 import type { ArtistProfile } from '@/types';
 
 describe('ProfileProgress component', () => {
   it('computes completion percentage correctly', () => {
     const profile: Partial<ArtistProfile> = { business_name: 'x', description: 'd' };
     expect(computeProfileCompletion(profile)).toBe(40);
+  });
+
+  it('computes missing fields correctly', () => {
+    const profile: Partial<ArtistProfile> = { business_name: 'x' };
+    const missing = getMissingProfileFields(profile);
+    expect(missing).toContain('description');
+    expect(missing).toContain('location');
   });
 
   it('renders progress bar with width', () => {
@@ -27,6 +34,24 @@ describe('ProfileProgress component', () => {
 
     const inner = container.querySelector('[data-testid="profile-progress"] div') as HTMLDivElement;
     expect(inner.style.width).toBe('100%');
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows missing field list when incomplete', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const profile: Partial<ArtistProfile> = { business_name: 'x' };
+    act(() => {
+      root.render(<ProfileProgress profile={profile} />);
+    });
+
+    const details = container.querySelector('[data-testid="profile-progress-details"]');
+    expect(details).toBeTruthy();
 
     act(() => {
       root.unmount();


### PR DESCRIPTION
## Summary
- expand `ProfileProgress` to show missing profile fields
- update tests for `ProfileProgress`

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: getFullImageUrl is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6884df6d106c832e9a23c40df3a7f255