### PR TITLE
Fix Stepper brand color styles

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -302,7 +302,7 @@ export default function AddServiceModal({
                             className={clsx(
                               "flex flex-col items-center justify-center p-6 bg-white rounded-2xl shadow hover:shadow-md transition",
                               watch("service_type") === value
-                                ? "border-2 border-[#FF5A5F]"
+                                ? "border-2 border-[var(--brand-color)]"
                                 : "border border-gray-200",
                             )}
                           >

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -43,9 +43,9 @@ export default function Stepper({
             className={clsx(
               'relative flex items-center justify-center w-5 h-5 rounded-full border',
               isCompleted
-                ? 'bg-[#FF5A5F] border-[#FF5A5F] text-white'
+                ? 'bg-[var(--brand-color)] border-2 border-[var(--brand-color)] text-white'
                 : isActive
-                  ? 'bg-white border-[#FF5A5F] text-[#FF5A5F]'
+                  ? 'bg-white border-2 border-[var(--brand-color)] text-[var(--brand-color)]'
                   : 'bg-white border-gray-300 text-gray-400',
             )}
           >
@@ -57,7 +57,7 @@ export default function Stepper({
           <span
             className={clsx(
               'mt-1 text-xs font-semibold',
-              isActive ? 'text-[#FF5A5F]' : 'text-gray-500',
+              isActive ? 'text-[var(--brand-color)]' : 'text-gray-500',
             )}
           >
             {label}

--- a/frontend/src/components/ui/TextArea.tsx
+++ b/frontend/src/components/ui/TextArea.tsx
@@ -25,7 +25,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           ref={ref}
           id={id}
           className={clsx(
-            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[#FF5A5F] focus:ring-[#FF5A5F] sm:text-sm',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[var(--brand-color)] focus:ring-[var(--brand-color)] sm:text-sm',
             error && 'border-red-500',
             className,
           )}

--- a/frontend/src/components/ui/TextInput.tsx
+++ b/frontend/src/components/ui/TextInput.tsx
@@ -31,7 +31,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInpu
           ref={ref}
           id={inputId}
           className={clsx(
-            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[#FF5A5F] focus:ring-[#FF5A5F] sm:text-sm',
+            'block w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:border-[var(--brand-color)] focus:ring-[var(--brand-color)] sm:text-sm',
             error && 'border-red-500',
             className,
           )}


### PR DESCRIPTION
## Summary
- swap hard-coded brand color for CSS variables
- apply selected border width consistently
- use palette variables for TextInput, TextArea and AddServiceModal

## Testing
- `npx jest --maxWorkers=50% --passWithNoTests` *(fails: getFullImageUrl is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6885fea01bbc832ea5a4b42a86c87798