### PR TITLE
Fix Add Service modal overlay

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -261,7 +261,7 @@ export default function AddServiceModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Dialog.Overlay className="fixed inset-0 bg-white" />
+          <Dialog.Overlay className="fixed inset-0 bg-white z-40" />
         </Transition.Child>
         <div className="flex min-h-full items-center justify-center p-0 sm:p-4">
           <Transition.Child
@@ -273,7 +273,7 @@ export default function AddServiceModal({
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-          <Dialog.Panel className="pointer-events-auto flex flex-col h-[90vh] w-full sm:max-w-4xl rounded-2xl shadow-2xl bg-white">
+          <Dialog.Panel className="pointer-events-auto flex flex-col h-[90vh] w-full sm:max-w-4xl rounded-2xl shadow-2xl bg-white z-50">
               <div className="flex flex-col h-full">
                 <Stepper
                   steps={steps.slice(0, 4)}


### PR DESCRIPTION
## Summary
- ensure Add Service modal panel shows above the white overlay

## Testing
- `./scripts/test-backend.sh` *(fails: OperationalError)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_688510b2cc44832e8d9261745423bfa9