### PR TITLE
Update focus styles for TextInput and TextArea

### DIFF
--- a/frontend/src/components/ui/TextArea.tsx
+++ b/frontend/src/components/ui/TextArea.tsx
@@ -25,7 +25,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           ref={ref}
           id={id}
           className={clsx(
-            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-2 focus:border-[#FF5A5F] sm:text-sm',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[#FF5A5F] focus:ring-[#FF5A5F] sm:text-sm',
             error && 'border-red-500',
             className,
           )}

--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -31,7 +31,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInpu
           ref={ref}
           id={inputId}
           className={clsx(
-            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-2 focus:border-[#FF5A5F] sm:text-sm',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[#FF5A5F] focus:ring-[#FF5A5F] sm:text-sm',
             error && 'border-red-500',
             className,
           )}


### PR DESCRIPTION
## Summary
- update focus classes in TextInput and TextArea to use brand color

## Testing
- `./scripts/test-all.sh` *(fails: unable to fetch from origin)*

------
https://chatgpt.com/codex/tasks/task_e_6885fd941d78832eb60959910be1e993