### PR TITLE
Update brand colors to pink palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,9 +1222,9 @@ NEXT_PUBLIC_DEFAULT_CURRENCY=EUR
 ### Brand Colors
 
 The frontend uses a small **brand** palette defined in `tailwind.config.js`. The
-primary hue is indigo (`#6366f1`), with `brand-dark` and `brand-light` variants.
-Components reference these via utility classes such as `bg-brand` and
-`bg-brand-dark`.
+primary hue is now pink (`#FF5A5F`) with matching dark and light variants.
+These values are exposed as CSS variables in `globals.css` and referenced via
+utility classes such as `bg-brand` and `bg-brand-dark`.
 
 
 ### Help Prompt

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,16 +4,16 @@
 
 :root {
   --font-sans: var(--font-inter);
-  --color-primary: #6366f1;
-  --color-secondary: #4f46e5;
-  --color-accent: #ec4899;
-  --color-border: #e5e7eb;
+  --color-primary: #FF5A5F;
+  --color-secondary: #E04852;
+  --color-accent: #FF7A85;
+  --color-border: #FFD0D3;
   --color-background: #ffffff;
   --color-foreground: #111827;
   --brand-color: var(--color-primary);
   --brand-color-dark: var(--color-secondary);
   /* lighter tint used for subtle page gradients */
-  --brand-color-light: #eef2ff;
+  --brand-color-light: #FFEAEA;
   --color-link: var(--brand-color-dark);
   --color-link-hover: var(--brand-color);
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -23,14 +23,14 @@ module.exports = {
           light: 'var(--brand-color-light)',
         },
         wizard: {
-          step: '#6366f1',
+          step: 'var(--color-primary)',
           pending: '#e5e7eb',
         },
         primary: {
           DEFAULT: 'var(--color-primary)',
-          50: '#EEF2FF',
-          600: '#4F46E5',
-          700: '#4338CA',
+          50: '#FFEAEA',
+          600: '#FF5A5F',
+          700: '#E04852',
         },
         secondary: 'var(--color-secondary)',
         accent: 'var(--color-accent)',


### PR DESCRIPTION
## Summary
- update brand variables in `globals.css` to a pink palette
- use the variables in Tailwind config
- document the palette change in the README

## Testing
- `npm install --silent` in `frontend`
- `./scripts/test-all.sh` *(fails: getFullImageUrl not defined and other Jest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885fbad2c78832ea72d2b3c8dc45c2c