### PR TITLE
Implement improved service modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * The handle blocks the context menu so long presses don't select text, applying `user-select: none` only during drag so you can still highlight service details normally.
 * Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.
 * Service deletion now requires confirmation to prevent mistakes.
-* **Add Service** button now opens a multi-step wizard with Type, Details, Media, and Packages steps. Review and publish once complete. The wizard replaces the old single form.
+* **Add Service** button now opens a full-screen wizard. Steps are shown in a responsive stepper with checkmarks and keyboard focus trapping. The final review mirrors the earlier steps with image thumbnails before publishing.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
 * "Your Services" now appears in a collapsible section just like booking requests, keeping the dashboard tidy.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -26,5 +26,6 @@ Run all tests with:
 - **PriceFilter** uses a keyboard focus trap and returns focus to the triggering element.
 - **BookingWizard** moves focus to the step heading when advancing steps.
 - **MobileMenuDrawer** relies on `@headlessui/dialog` for accessible focus handling.
+- **AddServiceModal** opens with `@headlessui/dialog`, trapping focus and closing on Escape.
 
 Contributions should follow these guidelines to maintain an inclusive experience.

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { motion } from 'framer-motion';
 import clsx from 'clsx';
+import { CheckIcon } from '@heroicons/react/24/solid';
 
 interface StepperProps {
   steps: string[];
@@ -17,8 +18,8 @@ export default function Stepper({
   onStepClick,
   ariaLabel,
 }: StepperProps) {
-  const maxStep =
-    typeof maxStepCompleted === 'number' ? maxStepCompleted : currentStep;
+  const maxStepAllowed =
+    typeof maxStepCompleted === 'number' ? maxStepCompleted + 1 : currentStep + 1;
   return (
     <motion.div
       layout
@@ -32,28 +33,40 @@ export default function Stepper({
         aria-hidden="true"
       />
       {steps.map((label, i) => {
-        const isClickable = !!onStepClick && i <= maxStep && i !== currentStep;
+        const isClickable = !!onStepClick && i <= maxStepAllowed && i !== currentStep;
         const isCompleted = i < currentStep;
         const isActive = i === currentStep;
+
         const circle = (
-          <div className="relative flex items-center justify-center">
-            <motion.div
-              layout
-              className={clsx(
-                'w-4 h-4 rounded-full z-10',
-                isCompleted || isActive
-                  ? 'bg-[var(--brand-color)] text-white'
-                  : 'bg-gray-200',
-              )}
-            />
-            {isActive && (
-              <motion.div
-                layout
-                className="absolute inset-0 rounded-full ring-2 ring-[var(--brand-color-dark)] animate-ping"
-              />
+          <div
+            className={clsx(
+              'relative flex items-center justify-center w-5 h-5 rounded-full border',
+              isCompleted
+                ? 'bg-green-600 border-green-600 text-white'
+                : isActive
+                  ? 'bg-white border-[var(--brand-color)] text-[var(--brand-color-dark)]'
+                  : 'bg-gray-200 border-gray-200 text-gray-400',
             )}
+          >
+            {isCompleted && <CheckIcon className="w-4 h-4" />}
           </div>
         );
+
+        const labelEl = (
+          <span
+            className={clsx(
+              'mt-1 text-sm font-medium',
+              isCompleted
+                ? 'text-gray-800'
+                : isActive
+                  ? 'text-[var(--brand-color-dark)] underline decoration-[var(--brand-color-dark)] decoration-4 underline-offset-8'
+                  : 'text-gray-400',
+            )}
+          >
+            {label}
+          </span>
+        );
+
         const content = (
           <div
             className="flex flex-col items-center"
@@ -62,6 +75,7 @@ export default function Stepper({
             aria-disabled={isClickable ? undefined : true}
           >
             {circle}
+            {labelEl}
           </div>
         );
         if (onStepClick) {


### PR DESCRIPTION
## Summary
- expand AddServiceModal to fullscreen headless-ui dialog
- refine stepper UX with check icons and better accessibility
- show review info in card layout with image thumbnails
- document focus trapping for the service modal

## Testing
- `npm test` *(fails: (0 , _navigation.useRouter) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6884e96ca000832eb2bc9f02f8cfd892