### PR TITLE
Implement travel forecast API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ For setup instructions see [README.md](README.md).
 |-------|---------|-----------|---------|
 | **Booking Request** | Orchestrates the booking wizard and business rules | `backend/app/api/api_booking_request.py`<br>`frontend/src/components/booking/BookingWizard.tsx` | When a client submits or updates a booking |
 | **Provider Matching** | Selects sound and accommodation providers | `backend/app/crud/crud_service.py`<br>`backend/app/api/api_service.py` | During booking and quote steps |
-| **Travel & Accommodation** | Calculates travel distance and lodging costs | `backend/app/services/booking_quote.py`<br>`frontend/src/app/quote-calculator/page.tsx` | When estimating travel or lodging expenses |
+| **Travel & Accommodation** | Calculates travel distance, lodging costs, and now weather forecasts | `backend/app/services/booking_quote.py`<br>`backend/app/api/api_weather.py`<br>`frontend/src/app/quote-calculator/page.tsx` | When estimating travel or lodging expenses |
 | **Quote Generator** | Gathers performance, provider, travel, and accommodation costs | `backend/app/api/api_quote.py`<br>`frontend/src/components/booking/MessageThread.tsx` | After all booking info is entered |
 | **Quote Preview** | Shows an estimated total during the review step | `frontend/src/components/booking/steps/ReviewStep.tsx` | Right before submitting a booking request |
 | **Review** | Manages star ratings and comments for completed bookings | `backend/app/api/api_review.py`<br>`frontend/src/app/artists/[id]/page.tsx` | After a booking is marked completed |
@@ -42,9 +42,9 @@ For setup instructions see [README.md](README.md).
 
 ### 3. Travel & Accommodation Agent
 
-* **Purpose:** Calculates travel distance and optional lodging costs so quotes stay accurate.
+* **Purpose:** Calculates travel distance and optional lodging costs so quotes stay accurate. The agent also retrieves 3-day weather forecasts for trip planning.
 * **Frontend:** `quote-calculator/page.tsx` lets artists preview travel and accommodation fees.
-* **Backend:** `booking_quote.py` exposes helpers used by the quote API.
+* **Backend:** `booking_quote.py` exposes helpers used by the quote API. `/api/v1/travel-forecast` lives in `api_weather.py` and fetches forecast data from `wttr.in`.
 
 ### 4. Quote Generator
 

--- a/README.md
+++ b/README.md
@@ -1122,6 +1122,13 @@ include this query string so clients can pay with one click.
 
 All prices and quotes now default to **South African Rand (ZAR)**. Update your environment or tests if you previously assumed USD values.
 
+### Travel Forecast
+
+```
+GET /api/v1/travel-forecast?location={city}
+```
+Returns a 3-day weather outlook for the provided location using data from `wttr.in`. Invalid locations return a structured 422 response with `{"location": "Unknown location"}` in `field_errors`.
+
 ### Invoices
 
 ```

--- a/backend/app/api/api_weather.py
+++ b/backend/app/api/api_weather.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException, Query, status
+import logging
+
+from ..utils.errors import error_response
+from ..services import weather_service
+
+router = APIRouter(tags=["travel-forecast"])
+logger = logging.getLogger(__name__)
+
+
+@router.get("/travel-forecast")
+def travel_forecast(location: str = Query(..., min_length=1)):
+    """Return a 3-day weather forecast for the destination."""
+    try:
+        return weather_service.get_3day_forecast(location)
+    except weather_service.LocationNotFoundError:
+        raise error_response("Invalid location", {"location": "Unknown location"})
+    except weather_service.WeatherAPIError as exc:  # pragma: no cover - network
+        logger.error("Weather API error for %s: %s", location, exc, exc_info=True)
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail="Weather service error")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,6 +58,7 @@ from .api import (
     api_calendar,
     api_quote_template,
     api_settings,
+    api_weather,
 )
 
 # The “artist‐profiles” router lives under app/api/v1/
@@ -295,6 +296,13 @@ app.include_router(
     api_settings.router,
     prefix=f"{api_prefix}",
     tags=["settings"],
+)
+
+# ─── TRAVEL FORECAST ROUTES (under /api/v1) ─────────────────────────────
+app.include_router(
+    api_weather.router,
+    prefix=f"{api_prefix}",
+    tags=["travel-forecast"],
 )
 
 

--- a/backend/app/services/weather_service.py
+++ b/backend/app/services/weather_service.py
@@ -1,0 +1,34 @@
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
+class WeatherAPIError(Exception):
+    """General weather service failure."""
+
+class LocationNotFoundError(Exception):
+    """Raised when the service cannot find the location."""
+
+
+def get_3day_forecast(location: str) -> dict:
+    """Return a 3-day weather forecast for the given location."""
+    url = f"https://wttr.in/{location}"
+    try:
+        resp = httpx.get(url, params={"format": "j1"}, timeout=10)
+        resp.raise_for_status()
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.error("Weather API request failed: %s", exc, exc_info=True)
+        raise WeatherAPIError("Weather service unreachable") from exc
+
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        logger.error("Weather API returned invalid JSON: %s", exc, exc_info=True)
+        raise WeatherAPIError("Invalid response from weather service") from exc
+
+    forecast = data.get("weather")
+    if not forecast:
+        logger.warning("No forecast data returned for location %s", location)
+        raise LocationNotFoundError(location)
+
+    return {"location": location, "forecast": forecast[:3]}

--- a/backend/tests/test_weather_endpoint.py
+++ b/backend/tests/test_weather_endpoint.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+import app.api.api_weather as api_weather
+from app.main import app
+
+
+def test_travel_forecast_success(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"weather": [1, 2, 3, 4]}
+
+        return Resp()
+
+    monkeypatch.setattr(api_weather.weather_service.httpx, "get", fake_get)
+    client = TestClient(app)
+    res = client.get("/api/v1/travel-forecast", params={"location": "Paris"})
+    assert res.status_code == 200
+    assert res.json() == {"location": "Paris", "forecast": [1, 2, 3]}
+
+
+def test_travel_forecast_invalid_location(monkeypatch):
+    def fake_get(url, params=None, timeout=10):
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        return Resp()
+
+    monkeypatch.setattr(api_weather.weather_service.httpx, "get", fake_get)
+    client = TestClient(app)
+    res = client.get("/api/v1/travel-forecast", params={"location": "Nowhere"})
+    assert res.status_code == 422
+    data = res.json()
+    assert data["detail"]["field_errors"]["location"] == "Unknown location"


### PR DESCRIPTION
## Summary
- add weather service and `/travel-forecast` endpoint
- document the feature in `README.md` and `AGENTS.md`
- test the new API

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_weather_endpoint.py -q`
- `npm run lint` *(fails: '_ref' is defined but never used ...')*
- `./scripts/test-all.sh` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_68853a7cd6a4832ea2bf395c97b6b368