### PR TITLE
Improve dashboard error messages

### DIFF
--- a/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/ServiceDeleteConfirmation.test.tsx
@@ -6,6 +6,7 @@ import * as api from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from 'next/navigation';
 import { Service } from '@/types';
+import { flushPromises } from '@/test/utils/flush';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
@@ -73,6 +74,21 @@ describe('Service deletion confirmation', () => {
     });
     expect(window.confirm).toHaveBeenCalled();
     expect(api.deleteService).toHaveBeenCalledWith(service.id);
+    window.confirm = originalConfirm;
+  });
+
+  it('shows error message when deletion fails', async () => {
+    (api.deleteService as jest.Mock).mockRejectedValue(new Error('fail'));
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+    const deleteBtn = container.querySelector('button[aria-label="Delete"]') as HTMLButtonElement;
+    await act(async () => {
+      deleteBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(container.textContent).toContain('Failed to delete service');
     window.confirm = originalConfirm;
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -320,6 +320,7 @@ export default function DashboardPage() {
       setServices((prev) => prev.filter((s) => s.id !== id));
     } catch (err) {
       console.error("Service delete error:", err);
+      setError("Failed to delete service. Please try again.");
     }
   };
 
@@ -335,6 +336,9 @@ export default function DashboardPage() {
       );
     } catch (err) {
       console.error("Service reorder error:", err);
+      setError(
+        "Failed to update service order. Your changes may not be saved."
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- log dashboard errors more clearly and surface alerts for service actions
- test service deletion failure shows the alert

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 51 failed, 3 skipped, 266 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68853ce70f0c832ea8f791e2364b0a1b