### PR TITLE
Fix service card drag layout on dashboard

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -626,7 +626,7 @@ export default function DashboardPage() {
                   values={services}
                   onReorder={handleReorder}
                   layoutScroll
-                  className="mt-2 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+                  className={`mt-2 grid gap-6 ${isReordering ? 'grid-cols-1' : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'}`}
                 >
                   {services.map((service) => (
                     <ServiceCard


### PR DESCRIPTION
## Summary
- adjust dashboard service grid to become a single column while reordering

## Testing
- `npm ci` *(install deps)*
- `./scripts/test-all.sh` *(fails: cannot fetch remote)*
- `npm test -- --runInBand` *(fails: 52 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885bef341bc832e8af8defd6a26335d