### PR TITLE
Fix dashboard badge css apply error

### DIFF
--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -39,7 +39,8 @@
 }
 
 .status-badge-quote-provided {
-  @apply status-badge bg-[var(--color-accent)]/10 text-[var(--color-accent)];
+  @apply status-badge text-[var(--color-accent)];
+  background-color: rgb(236 72 153 / 0.1); /* 10% accent tint */
 }
 
 .status-badge-pending-quote {


### PR DESCRIPTION
## Summary
- fix accent status badge using RGB color since Tailwind `@apply` can't process `bg-[var(--color-accent)]/10`

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 21 failed, 50 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885396f70d0832e8fbbab9a557a70f0