### PR TITLE
Update button styles with brand color

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,13 +23,16 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 ## UI Theme
 
 Reusable style constants are defined in `src/styles`. Button variants come from
-`buttonVariants.ts` so colors stay consistent across the app. A new `link`
+`buttonVariants.ts` so colors stay consistent across the app. The base `Button`
+component now uses a `rounded-lg` radius for a softer look. A new `link`
 variant provides a text-only style for inline actions. The Tailwind
 configuration includes this directory in its `content` array so these constant
 class names are preserved during production builds.
 All text inputs should use the `TextInput` component in `src/components/ui` so
 form fields share consistent spacing and focus styles.
 The `Stepper` progress bar highlights the active step with `bg-brand` and `text-brand-dark` to reinforce the brand palette.
+
+Primary, secondary and outline buttons now use the brand color for borders and background with a subtle shadow hover transition.
 
 ### Loading Indicators
 

--- a/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
+++ b/frontend/src/components/review/__tests__/ReviewFormModal.test.tsx
@@ -29,9 +29,9 @@ describe('ReviewFormModal', () => {
     const textarea = div.querySelector('textarea');
 
     expect(ratingLabel?.textContent).toBe('Rating');
-    expect(ratingInput.className).toContain('rounded-md');
+    expect(ratingInput.className).toContain('rounded-lg');
     expect(commentLabel?.textContent).toBe('Comment');
-    expect(textarea?.className).toContain('rounded-md');
+    expect(textarea?.className).toContain('rounded-lg');
 
     act(() => {
       root.unmount();

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -31,7 +31,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ? 'px-3 py-1.5 text-sm'
         : 'px-4 py-2 text-sm';
     const base =
-      'inline-flex items-center justify-center rounded-md font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform transition-colors active:scale-95 min-h-12 min-w-12';
+      'inline-flex items-center justify-center rounded-lg font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform transition-colors active:scale-95 min-h-12 min-w-12';
     const variantClass = buttonVariants[variant];
     return (
       <button

--- a/frontend/src/styles/__tests__/buttonVariants.test.ts
+++ b/frontend/src/styles/__tests__/buttonVariants.test.ts
@@ -6,7 +6,7 @@ describe('buttonVariants', () => {
   });
 
   it('provides classes for secondary buttons', () => {
-    expect(buttonVariants.secondary).toMatch('border-gray-300');
+    expect(buttonVariants.secondary).toMatch('border-brand');
   });
 
   it('provides classes for danger buttons', () => {

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,9 +1,10 @@
 export const buttonVariants = {
-  primary: 'bg-brand hover:bg-brand-dark text-white focus:ring-brand-dark',
+  primary:
+    'bg-brand text-white hover:bg-brand-dark/90 hover:shadow focus:ring-brand-dark',
   secondary:
-    'bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300',
+    'bg-white border border-brand text-brand hover:bg-brand-light focus:ring-brand',
   outline:
-    'bg-transparent border border-gray-300 text-gray-800 hover:bg-gray-50 focus:ring-gray-300',
+    'bg-transparent border border-brand text-brand hover:bg-brand-light focus:ring-brand',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
   link:
     'bg-transparent underline text-brand-dark hover:text-brand-dark focus:ring-brand px-0 py-0',


### PR DESCRIPTION
## Summary
- bump default Button border radius to `rounded-lg`
- use brand color and shadow hover in button variants
- adjust button variant tests
- expect `rounded-lg` in review form tests
- document new styles in frontend README

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 21 failed, 1 skipped, 73 passed, 94 of 95 total)*

------
https://chatgpt.com/codex/tasks/task_e_6885fbb44bec832e968163be2bd2d97f