### PR TITLE
Fix modal overlay pointer events

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -260,7 +260,7 @@ export default function AddServiceModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Dialog.Overlay className="fixed inset-0 bg-gray-800 bg-opacity-50" />
+          <Dialog.Overlay className="fixed inset-0 bg-gray-800 bg-opacity-50 pointer-events-none" />
         </Transition.Child>
         <div className="flex min-h-full items-center justify-center">
           <Transition.Child
@@ -272,7 +272,7 @@ export default function AddServiceModal({
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <Dialog.Panel className="m-auto bg-white w-full sm:w-[80%] max-w-5xl h-[90vh] rounded-lg p-6">
+            <Dialog.Panel className="pointer-events-auto m-auto bg-white w-full sm:w-[80%] max-w-5xl h-[90vh] rounded-lg p-6">
               <div className="flex flex-col h-full">
                 <Stepper
                   steps={steps.slice(0, 4)}


### PR DESCRIPTION
## Summary
- avoid overlay blocking clicks by using pointer-events-none on AddServiceModal overlay

## Testing
- `setup.sh`
- `scripts/test-all.sh` *(fails: repository has no remote origin)*

------
https://chatgpt.com/codex/tasks/task_e_6884ee26cdbc832e8906411005d78089