### PR TITLE
Update input styling

### DIFF
--- a/frontend/src/components/ui/TextArea.tsx
+++ b/frontend/src/components/ui/TextArea.tsx
@@ -13,16 +13,20 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ label, id, error, loading = false, className, ...props }, ref) => (
     <div className="w-full">
       {label && (
-        <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor={id}
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
           {label}
         </label>
       )}
-      <div className="mt-1 relative">
+      <div className="relative">
         <textarea
           ref={ref}
           id={id}
           className={clsx(
-            'block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
+            'block w-full rounded-lg border bg-white px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-brand-dark focus:ring-2 focus:ring-brand-dark sm:text-sm',
+            error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
             className,
           )}
           {...props}

--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -19,16 +19,20 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInpu
   return (
     <div className="w-full">
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor={inputId}
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
           {label}
         </label>
       )}
-      <div className="mt-1 relative">
+      <div className="relative">
         <input
           ref={ref}
           id={inputId}
           className={clsx(
-            'block w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand sm:text-sm',
+            'block w-full rounded-lg border bg-white px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-brand-dark focus:ring-2 focus:ring-brand-dark sm:text-sm',
+            error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
             className,
           )}
           {...props}


### PR DESCRIPTION
## Summary
- refine TextInput and TextArea components with rounded borders and padding

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: LocationStep selection shows map after selecting a place)*

------
https://chatgpt.com/codex/tasks/task_e_6885efbdcf58832eac0451f9b4776a71