### PR TITLE
Update tests for brand color classes

### DIFF
--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -114,6 +114,16 @@ describe('Stepper progress bar', () => {
     expect(buttons[1].className).not.toContain('cursor-not-allowed');
   });
 
+  it('uses brand colored border for the active step', () => {
+    act(() => {
+      root.render(<Stepper steps={["One", "Two", "Three"]} currentStep={1} />);
+    });
+    const circles = container.querySelectorAll('button div.relative');
+    const activeCircle = circles[1] as HTMLDivElement;
+    expect(activeCircle.className).toContain('border-[var(--brand-color)]');
+    expect(activeCircle.className).toContain('border-2');
+  });
+
   it('applies focus ring when navigating with the keyboard', () => {
     act(() => {
       root.render(

--- a/frontend/src/components/ui/__tests__/TextInput.test.tsx
+++ b/frontend/src/components/ui/__tests__/TextInput.test.tsx
@@ -53,4 +53,13 @@ describe('TextInput component', () => {
     expect(inputs).toHaveLength(2);
     expect(inputs[0].id).not.toBe(inputs[1].id);
   });
+
+  it('applies brand colored focus styles', () => {
+    act(() => {
+      root.render(<TextInput label="Email" />);
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input.className).toContain('focus:border-[var(--brand-color)]');
+    expect(input.className).toContain('focus:ring-[var(--brand-color)]');
+  });
 });


### PR DESCRIPTION
## Summary
- verify active step border uses brand color
- check text input uses brand color focus styles

## Testing
- `./scripts/test-all.sh` *(fails: test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_688608fc8bec832e81e1f9e791053bb2