### PR TITLE
Improve AddServiceModal UX and validation

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -1,31 +1,23 @@
-'use client';
+"use client";
 
-import {
-  useForm,
-  type SubmitHandler,
-} from 'react-hook-form';
-import {
-  useState,
-  useRef,
-  useEffect,
-  Fragment,
-} from 'react';
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { useState, useRef, useEffect, Fragment } from "react";
 import {
   MusicalNoteIcon,
   VideoCameraIcon,
   SparklesIcon,
   SquaresPlusIcon,
-} from '@heroicons/react/24/outline';
-import clsx from 'clsx';
-import { Service } from '@/types';
+} from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import { Service } from "@/types";
 import {
   createService as apiCreateService,
   getDashboardStats,
-} from '@/lib/api';
-import { DEFAULT_CURRENCY } from '@/lib/constants';
-import { Dialog, Transition } from '@headlessui/react';
-import Button from '../ui/Button';
-import { Stepper, TextInput, TextArea, ToggleSwitch } from '../ui';
+} from "@/lib/api";
+import { DEFAULT_CURRENCY } from "@/lib/constants";
+import { Dialog, Transition } from "@headlessui/react";
+import Button from "../ui/Button";
+import { Stepper, TextInput, TextArea, ToggleSwitch } from "../ui";
 
 interface AddServiceModalProps {
   isOpen: boolean;
@@ -39,10 +31,10 @@ interface PackageData {
 }
 
 interface ServiceFormData {
-  service_type: Service['service_type'] | undefined;
+  service_type: Service["service_type"] | undefined;
   title: string;
   description: string;
-  duration_minutes: number | '';
+  duration_minutes: number | "";
   is_remote: boolean;
 }
 
@@ -51,7 +43,7 @@ export default function AddServiceModal({
   onClose,
   onServiceAdded,
 }: AddServiceModalProps) {
-  const steps = ['1. Type', '2. Details', '3. Media', '4. Packages', 'Review'];
+  const steps = ["1. Type", "2. Details", "3. Media", "4. Packages", "Review"];
   const [step, setStep] = useState(0);
   const [maxStep, setMaxStep] = useState(0);
   const {
@@ -65,8 +57,8 @@ export default function AddServiceModal({
   } = useForm<ServiceFormData>({
     defaultValues: {
       service_type: undefined,
-      title: '',
-      description: '',
+      title: "",
+      description: "",
       duration_minutes: 60,
       is_remote: false,
     },
@@ -75,13 +67,16 @@ export default function AddServiceModal({
   const [mediaFiles, setMediaFiles] = useState<File[]>([]);
   const [mediaError, setMediaError] = useState<string | null>(null);
   const [packages, setPackages] = useState<PackageData[]>([
-    { name: '', price: '' },
+    { name: "", price: "" },
   ]);
+  const [packageErrors, setPackageErrors] = useState<
+    { name?: string; price?: string }[]
+  >([{}]);
   const [publishing, setPublishing] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [stats, setStats] = useState<{ monthly_new_inquiries: number }>();
-  const watchTitle = watch('title');
-  const watchDescription = watch('description');
+  const watchTitle = watch("title");
+  const watchDescription = watch("description");
 
   useEffect(() => {
     if (step === 3 && !stats) {
@@ -92,63 +87,79 @@ export default function AddServiceModal({
   }, [step, stats]);
 
   const nextDisabled = () => {
-    if (step === 0) return !watch('service_type');
+    if (step === 0) return !watch("service_type");
     if (step === 1) {
-      return !!(
-        errors.title ||
-        errors.description ||
-        errors.duration_minutes
-      );
+      return !!(errors.title || errors.description || errors.duration_minutes);
     }
     if (step === 2) {
-      return !mediaFiles.some((f) => f.type.startsWith('image/'));
+      return !mediaFiles.some((f) => f.type.startsWith("image/"));
     }
     if (step === 3) {
-      return packages.some(
-        (p) => !p.name.trim() || Number(p.price) <= 0,
-      );
+      return packages.some((p) => !p.name.trim() || Number(p.price) <= 0);
     }
     return false;
   };
 
+  const validatePackages = () => {
+    const errs = packages.map((p) => ({
+      name: p.name.trim() ? undefined : "Name is required",
+      price: Number(p.price) > 0 ? undefined : "Price must be positive",
+    }));
+    setPackageErrors(errs);
+    return errs.every((e) => !e.name && !e.price);
+  };
+
   const next = async () => {
     if (step === 1) {
-      const valid = await trigger([
-        'title',
-        'description',
-        'duration_minutes',
-      ]);
+      const valid = await trigger(["title", "description", "duration_minutes"]);
       if (!valid) return;
+    }
+    if (step === 2) {
+      if (!mediaFiles.some((f) => f.type.startsWith("image/"))) {
+        setMediaError("At least one image is required.");
+        return;
+      }
+    }
+    if (step === 3) {
+      if (!validatePackages()) return;
     }
     setStep((s) => Math.min(s + 1, steps.length - 1));
     setMaxStep((m) => Math.max(m, step + 1));
   };
 
-const prev = () => setStep((s) => Math.max(s - 1, 0));
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
 
-const onFileChange = (files: FileList | null) => {
-  if (!files) return;
-  const arr = Array.from(files);
-  setMediaFiles((prev) => [...prev, ...arr]);
-  if (!arr.some((f) => f.type.startsWith('image/')) && !mediaFiles.some((f) => f.type.startsWith('image/')))
-    setMediaError('At least one image is required.');
-  else setMediaError(null);
-};
+  const onFileChange = (files: FileList | null) => {
+    if (!files) return;
+    const images = Array.from(files).filter((f) => f.type.startsWith("image/"));
+    if (images.length !== files.length) {
+      setMediaError("Only image files are allowed.");
+    } else {
+      setMediaError(null);
+    }
+    setMediaFiles((prev) => [...prev, ...images]);
+    if (
+      images.length === 0 &&
+      !mediaFiles.some((f) => f.type.startsWith("image/"))
+    ) {
+      setMediaError("At least one image is required.");
+    }
+  };
 
   const removeFile = (i: number) => {
     setMediaFiles((prev) => {
       const updated = prev.filter((_, idx) => idx !== i);
-      if (!updated.some((f) => f.type.startsWith('image/'))) {
-        setMediaError('At least one image is required.');
+      if (!updated.some((f) => f.type.startsWith("image/"))) {
+        setMediaError("At least one image is required.");
       }
       return updated;
     });
   };
 
-  const addPackage = () =>
-    setPackages((prev) =>
-      [...prev, { name: '', price: '' }].slice(0, 3),
-    );
+  const addPackage = () => {
+    setPackages((prev) => [...prev, { name: "", price: "" }].slice(0, 3));
+    setPackageErrors((prev) => [...prev, {}].slice(0, 3));
+  };
 
   const updatePackage = (
     i: number,
@@ -158,13 +169,29 @@ const onFileChange = (files: FileList | null) => {
     setPackages((prev) =>
       prev.map((p, idx) => (idx === i ? { ...p, [field]: value } : p)),
     );
+    setPackageErrors((prev) => {
+      const newErrs = [...prev];
+      if (field === "name") {
+        newErrs[i] = {
+          ...newErrs[i],
+          name: value.trim() ? undefined : "Name is required",
+        };
+      } else {
+        const num = Number(value);
+        newErrs[i] = {
+          ...newErrs[i],
+          price: num > 0 ? undefined : "Price must be positive",
+        };
+      }
+      return newErrs;
+    });
   };
 
   const onSubmit: SubmitHandler<ServiceFormData> = async (data) => {
     setServerError(null);
     setPublishing(true);
     try {
-      const price = parseFloat(packages[0].price || '0');
+      const price = parseFloat(packages[0].price || "0");
       const serviceData = {
         ...data,
         price,
@@ -174,15 +201,16 @@ const onFileChange = (files: FileList | null) => {
       onServiceAdded(res.data);
       reset();
       setMediaFiles([]);
-      setPackages([{ name: '', price: '' }]);
+      setPackages([{ name: "", price: "" }]);
+      setPackageErrors([{}]);
       setStep(0);
       onClose();
     } catch (err: unknown) {
-      console.error('Service creation error:', err);
+      console.error("Service creation error:", err);
       const msg =
         err instanceof Error
           ? err.message
-          : 'An unexpected error occurred. Failed to create service.';
+          : "An unexpected error occurred. Failed to create service.";
       setServerError(msg);
     } finally {
       setPublishing(false);
@@ -192,7 +220,8 @@ const onFileChange = (files: FileList | null) => {
   const handleCancel = () => {
     reset();
     setMediaFiles([]);
-    setPackages([{ name: '', price: '' }]);
+    setPackages([{ name: "", price: "" }]);
+    setPackageErrors([{}]);
     setStep(0);
     onClose();
   };
@@ -200,10 +229,18 @@ const onFileChange = (files: FileList | null) => {
   if (!isOpen) return null;
 
   const types = [
-    { value: 'Live Performance', label: 'Live Performance', Icon: MusicalNoteIcon },
-    { value: 'Personalized Video', label: 'Personalized Video', Icon: VideoCameraIcon },
-    { value: 'Custom Song', label: 'Custom Song', Icon: SparklesIcon },
-    { value: 'Other', label: 'Other', Icon: SquaresPlusIcon },
+    {
+      value: "Live Performance",
+      label: "Live Performance",
+      Icon: MusicalNoteIcon,
+    },
+    {
+      value: "Personalized Video",
+      label: "Personalized Video",
+      Icon: VideoCameraIcon,
+    },
+    { value: "Custom Song", label: "Custom Song", Icon: SparklesIcon },
+    { value: "Other", label: "Other", Icon: SquaresPlusIcon },
   ];
 
   const earnings =
@@ -235,276 +272,323 @@ const onFileChange = (files: FileList | null) => {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="m-auto bg-white w-[80%] max-w-5xl h-[90vh] rounded-lg overflow-auto p-6">
-          <Stepper
-            steps={steps.slice(0, 4)}
-            currentStep={step}
-            maxStepCompleted={maxStep}
-          onStepClick={(i) => i <= maxStep + 1 && setStep(i)}
-        />
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-          {step === 0 && (
-            <div>
-              <h2 className="text-xl font-semibold mb-4">
-                Choose Your Service Category
-              </h2>
-              <div className="grid grid-cols-2 gap-4">
-                {types.map(({ value, label, Icon }) => (
-                  <button
-                    type="button"
-                    key={value}
-                    data-value={value}
-                    onClick={() => setValue('service_type', value)}
-                    className={clsx(
-                      'flex flex-col items-center p-4 border rounded-md',
-                      watch('service_type') === value
-                        ? 'border-brand bg-brand-light'
-                        : 'border-gray-300',
-                    )}
-                  >
-                    <Icon className="h-8 w-8 mb-2" />
-                    <span>{label}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-          {step === 1 && (
-            <div className="space-y-4">
-              <h2 className="text-xl font-semibold">Service Details</h2>
-              <TextInput
-                label="Service Title"
-                {...register('title', {
-                  required: 'Service title is required',
-                  minLength: { value: 5, message: 'Must be at least 5 characters' },
-                  maxLength: { value: 60, message: 'Must be at most 60 characters' },
-                })}
-              />
-              <p className="text-xs text-right text-gray-500">
-                {(watchTitle || '').length}/60
-              </p>
-              <TextArea
-                label="Description"
-                rows={4}
-                {...register('description', {
-                  required: 'Description is required',
-                  minLength: { value: 20, message: 'Must be at least 20 characters' },
-                  maxLength: { value: 500, message: 'Must be at most 500 characters' },
-                })}
-              />
-              <p className="text-xs text-right text-gray-500">
-                {(watchDescription || '').length}/500
-              </p>
-              <TextInput
-                label="Duration (minutes)"
-                type="number"
-                {...register('duration_minutes', {
-                  required: 'Duration is required',
-                  valueAsNumber: true,
-                  min: { value: 1, message: 'Minimum 1' },
-                })}
-              />
-              <div className="flex items-center gap-2">
-                <ToggleSwitch
-                  checked={watch('is_remote')}
-                  onChange={(v) => setValue('is_remote', v)}
-                  label="Remote"
+            <Dialog.Panel className="m-auto bg-white w-full sm:w-[80%] max-w-5xl h-[90vh] rounded-lg p-6">
+              <div className="flex flex-col h-full">
+                <Stepper
+                  steps={steps.slice(0, 4)}
+                  currentStep={step}
+                  maxStepCompleted={maxStep}
+                  onStepClick={(i) => i <= maxStep + 1 && setStep(i)}
+                  ariaLabel="Add service progress"
                 />
-              </div>
-              {errors.title && (
-                <p className="text-sm text-red-600">{errors.title.message}</p>
-              )}
-              {errors.description && (
-                <p className="text-sm text-red-600">{errors.description.message}</p>
-              )}
-              {errors.duration_minutes && (
-                <p className="text-sm text-red-600">
-                  {errors.duration_minutes.message}
-                </p>
-              )}
-            </div>
-          )}
-          {step === 2 && (
-            <div>
-              <h2 className="text-xl font-semibold mb-4">Upload Media</h2>
-              <label
-                htmlFor="media-upload"
-                className="border-2 border-dashed rounded-md p-6 text-center cursor-pointer"
-                onDragOver={(e) => {
-                  e.preventDefault();
-                }}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  onFileChange(e.dataTransfer.files);
-                }}
-                data-testid="dropzone"
-              >
-                <p>Drag files here or click to upload</p>
-                <input
-                  id="media-upload"
-                  ref={fileInputRef}
-                  type="file"
-                  multiple
-                  accept="image/*,audio/*,video/*"
-                  className="hidden"
-                  onChange={(e) => onFileChange(e.target.files)}
-                />
-              </label>
-              {mediaError && (
-                <p className="text-sm text-red-600 mt-2">{mediaError}</p>
-              )}
-              <div className="flex flex-wrap gap-2 mt-4">
-                {mediaFiles.map((file, i) => (
-                  <div
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={i}
-                    className="relative w-24 h-24 border rounded overflow-hidden"
-                  >
-                    {file.type.startsWith('image/') ? (
-                      <img
-                        src={URL.createObjectURL(file)}
-                        alt={file.name}
-                        className="object-cover w-full h-full"
-                      />
-                    ) : (
-                      <span className="text-xs break-all p-1">{file.name}</span>
-                    )}
-                    <button
-                      type="button"
-                      onClick={() => removeFile(i)}
-                      className="absolute top-0 right-0 bg-black/50 text-white rounded-full w-4 h-4 text-xs"
-                    >
-                      ×
-                    </button>
-                  </div>
-                ))}
-              </div>
-              <p className="mt-4 text-sm text-gray-500">
-                Use at least 5 high-res photos (1024×683px) and a short video demo.
-              </p>
-            </div>
-          )}
-          {step === 3 && (
-            <div className="space-y-4">
-              <h2 className="text-xl font-semibold">Packages & Pricing</h2>
-              {packages.map((pkg, i) => (
-                <div
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={i}
-                  className="border rounded-md p-4 space-y-2"
+                <form
+                  onSubmit={handleSubmit(onSubmit)}
+                  className="flex flex-col flex-1 overflow-auto space-y-6"
                 >
-                  <TextInput
-                    label="Name"
-                    value={pkg.name}
-                    onChange={(e) => updatePackage(i, 'name', e.target.value)}
-                    name={`packages[${i}].name`}
-                  />
-                  <TextInput
-                    label={`Price (${DEFAULT_CURRENCY})`}
-                    type="number"
-                    step="0.01"
-                    value={pkg.price}
-                    onChange={(e) => updatePackage(i, 'price', e.target.value)}
-                    name={`packages[${i}].price`}
-                  />
-                </div>
-              ))}
-              {packages.length < 3 && (
-                <Button type="button" variant="secondary" onClick={addPackage}>
-                  + Add Another Package
-                </Button>
-              )}
-              {earnings !== null && (
-                <p className="text-sm text-gray-600">
-                  Estimated monthly earnings{' '}
-                  {Intl.NumberFormat('en-ZA', {
-                    style: 'currency',
-                    currency: DEFAULT_CURRENCY,
-                  }).format(earnings)}
-                </p>
-              )}
-            </div>
-          )}
-          {step === 4 && (
-            <div className="space-y-4">
-              <h2 className="text-xl font-semibold">Review Your Service</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="border rounded-md p-4">
-                  <h3 className="font-medium">Type</h3>
-                  <p>{watch('service_type')}</p>
-                </div>
-                <div className="border rounded-md p-4">
-                  <h3 className="font-medium">Title</h3>
-                  <p>{watch('title')}</p>
-                </div>
-                <div className="border rounded-md p-4">
-                  <h3 className="font-medium">Description</h3>
-                  <p>{watch('description')}</p>
-                </div>
-                <div className="border rounded-md p-4">
-                  <h3 className="font-medium">Duration</h3>
-                  <p>{watch('duration_minutes')} minutes</p>
-                </div>
-                <div className="border rounded-md p-4 col-span-full">
-                  <h3 className="font-medium">Packages</h3>
-                  {packages.map((p, idx) => (
-                    <p key={idx}>{p.name}: {p.price}</p>
-                  ))}
-                </div>
-                {mediaFiles.filter((f) => f.type.startsWith('image/')).length > 0 && (
-                  <div className="border rounded-md p-4 col-span-full">
-                    <h3 className="font-medium">Images</h3>
-                    <div className="flex flex-wrap gap-2 mt-2">
-                      {mediaFiles
-                        .filter((f) => f.type.startsWith('image/'))
-                        .map((file, i) => (
-                          <img
+                  {step === 0 && (
+                    <div>
+                      <h2 className="text-xl font-semibold mb-4">
+                        Choose Your Service Category
+                      </h2>
+                      <div className="grid grid-cols-2 gap-4">
+                        {types.map(({ value, label, Icon }) => (
+                          <button
+                            type="button"
+                            key={value}
+                            data-value={value}
+                            onClick={() => setValue("service_type", value)}
+                            className={clsx(
+                              "flex flex-col items-center p-4 border rounded-md",
+                              watch("service_type") === value
+                                ? "border-brand bg-brand-light"
+                                : "border-gray-300",
+                            )}
+                          >
+                            <Icon className="h-8 w-8 mb-2" />
+                            <span>{label}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {step === 1 && (
+                    <div className="space-y-4">
+                      <h2 className="text-xl font-semibold">Service Details</h2>
+                      <TextInput
+                        label="Service Title"
+                        {...register("title", {
+                          required: "Service title is required",
+                          minLength: {
+                            value: 5,
+                            message: "Must be at least 5 characters",
+                          },
+                          maxLength: {
+                            value: 60,
+                            message: "Must be at most 60 characters",
+                          },
+                        })}
+                      />
+                      <p className="text-xs text-right text-gray-500">
+                        {(watchTitle || "").length}/60
+                      </p>
+                      <TextArea
+                        label="Description"
+                        rows={4}
+                        {...register("description", {
+                          required: "Description is required",
+                          minLength: {
+                            value: 20,
+                            message: "Must be at least 20 characters",
+                          },
+                          maxLength: {
+                            value: 500,
+                            message: "Must be at most 500 characters",
+                          },
+                        })}
+                      />
+                      <p className="text-xs text-right text-gray-500">
+                        {(watchDescription || "").length}/500
+                      </p>
+                      <TextInput
+                        label="Duration (minutes)"
+                        type="number"
+                        {...register("duration_minutes", {
+                          required: "Duration is required",
+                          valueAsNumber: true,
+                          min: { value: 1, message: "Minimum 1" },
+                        })}
+                      />
+                      <div className="flex items-center gap-2">
+                        <ToggleSwitch
+                          checked={watch("is_remote")}
+                          onChange={(v) => setValue("is_remote", v)}
+                          label="Remote"
+                        />
+                      </div>
+                      {errors.title && (
+                        <p className="text-sm text-red-600">
+                          {errors.title.message}
+                        </p>
+                      )}
+                      {errors.description && (
+                        <p className="text-sm text-red-600">
+                          {errors.description.message}
+                        </p>
+                      )}
+                      {errors.duration_minutes && (
+                        <p className="text-sm text-red-600">
+                          {errors.duration_minutes.message}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {step === 2 && (
+                    <div>
+                      <h2 className="text-xl font-semibold mb-4">
+                        Upload Media
+                      </h2>
+                      <label
+                        htmlFor="media-upload"
+                        className="border-2 border-dashed rounded-md p-6 text-center cursor-pointer"
+                        aria-label="Upload service media"
+                        onDragOver={(e) => {
+                          e.preventDefault();
+                        }}
+                        onDrop={(e) => {
+                          e.preventDefault();
+                          onFileChange(e.dataTransfer.files);
+                        }}
+                        data-testid="dropzone"
+                      >
+                        <p>Drag files here or click to upload</p>
+                        <input
+                          id="media-upload"
+                          ref={fileInputRef}
+                          type="file"
+                          multiple
+                          accept="image/*"
+                          className="hidden"
+                          onChange={(e) => onFileChange(e.target.files)}
+                        />
+                      </label>
+                      {mediaError && (
+                        <p className="text-sm text-red-600 mt-2">
+                          {mediaError}
+                        </p>
+                      )}
+                      <div className="flex flex-wrap gap-2 mt-4">
+                        {mediaFiles.map((file, i) => (
+                          <div
                             // eslint-disable-next-line react/no-array-index-key
                             key={i}
-                            src={URL.createObjectURL(file)}
-                            alt={file.name}
-                            className="w-16 h-16 object-cover rounded"
-                          />
+                            className="relative w-24 h-24 border rounded overflow-hidden"
+                          >
+                            {file.type.startsWith("image/") ? (
+                              <img
+                                src={URL.createObjectURL(file)}
+                                alt={file.name}
+                                className="object-cover w-full h-full"
+                              />
+                            ) : (
+                              <span className="text-xs break-all p-1">
+                                {file.name}
+                              </span>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => removeFile(i)}
+                              className="absolute top-0 right-0 bg-black/50 text-white rounded-full w-4 h-4 text-xs"
+                            >
+                              ×
+                            </button>
+                          </div>
                         ))}
+                      </div>
+                      <p className="mt-4 text-sm text-gray-500">
+                        Use at least 5 high-res photos (1024×683px) and a short
+                        video demo.
+                      </p>
                     </div>
+                  )}
+                  {step === 3 && (
+                    <div className="space-y-4">
+                      <h2 className="text-xl font-semibold">
+                        Packages & Pricing
+                      </h2>
+                      {packages.map((pkg, i) => (
+                        <div
+                          // eslint-disable-next-line react/no-array-index-key
+                          key={i}
+                          className="border rounded-md p-4 space-y-2"
+                        >
+                          <TextInput
+                            label="Name"
+                            value={pkg.name}
+                            onChange={(e) =>
+                              updatePackage(i, "name", e.target.value)
+                            }
+                            name={`packages[${i}].name`}
+                            error={packageErrors[i]?.name}
+                          />
+                          <TextInput
+                            label={`Price (${DEFAULT_CURRENCY})`}
+                            type="number"
+                            step="0.01"
+                            value={pkg.price}
+                            onChange={(e) =>
+                              updatePackage(i, "price", e.target.value)
+                            }
+                            name={`packages[${i}].price`}
+                            error={packageErrors[i]?.price}
+                          />
+                        </div>
+                      ))}
+                      {packages.length < 3 && (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          onClick={addPackage}
+                        >
+                          + Add Another Package
+                        </Button>
+                      )}
+                      {earnings !== null && (
+                        <p className="text-sm text-gray-600">
+                          Estimated monthly earnings{" "}
+                          {Intl.NumberFormat("en-ZA", {
+                            style: "currency",
+                            currency: DEFAULT_CURRENCY,
+                          }).format(earnings)}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {step === 4 && (
+                    <div className="space-y-4">
+                      <h2 className="text-xl font-semibold">
+                        Review Your Service
+                      </h2>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="border rounded-md p-4">
+                          <h3 className="font-medium">Type</h3>
+                          <p>{watch("service_type")}</p>
+                        </div>
+                        <div className="border rounded-md p-4">
+                          <h3 className="font-medium">Title</h3>
+                          <p>{watch("title")}</p>
+                        </div>
+                        <div className="border rounded-md p-4">
+                          <h3 className="font-medium">Description</h3>
+                          <p>{watch("description")}</p>
+                        </div>
+                        <div className="border rounded-md p-4">
+                          <h3 className="font-medium">Duration</h3>
+                          <p>{watch("duration_minutes")} minutes</p>
+                        </div>
+                        <div className="border rounded-md p-4 col-span-full">
+                          <h3 className="font-medium">Packages</h3>
+                          {packages.map((p, idx) => (
+                            <p key={idx}>
+                              {p.name}: {p.price}
+                            </p>
+                          ))}
+                        </div>
+                        {mediaFiles.filter((f) => f.type.startsWith("image/"))
+                          .length > 0 && (
+                          <div className="border rounded-md p-4 col-span-full">
+                            <h3 className="font-medium">Images</h3>
+                            <div className="flex flex-wrap gap-2 mt-2">
+                              {mediaFiles
+                                .filter((f) => f.type.startsWith("image/"))
+                                .map((file, i) => (
+                                  <img
+                                    // eslint-disable-next-line react/no-array-index-key
+                                    key={i}
+                                    src={URL.createObjectURL(file)}
+                                    alt={file.name}
+                                    className="w-16 h-16 object-cover rounded"
+                                  />
+                                ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                      {serverError && (
+                        <p className="text-sm text-red-600">{serverError}</p>
+                      )}
+                    </div>
+                  )}
+                  <div className="flex justify-between pt-4">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={step === 0 ? handleCancel : prev}
+                      data-testid="back"
+                    >
+                      {step === 0 ? "Cancel" : "Back"}
+                    </Button>
+                    {step < steps.length - 1 && (
+                      <Button
+                        type="button"
+                        onClick={next}
+                        disabled={nextDisabled()}
+                        data-testid="next"
+                      >
+                        Next
+                      </Button>
+                    )}
+                    {step === steps.length - 1 && (
+                      <Button
+                        type="submit"
+                        isLoading={publishing || isSubmitting}
+                        disabled={publishing || isSubmitting || nextDisabled()}
+                      >
+                        Publish
+                      </Button>
+                    )}
                   </div>
-                )}
+                </form>
               </div>
-              {serverError && (
-                <p className="text-sm text-red-600">{serverError}</p>
-              )}
-            </div>
-          )}
-          <div className="flex justify-between pt-4">
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={step === 0 ? handleCancel : prev}
-              data-testid="back"
-            >
-              {step === 0 ? 'Cancel' : 'Back'}
-            </Button>
-            {step < steps.length - 1 && (
-              <Button
-                type="button"
-                onClick={next}
-                disabled={nextDisabled()}
-                data-testid="next"
-              >
-                Next
-              </Button>
-            )}
-            {step === steps.length - 1 && (
-              <Button
-                type="submit"
-                isLoading={publishing || isSubmitting}
-                disabled={publishing || isSubmitting || nextDisabled()}
-              >
-                Publish
-              </Button>
-            )}
-          </div>
-        </form>
             </Dialog.Panel>
           </Transition.Child>
         </div>

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -1,20 +1,20 @@
-import { createRoot } from 'react-dom/client';
-import React from 'react';
-import { act } from 'react';
-import AddServiceModal from '../AddServiceModal';
-import * as api from '@/lib/api';
-import { flushPromises } from '@/test/utils/flush';
+import { createRoot } from "react-dom/client";
+import React from "react";
+import { act } from "react";
+import AddServiceModal from "../AddServiceModal";
+import * as api from "@/lib/api";
+import { flushPromises } from "@/test/utils/flush";
 
-describe('AddServiceModal wizard', () => {
+describe("AddServiceModal wizard", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    jest.spyOn(api, 'createService').mockResolvedValue({ data: { id: 1 } });
-    jest.spyOn(api, 'getDashboardStats').mockResolvedValue({
+    jest.spyOn(api, "createService").mockResolvedValue({ data: { id: 1 } });
+    jest.spyOn(api, "getDashboardStats").mockResolvedValue({
       data: { monthly_new_inquiries: 1, profile_views: 0, response_rate: 0 },
     });
   });
@@ -27,7 +27,7 @@ describe('AddServiceModal wizard', () => {
     jest.clearAllMocks();
   });
 
-  it('completes the flow and publishes the service', async () => {
+  it("completes the flow and publishes the service", async () => {
     await act(async () => {
       root.render(
         React.createElement(AddServiceModal, {
@@ -38,73 +38,140 @@ describe('AddServiceModal wizard', () => {
       );
     });
 
-    const typeButton = container.querySelector('button[data-value="Live Performance"]') as HTMLButtonElement;
+    const typeButton = container.querySelector(
+      'button[data-value="Live Performance"]',
+    ) as HTMLButtonElement;
     act(() => {
-      typeButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      typeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    const next1 = container.querySelector('button[data-testid="next"]') as HTMLButtonElement;
+    const next1 = container.querySelector(
+      'button[data-testid="next"]',
+    ) as HTMLButtonElement;
     act(() => {
-      next1.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    const titleInput = container.querySelector('input[name="title"]') as HTMLInputElement;
-    const descInput = container.querySelector('textarea[name="description"]') as HTMLTextAreaElement;
-    const durationInput = container.querySelector('input[type="number"]') as HTMLInputElement;
-
-    act(() => {
-      titleInput.value = 'My Service';
-      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
-      descInput.value = 'A great service description that is long enough.';
-      descInput.dispatchEvent(new Event('input', { bubbles: true }));
-      durationInput.value = '30';
-      durationInput.dispatchEvent(new Event('input', { bubbles: true }));
+      next1.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const next2 = container.querySelector('button[data-testid="next"]') as HTMLButtonElement;
+    const titleInput = container.querySelector(
+      'input[name="title"]',
+    ) as HTMLInputElement;
+    const descInput = container.querySelector(
+      'textarea[name="description"]',
+    ) as HTMLTextAreaElement;
+    const durationInput = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+
     act(() => {
-      next2.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      titleInput.value = "My Service";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      descInput.value = "A great service description that is long enough.";
+      descInput.dispatchEvent(new Event("input", { bubbles: true }));
+      durationInput.value = "30";
+      durationInput.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
-    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const file = new File(['a'], 'a.jpg', { type: 'image/jpeg' });
+    const next2 = container.querySelector(
+      'button[data-testid="next"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      next2.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["a"], "a.jpg", { type: "image/jpeg" });
     await act(async () => {
-      Object.defineProperty(fileInput, 'files', { value: [file] });
-      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+      Object.defineProperty(fileInput, "files", { value: [file] });
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
     });
 
-    const next3 = container.querySelector('button[data-testid="next"]') as HTMLButtonElement;
+    const next3 = container.querySelector(
+      'button[data-testid="next"]',
+    ) as HTMLButtonElement;
     act(() => {
-      next3.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next3.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const nameInput = container.querySelector('input[name="packages[0].name"]') as HTMLInputElement;
-    const priceInput = container.querySelector('input[name="packages[0].price"]') as HTMLInputElement;
+    const nameInput = container.querySelector(
+      'input[name="packages[0].name"]',
+    ) as HTMLInputElement;
+    const priceInput = container.querySelector(
+      'input[name="packages[0].price"]',
+    ) as HTMLInputElement;
     act(() => {
-      nameInput.value = 'Basic';
-      nameInput.dispatchEvent(new Event('input', { bubbles: true }));
-      priceInput.value = '100';
-      priceInput.dispatchEvent(new Event('input', { bubbles: true }));
+      nameInput.value = "Basic";
+      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+      priceInput.value = "100";
+      priceInput.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
-    const next4 = container.querySelector('button[data-testid="next"]') as HTMLButtonElement;
+    const next4 = container.querySelector(
+      'button[data-testid="next"]',
+    ) as HTMLButtonElement;
     act(() => {
-      next4.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next4.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const publish = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    const publish = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
     await act(async () => {
-      publish.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      publish.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await flushPromises();
     });
 
     expect(api.createService).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: 'My Service',
-        description: 'A great service description that is long enough.',
-        service_type: 'Live Performance',
+        title: "My Service",
+        description: "A great service description that is long enough.",
+        service_type: "Live Performance",
         duration_minutes: 30,
         price: 100,
       }),
     );
+  });
+
+  it("closes when pressing Escape", async () => {
+    const onClose = jest.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(AddServiceModal, {
+          isOpen: true,
+          onClose,
+          onServiceAdded: jest.fn(),
+        }),
+      );
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when Cancel clicked on first step", async () => {
+    const onClose = jest.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(AddServiceModal, {
+          isOpen: true,
+          onClose,
+          onServiceAdded: jest.fn(),
+        }),
+      );
+    });
+
+    const cancelBtn = container.querySelector(
+      'button[data-testid="back"]',
+    ) as HTMLButtonElement;
+    act(() => {
+      cancelBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- refine AddServiceModal stepper and dialog layout
- enforce image-only uploads and package field validation
- add accessibility tweaks and cancel/escape tests

## Testing
- `SKIP_BACKEND=1 bash ./scripts/test-all.sh` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884eba55ea4832e98d3b11453e5b263