### PR TITLE
Fix Google Maps env var

### DIFF
--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -33,7 +33,7 @@ export default function CustomLocationInput({
     placePredictions,
     getPlacePredictions,
   } = usePlacesService({
-    apiKey: process.env.NEXT_PUBLIC_Maps_API_KEY,
+    apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
     debounce: 300,
   });
 


### PR DESCRIPTION
## Summary
- fix misnamed env var in LocationInput

## Testing
- `./scripts/test-all.sh` *(no tests ran)*
- `./scripts/test-frontend.sh --unit` *(tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884f4cc8210832eb53573b469b6c3b0