### PR TITLE
Add booking request search & load more

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ The dashboard brings common actions to the surface with a tidy layout:
 
 * **Profile progress** – a bar at the top shows how complete your artist profile is. Updating services and media increases the percentage so you know when you are ready to promote your page.
 * **Quick actions** – buttons for adding a service, updating your calendar, or sending a quote appear below the progress bar so frequent tasks are one tap away.
-* **Bookings and requests lists** – the next five upcoming bookings and newest requests are summarized in side-by-side cards. Each list links to a dedicated page where you can manage the full history.
+* **Bookings and requests lists** – the next five upcoming bookings and newest requests are summarized in side-by-side cards. Use the **Load More** button to reveal additional requests in batches of five.
 
 ![Dashboard components](docs/dashboard_overview.svg)
 

--- a/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/DashboardPage.test.tsx
@@ -527,8 +527,8 @@ describe('DashboardPage bookings link', () => {
   });
 });
 
-describe('DashboardPage booking requests link', () => {
-  it('shows link to all requests when more than five exist', async () => {
+describe('DashboardPage booking requests load more', () => {
+  it('loads more requests when button clicked', async () => {
     (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, user_type: 'artist', email: 'a@example.com' } });
     const requests = Array.from({ length: 6 }).map((_, i) => ({
@@ -567,8 +567,20 @@ describe('DashboardPage booking requests link', () => {
       await flushPromises();
     });
     }
-    const link = container.querySelector('a[href="/booking-requests"]');
-    expect(link).toBeTruthy();
+    const list = container.querySelectorAll('li');
+    expect(list.length).toBe(5);
+    const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Load More'),
+    ) as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    await act(async () => {
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    const updated = container.querySelectorAll('li');
+    expect(updated.length).toBe(6);
     act(() => {
       root.unmount();
     });

--- a/frontend/src/app/dashboard/__tests__/RequestSortFilter.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/RequestSortFilter.test.tsx
@@ -111,4 +111,16 @@ describe('DashboardPage booking request sort and filter', () => {
     expect(items.length).toBe(1);
     expect(items[0].textContent).toContain('C2');
   });
+
+  it('filters booking requests by client name', async () => {
+    const input = container.querySelector('input[aria-label="Search by client name"]') as HTMLInputElement;
+    await act(async () => {
+      input.value = 'C2';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flushPromises();
+    const items = container.querySelectorAll('li');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('C2');
+  });
 });


### PR DESCRIPTION
## Summary
- dashboard: add client name search field and Load More button
- support incremental request loading logic
- update dashboard tests for search and pagination
- document Load More behavior in README

## Testing
- `npm ci`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: getFullImageUrl is not defined and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885470c0c88832e866b63823bc72098