### PR TITLE
Update dashboard stats layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,10 +905,10 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking request cards now include a **Manage Request** link that opens the request details page.
 * Improved dashboard stats layout. Artists now see a monthly earnings card.
 
-* Dashboard overview now also shows **New Inquiries This Month**, **Profile Views**, and **Response Rate**.
+* Dashboard overview now highlights **New Inquiries**, **Total Services**, and **Earnings This Month**.
 
-* A profile completion progress bar now appears above the dashboard stats for artists.
-* Stats cards use a new **OverviewAccordion** component for expandable details.
+* A profile completion progress bar still appears above the dashboard stats for artists.
+* Stats cards use a simple grid layout for quick reference.
 
 * Currency values now use consistent locale formatting with `formatCurrency()`.
 * Service API responses now include a `currency` field.

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -173,7 +173,7 @@ describe('DashboardPage artist stats', () => {
 
 
   it('renders new dashboard metrics', () => {
-    expect(container.textContent).toContain('New Inquiries This Month');
+    expect(container.textContent).toContain('New Inquiries');
     expect(container.textContent).toContain('3');
     expect(container.textContent).toContain('Profile Views');
     expect(container.textContent).toContain('5');

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -24,7 +24,6 @@ import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
 import ProfileProgress from "@/components/dashboard/ProfileProgress";
 import SectionList from "@/components/dashboard/SectionList";
 import BookingRequestCard from "@/components/dashboard/BookingRequestCard";
-import OverviewCard from "@/components/dashboard/OverviewCard";
 import CollapsibleSection from "@/components/ui/CollapsibleSection";
 import { Spinner, Button } from '@/components/ui';
 import DashboardTabs from "@/components/dashboard/DashboardTabs";
@@ -35,14 +34,7 @@ import {
   PencilIcon,
   TrashIcon,
 } from "@heroicons/react/24/solid";
-import {
-  Bars3Icon,
-  CalendarDaysIcon,
-  EyeIcon,
-  EnvelopeIcon,
-  MusicalNoteIcon,
-  BanknotesIcon,
-} from "@heroicons/react/24/outline";
+import { Bars3Icon } from "@heroicons/react/24/outline";
 
 interface ServiceCardProps {
   service: Service;
@@ -180,9 +172,6 @@ export default function DashboardPage() {
 
   // Aggregated totals for dashboard statistics
   const servicesCount = services.length;
-  const totalEarnings = bookings
-    .filter((booking) => booking.status === "completed")
-    .reduce((acc, booking) => acc + booking.total_price, 0);
   const earningsThisMonth = bookings
     .filter((booking) => {
       if (booking.status !== "completed") return false;
@@ -195,34 +184,27 @@ export default function DashboardPage() {
     })
     .reduce((acc, booking) => acc + booking.total_price, 0);
 
-  const overviewPrimary = useMemo(() => {
-    const cards: { label: string; value: string | number; icon: React.ReactNode }[] = [
-      { label: 'Total Bookings', value: bookings.length, icon: <CalendarDaysIcon className="w-5 h-5" /> },
+  const statCards = useMemo(() => {
+    const stats: { label: string; value: string | number; color: string }[] = [
+      { label: 'Total Bookings', value: bookings.length, color: 'text-brand-primary' },
     ];
     if (user?.user_type === 'artist') {
-      cards.push(
+      stats.push(
         {
-          label: 'New Inquiries This Month',
+          label: 'New Inquiries',
           value: dashboardStats?.monthly_new_inquiries ?? 0,
-          icon: <EnvelopeIcon className="w-5 h-5" />,
+          color: 'text-brand-accent',
         },
-        { label: 'Total Services', value: servicesCount, icon: <MusicalNoteIcon className="w-5 h-5" /> },
-        { label: 'Earnings This Month', value: formatCurrency(earningsThisMonth), icon: <BanknotesIcon className="w-5 h-5" /> },
+        { label: 'Total Services', value: servicesCount, color: 'text-brand-primary' },
+        {
+          label: 'Earnings This Month',
+          value: formatCurrency(earningsThisMonth),
+          color: 'text-brand-secondary',
+        },
       );
     }
-    return cards.slice(0, 4);
+    return stats.slice(0, 4);
   }, [bookings.length, user, servicesCount, earningsThisMonth, dashboardStats]);
-
-  const overviewSecondary = useMemo(() => {
-    if (user?.user_type !== 'artist' || !dashboardStats) return [] as { label: string; value: string | number; icon: React.ReactNode }[];
-    return [
-      {
-        label: 'Profile Views',
-        value: dashboardStats.profile_views,
-        icon: <EyeIcon className="w-5 h-5" />,
-      },
-    ];
-  }, [user, dashboardStats]);
 
   const visibleRequests = useMemo(() => {
     const filtered = bookingRequests.filter(
@@ -454,24 +436,17 @@ export default function DashboardPage() {
           )}
 
           {/* Stats */}
-          <div className="mt-8 grid grid-cols-2 gap-3">
-            {overviewPrimary.map((s) => (
-              <OverviewCard
-                key={s.label}
-                label={s.label}
-                value={s.value}
-                icon={s.icon ?? null}
-              />
+          <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-10">
+            {statCards.map((stat) => (
+              <div
+                key={stat.label}
+                className="bg-white rounded-xl shadow-custom p-5 text-center"
+              >
+                <p className="text-sm text-gray-500 mb-1">{stat.label}</p>
+                <h2 className={`text-3xl font-bold ${stat.color}`}>{stat.value}</h2>
+              </div>
             ))}
-            {overviewSecondary.map((s) => (
-              <OverviewCard
-                key={s.label}
-                label={s.label}
-                value={s.value}
-                icon={s.icon ?? null}
-              />
-            ))}
-          </div>
+          </section>
 
           <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
             <div className="bg-white rounded-xl shadow-custom p-6">


### PR DESCRIPTION
## Summary
- restyle artist dashboard stats with a simplified grid
- update unit tests to match new label
- document the updated overview layout in README

## Testing
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: DashboardPage accepted quote label, BookingWizard flow, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688543d852d4832ea1270a417ae93ebd