### PR TITLE
Use new status badge classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The client user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.
 - Artist profile picture uploads now update the account avatar so the image persists after logout and page refreshes. When logged in as an artist, the profile picture from **Edit Profile** is shown across the site, including the top navigation menu.
 - Booking request cards now show the client's profile picture when available so requests are easier to identify.
+- Status badges on booking request cards now use classes like `status-badge-quote-provided` for consistent colors.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -8,40 +8,32 @@ import {
   MicrophoneIcon,
   MusicalNoteIcon,
 } from '@heroicons/react/24/outline';
-import { BookingRequest, User } from '@/types';
+import { BookingRequest } from '@/types';
 import { formatStatus } from '@/lib/utils';
 import { Avatar } from '../ui';
 import { buttonVariants } from '@/styles/buttonVariants';
 
-const STATUS_COLORS: Record<
-  'pending' | 'pendingAction' | 'quoted' | 'booked' | 'declined',
-  string
-> = {
-  pending: 'bg-yellow-100 text-yellow-800',
-  pendingAction: 'bg-orange-100 text-orange-800',
-  quoted: 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]',
-  booked: 'bg-brand-light text-brand-dark',
-  declined: 'bg-red-100 text-red-800',
-};
-
-const getStatusColor = (status: string): string => {
+const getBadgeClass = (status: string): string => {
   if (
     status.includes('declined') ||
     status.includes('rejected') ||
     status.includes('withdrawn')
   ) {
-    return STATUS_COLORS.declined;
+    return 'status-badge-declined';
   }
   if (status.includes('confirmed') || status.includes('accepted')) {
-    return STATUS_COLORS.booked;
+    return 'status-badge-confirmed';
   }
-  if (status !== 'pending_quote' && status.includes('quote')) {
-    return STATUS_COLORS.quoted;
+  if (status === 'pending_quote') {
+    return 'status-badge-pending-quote';
   }
-  if (status !== 'pending_quote' && status.includes('pending')) {
-    return STATUS_COLORS.pendingAction;
+  if (status.includes('quote')) {
+    return 'status-badge-quote-provided';
   }
-  return STATUS_COLORS.pending;
+  if (status.includes('pending')) {
+    return 'status-badge-pending-action';
+  }
+  return 'status-badge-pending-quote';
 };
 
 export interface BookingRequestCardProps {
@@ -74,11 +66,7 @@ export default function BookingRequestCard({ req }: BookingRequestCardProps) {
         </div>
       </div>
       <div className="flex flex-col items-end gap-2">
-        <span
-          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${getStatusColor(
-            req.status,
-          )}`}
-        >
+        <span className={getBadgeClass(req.status)}>
           {formatStatus(req.status)}
         </span>
         <Link

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -77,13 +77,13 @@ describe('BookingRequestCard', () => {
     expect(img).toBeNull();
   });
 
-  it('applies different badge colors based on status', () => {
+  it('applies status badge classes based on status', () => {
     const cases: [string, string][] = [
-      ['pending_quote', 'bg-yellow-100'],
-      ['pending_artist_confirmation', 'bg-orange-100'],
-      ['quote_provided', 'bg-[var(--color-accent)]/10'],
-      ['request_confirmed', 'bg-brand-light'],
-      ['request_declined', 'bg-red-100'],
+      ['pending_quote', 'status-badge-pending-quote'],
+      ['pending_artist_confirmation', 'status-badge-pending-action'],
+      ['quote_provided', 'status-badge-quote-provided'],
+      ['request_confirmed', 'status-badge-confirmed'],
+      ['request_declined', 'status-badge-declined'],
     ];
     cases.forEach(([status, expected]) => {
       act(() => {
@@ -93,8 +93,8 @@ describe('BookingRequestCard', () => {
           }),
         );
       });
-      const badge = container.querySelector('span.inline-flex') as HTMLSpanElement;
-      expect(badge.className).toContain(expected);
+      const badge = container.querySelector('span[class*=\"status-badge\"]') as HTMLSpanElement;
+      expect(badge?.className).toContain(expected);
     });
   });
 });


### PR DESCRIPTION
## Summary
- show new dashboard status badges on booking request cards
- update tests for new status badge classes
- mention status-badge CSS in README

## Testing
- `npm test -- --runTestsByPath src/components/dashboard/__tests__/BookingRequestCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688533977628832eacb99f3ba7dfeee6