### PR TITLE
Fix booking wizard step style

### DIFF
--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -6,6 +6,7 @@ import { uploadBookingAttachment } from '@/lib/api';
 import toast from '../../ui/Toast';
 import { useState } from 'react';
 import { Button } from '../../ui';
+import WizardNav from '../WizardNav';
 
 interface Props {
   control: Control<FieldValues>;
@@ -97,37 +98,14 @@ export default function NotesStep({
           <span className="text-xs">{progress}%</span>
         </div>
       )}
-      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
-        {step > 0 && (
-          <Button
-            type="button"
-            onClick={onBack}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Back
-          </Button>
-        )}
-
-        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <Button
-            type="button"
-            onClick={onSaveDraft}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Save Draft
-          </Button>
-          <Button
-            type="button"
-            onClick={onNext}
-            disabled={uploading}
-            className={`w-full sm:w-auto min-h-[44px] ${uploading ? 'cursor-not-allowed opacity-50' : ''}`}
-          >
-            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </Button>
-        </div>
-      </div>
+      <WizardNav
+        step={step}
+        steps={steps}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        onNext={onNext}
+        submitting={uploading}
+      />
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Control, Controller, FieldValues } from 'react-hook-form';
 import { Button } from '../../ui';
+import WizardNav from '../WizardNav';
 
 interface Props {
   control: Control<FieldValues>;
@@ -21,6 +22,7 @@ export default function SoundStep({
 }: Props) {
   return (
     <div className="space-y-4">
+      <p className="text-sm text-gray-600">Will sound equipment be needed?</p>
       <Controller
         name="sound"
         control={control}
@@ -50,36 +52,13 @@ export default function SoundStep({
           </fieldset>
         )}
       />
-      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
-        {step > 0 && (
-          <Button
-            type="button"
-            onClick={onBack}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Back
-          </Button>
-        )}
-
-        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <Button
-            type="button"
-            onClick={onSaveDraft}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Save Draft
-          </Button>
-          <Button
-            type="button"
-            onClick={onNext}
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </Button>
-        </div>
-      </div>
+      <WizardNav
+        step={step}
+        steps={steps}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        onNext={onNext}
+      />
     </div>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -3,6 +3,7 @@ import { Controller, Control, FieldValues } from 'react-hook-form';
 import { useState, useRef } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
 import { BottomSheet, Button } from '../../ui';
+import WizardNav from '../WizardNav';
 
 interface Props {
   control: Control<FieldValues>;
@@ -34,6 +35,7 @@ export default function VenueStep({
 
   return (
     <div className="space-y-4">
+      <p className="text-sm text-gray-600">What type of venue is it?</p>
       <Controller
         name="venueType"
         control={control}
@@ -99,36 +101,13 @@ export default function VenueStep({
           </>
         )}
       />
-      <div className="flex flex-col gap-2 mt-6 sm:flex-row sm:justify-between sm:items-center">
-        {step > 0 && (
-          <Button
-            type="button"
-            onClick={onBack}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Back
-          </Button>
-        )}
-
-        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:ml-auto">
-          <Button
-            type="button"
-            onClick={onSaveDraft}
-            variant="secondary"
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            Save Draft
-          </Button>
-          <Button
-            type="button"
-            onClick={onNext}
-            className="w-full sm:w-auto min-h-[44px]"
-          >
-            {step === steps.length - 1 ? 'Submit Request' : 'Next'}
-          </Button>
-        </div>
-      </div>
+      <WizardNav
+        step={step}
+        steps={steps}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        onNext={onNext}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- unify styling on sound, venue, and notes steps
- use `WizardNav` for consistent navigation across steps

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: `git fetch` failed because no remote `origin`)*

------
https://chatgpt.com/codex/tasks/task_e_68864357ea18832e862a33df27d12ac5