### PR TITLE
Fix service card reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - A **Leave Review** button now appears in chat when a completed booking has no review.
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
+- Artists can also drag and drop service cards on the dashboard to set their display order.
 - Quote modal items can now be removed even when only one item is present.
 - Clients can upload and crop a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.
 - The client user menu now links to an **Account** page where you can update your profile picture, export data, or delete the account.

--- a/docs/dashboard_overview.md
+++ b/docs/dashboard_overview.md
@@ -6,5 +6,6 @@ The redesigned dashboard organizes key information in cards and highlights what 
 - **Quick actions** – primary tasks such as adding a service, requesting reviews, boosting a service, viewing quotes, or accessing provider and quote calculator resources are presented as buttons right below the progress bar.
 - **Bookings list** – shows upcoming confirmed bookings with a link to view them all.
 - **Requests list** – summarizes recent booking requests and links to the full requests page.
+- **Service cards** – drag and drop services to reorder how they appear to clients.
 
 See `docs/dashboard_overview.svg` for a high level illustration.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -17,7 +17,12 @@ import {
   deleteService,
 } from "@/lib/api";
 import { format } from "date-fns";
-import { formatCurrency, normalizeService, formatStatus } from "@/lib/utils";
+import {
+  formatCurrency,
+  normalizeService,
+  formatStatus,
+  applyDisplayOrder,
+} from "@/lib/utils";
 import AddServiceModal from "@/components/dashboard/AddServiceModal";
 import EditServiceModal from "@/components/dashboard/EditServiceModal";
 import UpdateRequestModal from "@/components/dashboard/UpdateRequestModal";
@@ -307,6 +312,8 @@ export default function DashboardPage() {
 
   const [isReordering, setIsReordering] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  // Store the most recent drag order so we persist the correct sequence
+  const latestOrderRef = useRef<Service[]>([]);
 
   const persistServiceOrder = async (ordered: Service[]) => {
     try {
@@ -324,7 +331,8 @@ export default function DashboardPage() {
   };
 
   const handleReorder = (newOrder: Service[]) => {
-    const updated = newOrder.map((s, i) => ({ ...s, display_order: i + 1 }));
+    const updated = applyDisplayOrder(newOrder);
+    latestOrderRef.current = updated;
     setServices(updated);
     setIsReordering(true);
   };
@@ -332,7 +340,7 @@ export default function DashboardPage() {
   const handleDragEnd = () => {
     if (isReordering) {
       setIsReordering(false);
-      persistServiceOrder(services);
+      persistServiceOrder(latestOrderRef.current);
     }
   };
 

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatCurrency,
   formatStatus,
   generateQuoteNumber,
+  applyDisplayOrder,
 } from '../utils';
 import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
@@ -52,6 +53,18 @@ describe('normalizeService', () => {
     expect(typeof normalized.duration_minutes).toBe('number');
     expect(normalized.price).toBeCloseTo(12.5);
     expect(normalized.duration_minutes).toBe(30);
+  });
+});
+
+describe('applyDisplayOrder', () => {
+  it('increments display_order sequentially', () => {
+    const services: Service[] = [
+      { id: 1, artist_id: 1, title: 'A', description: '', service_type: 'Other', duration_minutes: 10, display_order: 5, price: 1, artist: {} as ArtistProfile },
+      { id: 2, artist_id: 1, title: 'B', description: '', service_type: 'Other', duration_minutes: 10, display_order: 2, price: 1, artist: {} as ArtistProfile },
+    ];
+    const ordered = applyDisplayOrder(services);
+    expect(ordered[0].display_order).toBe(1);
+    expect(ordered[1].display_order).toBe(2);
   });
 });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -71,6 +71,13 @@ export const normalizeService = (service: Service): Service => ({
       : service.duration_minutes,
 });
 
+/**
+ * Apply sequential display_order values to the provided services.
+ * The returned array maintains the input order.
+ */
+export const applyDisplayOrder = (services: Service[]): Service[] =>
+  services.map((s, i) => ({ ...s, display_order: i + 1 }));
+
 export const normalizeQuoteTemplate = (
   tmpl: QuoteTemplate,
 ): QuoteTemplate => ({


### PR DESCRIPTION
## Summary
- allow dashboard service card drag order persistence
- add applyDisplayOrder helper
- test display order helper
- document dashboard service card reordering

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: TypeError in test_google_calendar)*

------
https://chatgpt.com/codex/tasks/task_e_6885bc506194832e9b000970092bcf07