### PR TITLE
Fix AddServiceModal overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Reordering keeps the first card below the **Your Services** heading by constraining drag movement to the list area.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a full-screen wizard. Steps appear in a coral-accented stepper with keyboard focus trapping. The final review mirrors earlier steps with image thumbnails before publishing.
+* The wizard uses a semi-transparent black overlay (`bg-black/40`) so the modal stands out and clicking outside closes it.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.
 * Mobile-friendly dashboard cards for bookings and requests with larger service action buttons.
 * "Your Services" now appears in a collapsible section just like booking requests, keeping the dashboard tidy.

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -260,7 +260,7 @@ export default function AddServiceModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-10 pointer-events-none" />
+          <Dialog.Overlay className="fixed inset-0 bg-black/40" />
         </Transition.Child>
         <div className="flex min-h-full items-center justify-center p-0 sm:p-4">
           <Transition.Child


### PR DESCRIPTION
## Summary
- darken AddService wizard overlay so the modal stands out
- document overlay style in README

## Testing
- `npm ci` *(fails: many peer dependency warnings)*
- `npm test` *(fails: jest not found once node_modules removed; tests had failures earlier)*

------
https://chatgpt.com/codex/tasks/task_e_6884fea4e9ec832ea88dcdd5d628d458