### PR TITLE
Improve input focus styles

### DIFF
--- a/frontend/src/components/ui/TextArea.tsx
+++ b/frontend/src/components/ui/TextArea.tsx
@@ -25,8 +25,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           ref={ref}
           id={id}
           className={clsx(
-            'block w-full rounded-lg border bg-white px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-brand-dark focus:ring-2 focus:ring-brand-dark sm:text-sm',
-            error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-2 focus:border-[#FF5A5F] sm:text-sm',
+            error && 'border-red-500',
             className,
           )}
           {...props}

--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -31,8 +31,8 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInpu
           ref={ref}
           id={inputId}
           className={clsx(
-            'block w-full rounded-lg border bg-white px-3 py-2 text-gray-900 placeholder-gray-400 focus:border-brand-dark focus:ring-2 focus:ring-brand-dark sm:text-sm',
-            error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-2 focus:border-[#FF5A5F] sm:text-sm',
+            error && 'border-red-500',
             className,
           )}
           {...props}


### PR DESCRIPTION
## Summary
- tweak TextInput and TextArea styles to remove browser outlines
- use thicker brand border on focus

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: getFullImageUrl is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6885fa0e0934832eaff567e0bc6bf01e