### PR TITLE
Fix dashboard progress bar selectors

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -182,7 +182,9 @@ describe('DashboardPage artist stats', () => {
   });
 
   it('shows profile progress bar', () => {
-    const bar = container.querySelector('[data-testid="profile-progress"] div') as HTMLDivElement;
+    const bar = container.querySelector(
+      '[data-testid="profile-progress"] .progress-bar-fill'
+    ) as HTMLDivElement;
     expect(bar.style.width).toBe('100%');
 
   });

--- a/frontend/src/components/dashboard/__tests__/ProfileProgress.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/ProfileProgress.test.tsx
@@ -25,7 +25,9 @@ describe('ProfileProgress component', () => {
       root.render(<ProfileProgress profile={profile} />);
     });
 
-    const inner = container.querySelector('[data-testid="profile-progress"] div') as HTMLDivElement;
+    const inner = container.querySelector(
+      '[data-testid="profile-progress"] .progress-bar-fill'
+    ) as HTMLDivElement;
     expect(inner.style.width).toBe('100%');
 
     act(() => {


### PR DESCRIPTION
## Summary
- update test selectors for new progress bar class

## Testing
- `./scripts/test-all.sh` *(fails: jest not found initially, later tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688534e8467c832e8ef9e8c277bcd453