### PR TITLE
Update dashboard UI and metrics

### DIFF
--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -177,8 +177,6 @@ describe('DashboardPage artist stats', () => {
     expect(container.textContent).toContain('3');
     expect(container.textContent).toContain('Profile Views');
     expect(container.textContent).toContain('5');
-    expect(container.textContent).toContain('Response Rate');
-    expect(container.textContent).toContain('50%');
   });
 
   it('shows profile progress bar', () => {
@@ -380,7 +378,7 @@ describe('DashboardPage list toggles', () => {
   });
 
   it('renders booking requests section', () => {
-    expect(container.textContent).toContain('Booking Requests');
+    expect(container.textContent).toContain('Recent Booking Requests');
   });
 });
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -22,9 +22,9 @@ import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
 import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
 import ProfileProgress from "@/components/dashboard/ProfileProgress";
-import OverviewAccordion from "@/components/dashboard/OverviewAccordion";
 import SectionList from "@/components/dashboard/SectionList";
 import BookingRequestCard from "@/components/dashboard/BookingRequestCard";
+import OverviewCard from "@/components/dashboard/OverviewCard";
 import CollapsibleSection from "@/components/ui/CollapsibleSection";
 import { Spinner, Button } from '@/components/ui';
 import DashboardTabs from "@/components/dashboard/DashboardTabs";
@@ -40,7 +40,6 @@ import {
   CalendarDaysIcon,
   EyeIcon,
   EnvelopeIcon,
-  ChatBubbleLeftRightIcon,
   MusicalNoteIcon,
   BanknotesIcon,
 } from "@heroicons/react/24/outline";
@@ -217,8 +216,11 @@ export default function DashboardPage() {
   const overviewSecondary = useMemo(() => {
     if (user?.user_type !== 'artist' || !dashboardStats) return [] as { label: string; value: string | number; icon: React.ReactNode }[];
     return [
-      { label: 'Profile Views', value: dashboardStats.profile_views, icon: <EyeIcon className="w-5 h-5" /> },
-      { label: 'Response Rate', value: `${dashboardStats.response_rate}%`, icon: <ChatBubbleLeftRightIcon className="w-5 h-5" /> },
+      {
+        label: 'Profile Views',
+        value: dashboardStats.profile_views,
+        icon: <EyeIcon className="w-5 h-5" />,
+      },
     ];
   }, [user, dashboardStats]);
 
@@ -452,11 +454,23 @@ export default function DashboardPage() {
           )}
 
           {/* Stats */}
-          <div className="mt-8 space-y-2">
-            <OverviewAccordion
-              primaryStats={overviewPrimary}
-              secondaryStats={overviewSecondary}
-            />
+          <div className="mt-8 grid grid-cols-2 gap-3">
+            {overviewPrimary.map((s) => (
+              <OverviewCard
+                key={s.label}
+                label={s.label}
+                value={s.value}
+                icon={s.icon ?? null}
+              />
+            ))}
+            {overviewSecondary.map((s) => (
+              <OverviewCard
+                key={s.label}
+                label={s.label}
+                value={s.value}
+                icon={s.icon ?? null}
+              />
+            ))}
           </div>
 
           <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
@@ -476,8 +490,8 @@ export default function DashboardPage() {
                 <div className="flex items-center space-x-3 p-3 rounded-lg bg-gray-50 border border-gray-200">
                   <div className="text-brand-primary text-xl">📊</div>
                   <div>
-                    <p className="text-sm text-gray-500">Response Rate</p>
-                    <p className="text-lg font-medium text-gray-800">{dashboardStats?.response_rate ?? 0}%</p>
+                    <p className="text-sm text-gray-500">Profile Views</p>
+                    <p className="text-lg font-medium text-gray-800">{dashboardStats?.profile_views ?? 0}</p>
                   </div>
                 </div>
                 <div className="flex items-center space-x-3 p-3 rounded-lg bg-gray-50 border border-gray-200">
@@ -515,26 +529,29 @@ export default function DashboardPage() {
           </div>
 
           {activeTab === 'requests' && (
-            <>
-              <div className="flex space-x-2 mb-2">
+            <section className="bg-white rounded-xl shadow-custom p-6 mb-10">
+              <h2 className="text-2xl font-bold text-gray-800 mb-6">
+                Recent Booking Requests
+              </h2>
+              <div className="flex flex-col md:flex-row gap-4 mb-4">
                 <select
+                  aria-label="Sort requests"
                   data-testid="request-sort"
+                  className="border border-gray-300 rounded-md p-2 text-sm text-gray-700 bg-white focus:ring-brand-primary focus:border-brand-primary flex-1"
                   value={requestSort}
                   onChange={(e) =>
                     setRequestSort(e.target.value as 'newest' | 'oldest')
                   }
-                  aria-label="Sort requests"
-                  className="border rounded-md p-1 text-sm"
                 >
-                  <option value="newest">Newest</option>
-                  <option value="oldest">Oldest</option>
+                  <option value="newest">Newest First</option>
+                  <option value="oldest">Oldest First</option>
                 </select>
                 <select
+                  aria-label="Filter requests"
                   data-testid="request-status"
+                  className="border border-gray-300 rounded-md p-2 text-sm text-gray-700 bg-white focus:ring-brand-primary focus:border-brand-primary flex-1"
                   value={requestStatusFilter}
                   onChange={(e) => setRequestStatusFilter(e.target.value)}
-                  aria-label="Filter requests"
-                  className="border rounded-md p-1 text-sm"
                 >
                   <option value="">All Statuses</option>
                   <option value="pending_quote">Pending Quote</option>
@@ -542,23 +559,27 @@ export default function DashboardPage() {
                   <option value="completed">Completed</option>
                 </select>
               </div>
-              <SectionList
-                title="Booking Requests"
-                data={visibleRequests}
-                defaultOpen={false}
-                emptyState={<span>No bookings yet</span>}
-                renderItem={(req) => (
-                  <BookingRequestCard key={req.id} req={req} />
+              <ul className="space-y-4">
+                {visibleRequests.map((req) => (
+                  <li key={req.id}>
+                    <BookingRequestCard req={req} />
+                  </li>
+                ))}
+                {visibleRequests.length === 0 && (
+                  <li className="text-sm text-gray-500">No bookings yet</li>
                 )}
-                footer={
-                  bookingRequests.length > visibleRequests.length ? (
-                    <Link href="/booking-requests" className="text-brand-dark hover:underline text-sm">
-                      View All Requests
-                    </Link>
-                  ) : null
-                }
-              />
-            </>
+              </ul>
+              {bookingRequests.length > visibleRequests.length && (
+                <div className="mt-6 text-center">
+                  <Link
+                    href="/booking-requests"
+                    className="text-brand-primary hover:underline text-sm font-medium"
+                  >
+                    View All Requests
+                  </Link>
+                </div>
+              )}
+            </section>
           )}
 
           {activeTab === 'bookings' && (

--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -50,11 +50,16 @@ export default function BookingRequestCard({ req }: BookingRequestCardProps) {
   const formattedDate = format(new Date(req.created_at), 'dd MMM yyyy');
 
   return (
-    <div className="flex justify-between rounded-lg bg-white shadow p-4">
-      <div className="flex gap-4">
-        <Avatar src={avatarSrc} initials={clientName.charAt(0)} size={48} />
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center p-4 rounded-lg bg-gray-50 border border-gray-200 shadow-sm">
+      <div className="flex gap-4 items-center">
+        <Avatar
+          src={avatarSrc}
+          initials={clientName.charAt(0)}
+          size={48}
+          className="bg-blue-100 w-12 h-12"
+        />
         <div>
-          <div className="font-bold text-gray-900">{clientName}</div>
+          <div className="font-bold text-gray-800">{clientName}</div>
           <div className="flex items-center gap-1 text-sm text-gray-600">
             <ServiceIcon className="w-4 h-4" />
             <span>{req.service?.title || '—'}</span>
@@ -65,13 +70,11 @@ export default function BookingRequestCard({ req }: BookingRequestCardProps) {
           </div>
         </div>
       </div>
-      <div className="flex flex-col items-end gap-2">
-        <span className={getBadgeClass(req.status)}>
-          {formatStatus(req.status)}
-        </span>
+      <div className="flex flex-col items-end gap-2 mt-3 sm:mt-0">
+        <span className={getBadgeClass(req.status)}>{formatStatus(req.status)}</span>
         <Link
           href={`/booking-requests/${req.id}`}
-          className={`inline-flex items-center gap-1 px-3 py-1.5 text-sm rounded-md ${buttonVariants.primary}`}
+          className="inline-flex items-center gap-1 px-4 py-2 text-sm rounded-md bg-brand-primary hover:opacity-90 text-white font-semibold transition shadow-md"
         >
           Manage
         </Link>


### PR DESCRIPTION
## Summary
- remove collapsible overview accordion and show all stats in a grid
- display profile views instead of response rate in the response & activity card
- restyle booking request cards and section
- update corresponding tests

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: unable to fetch from origin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688541d15168832e955a96c80a3d68f3