### PR TITLE
Add dashboard overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,16 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking requests on the dashboard can now be **sorted and filtered** client-side.
 ![Mobile dashboard states](docs/mobile_dashboard_states.svg)
 
+### Redesigned Dashboard
+
+The dashboard brings common actions to the surface with a tidy layout:
+
+* **Profile progress** – a bar at the top shows how complete your artist profile is. Updating services and media increases the percentage so you know when you are ready to promote your page.
+* **Quick actions** – buttons for adding a service, updating your calendar, or sending a quote appear below the progress bar so frequent tasks are one tap away.
+* **Bookings and requests lists** – the next five upcoming bookings and newest requests are summarized in side-by-side cards. Each list links to a dedicated page where you can manage the full history.
+
+![Dashboard components](docs/dashboard_overview.svg)
+
 ### Artist Availability
 
 * `GET /api/v1/artist-profiles/{artist_id}/availability` returns `unavailable_dates`.

--- a/docs/dashboard_overview.md
+++ b/docs/dashboard_overview.md
@@ -1,0 +1,10 @@
+# Dashboard Overview
+
+The redesigned dashboard organizes key information in cards and highlights what needs attention.
+
+- **Profile progress bar** – displays how complete your artist profile is. Uploading media, adding services and filling out your bio all increase the percentage.
+- **Quick actions** – primary tasks such as adding a service, updating availability or sending a quote are presented as buttons right below the progress bar.
+- **Bookings list** – shows upcoming confirmed bookings with a link to view them all.
+- **Requests list** – summarizes recent booking requests and links to the full requests page.
+
+See `docs/dashboard_overview.svg` for a high level illustration.

--- a/docs/dashboard_overview.svg
+++ b/docs/dashboard_overview.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200">
+  <rect x="0" y="0" width="400" height="200" fill="#ffffff" />
+  <rect x="20" y="20" width="360" height="10" fill="#4ade80" />
+  <text x="200" y="15" text-anchor="middle" font-size="10" fill="#333">Profile 75%</text>
+  <rect x="20" y="40" width="80" height="20" fill="#f0f0f0" stroke="#ccc" />
+  <text x="60" y="55" text-anchor="middle" font-size="10" fill="#333">Add Service</text>
+  <rect x="120" y="40" width="80" height="20" fill="#f0f0f0" stroke="#ccc" />
+  <text x="160" y="55" text-anchor="middle" font-size="10" fill="#333">Update Calendar</text>
+  <rect x="220" y="40" width="80" height="20" fill="#f0f0f0" stroke="#ccc" />
+  <text x="260" y="55" text-anchor="middle" font-size="10" fill="#333">Request Quote</text>
+  <rect x="20" y="80" width="160" height="100" fill="#fafafa" stroke="#ccc" />
+  <text x="100" y="95" text-anchor="middle" font-size="12" fill="#333">Bookings</text>
+  <rect x="200" y="80" width="180" height="100" fill="#fafafa" stroke="#ccc" />
+  <text x="290" y="95" text-anchor="middle" font-size="12" fill="#333">Requests</text>
+</svg>


### PR DESCRIPTION
## Summary
- document redesigned dashboard details in README
- add a screenshot and doc describing dashboard components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688537b38ef0832e9e6feee06444c893