### PR TITLE
Improve booking wizard radio styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Users can download all account data via `/api/v1/users/me/export` and permanently delete their account with `DELETE /api/v1/users/me`.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking wizard includes a required **Guests** step.
+- Venue and sound selection now use **SelectableCard** components so options look like modern clickable cards rather than plain radio buttons.
 - Date picker and quote calculator show skeleton loaders while data fetches.
 - Google Maps and large images load lazily once in view to reduce first paint time.
 - Client dashboards now include a bookings list with upcoming and past filters via `/api/v1/bookings/my-bookings?status=`.

--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -56,4 +56,6 @@ Buttons use a `rounded-lg` radius and display a subtle shadow on hover.
 
 Cards use `rounded-xl` corners with a `shadow-sm` and `border` in the brand border color. They respect the same spacing scale so content aligns with other components.
 
+`SelectableCard` replaces plain radio buttons in the booking wizard. It hides the native input and styles the associated label as a clickable card using Tailwind `peer` classes. This provides large touch targets, hover states and a subtle brand-colored highlight when selected.
+
 These guidelines ensure a cohesive look and feel as the app evolves.

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Control, Controller, FieldValues } from 'react-hook-form';
-import { Button } from '../../ui';
+import { Button, SelectableCard } from '../../ui';
 import WizardNav from '../WizardNav';
 
 interface Props {
@@ -27,28 +27,22 @@ export default function SoundStep({
         name="sound"
         control={control}
         render={({ field }) => (
-          <fieldset className="space-y-2">
-            <legend className="font-medium">Is sound needed?</legend>
-            <label className="flex items-center space-x-2 py-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="yes"
-                checked={field.value === 'yes'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>Yes</span>
-            </label>
-            <label className="flex items-center space-x-2 py-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="no"
-                checked={field.value === 'no'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>No</span>
-            </label>
+          <fieldset className="grid grid-cols-2 gap-3">
+            <legend className="font-medium col-span-2 mb-2">Is sound needed?</legend>
+            <SelectableCard
+              name={field.name}
+              value="yes"
+              label="Yes"
+              checked={field.value === 'yes'}
+              onChange={(e) => field.onChange(e.target.value)}
+            />
+            <SelectableCard
+              name={field.name}
+              value="no"
+              label="No"
+              checked={field.value === 'no'}
+              onChange={(e) => field.onChange(e.target.value)}
+            />
           </fieldset>
         )}
       />

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -2,7 +2,7 @@
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import { useState, useRef } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
-import { BottomSheet, Button } from '../../ui';
+import { BottomSheet, Button, SelectableCard } from '../../ui';
 import WizardNav from '../WizardNav';
 
 interface Props {
@@ -60,41 +60,37 @@ export default function VenueStep({
                   initialFocus={firstRadioRef}
                   testId="bottom-sheet"
                 >
-                  <fieldset className="p-4 space-y-2">
-                    <legend className="font-medium">Venue Type</legend>
+                  <fieldset className="p-4 grid gap-3">
+                    <legend className="font-medium mb-2">Venue Type</legend>
                     {options.map((opt, idx) => (
-                      <label key={opt.value} className="flex items-center space-x-2 py-2">
-                        <input
-                          ref={idx === 0 ? firstRadioRef : undefined}
-                          type="radio"
-                          name={field.name}
-                          value={opt.value}
-                          checked={field.value === opt.value}
-                          onChange={(e) => {
-                            field.onChange(e.target.value);
-                            setSheetOpen(false);
-                          }}
-                        />
-                        <span>{opt.label}</span>
-                      </label>
+                      <SelectableCard
+                        key={opt.value}
+                        ref={idx === 0 ? firstRadioRef : undefined}
+                        name={field.name}
+                        value={opt.value}
+                        label={opt.label}
+                        checked={field.value === opt.value}
+                        onChange={(e) => {
+                          field.onChange(e.target.value);
+                          setSheetOpen(false);
+                        }}
+                      />
                     ))}
                   </fieldset>
                 </BottomSheet>
               </>
             ) : (
-              <fieldset className="space-y-2">
-                <legend className="font-medium">Venue Type</legend>
+              <fieldset className="grid grid-cols-3 gap-3">
+                <legend className="font-medium col-span-3 mb-2">Venue Type</legend>
                 {options.map((opt) => (
-                  <label key={opt.value} className="flex items-center space-x-2 py-2">
-                    <input
-                      type="radio"
-                      name={field.name}
-                      value={opt.value}
-                      checked={field.value === opt.value}
-                      onChange={(e) => field.onChange(e.target.value)}
-                    />
-                    <span>{opt.label}</span>
-                  </label>
+                  <SelectableCard
+                    key={opt.value}
+                    name={field.name}
+                    value={opt.value}
+                    label={opt.label}
+                    checked={field.value === opt.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
                 ))}
               </fieldset>
             )}

--- a/frontend/src/components/ui/SelectableCard.tsx
+++ b/frontend/src/components/ui/SelectableCard.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { forwardRef, InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export interface SelectableCardProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label: string;
+}
+
+const SelectableCard = forwardRef<HTMLInputElement, SelectableCardProps>(
+  ({ label, className, ...props }, ref) => (
+    <label className="block cursor-pointer">
+      <input
+        {...props}
+        ref={ref}
+        type="radio"
+        className="peer sr-only"
+      />
+      <div
+        className={clsx(
+          'flex items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-all',
+          'peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--brand-color)]',
+          'peer-checked:border-[var(--brand-color)] peer-checked:bg-brand-light',
+          'hover:bg-gray-50',
+          className,
+        )}
+      >
+        {label}
+      </div>
+    </label>
+  ),
+);
+SelectableCard.displayName = 'SelectableCard';
+
+export default SelectableCard;

--- a/frontend/src/components/ui/__tests__/SelectableCard.test.tsx
+++ b/frontend/src/components/ui/__tests__/SelectableCard.test.tsx
@@ -1,0 +1,49 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import SelectableCard from '../SelectableCard';
+
+describe('SelectableCard component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('matches snapshot for default and selected states', () => {
+    act(() => {
+      root.render(
+        <SelectableCard
+          name="demo"
+          value="a"
+          label="Option"
+          onChange={() => {}}
+        />,
+      );
+    });
+    expect(container.firstChild).toMatchSnapshot();
+
+    act(() => {
+      root.render(
+        <SelectableCard
+          name="demo"
+          value="a"
+          label="Option"
+          checked
+          onChange={() => {}}
+        />,
+      );
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/ui/__tests__/__snapshots__/SelectableCard.test.tsx.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/SelectableCard.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectableCard component matches snapshot for default and selected states 1`] = `
+<label
+  class="block cursor-pointer"
+>
+  <input
+    class="peer sr-only"
+    name="demo"
+    type="radio"
+    value="a"
+  />
+  <div
+    class="flex items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-all peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--brand-color)] peer-checked:border-[var(--brand-color)] peer-checked:bg-brand-light hover:bg-gray-50"
+  >
+    Option
+  </div>
+</label>
+`;
+
+exports[`SelectableCard component matches snapshot for default and selected states 2`] = `
+<label
+  class="block cursor-pointer"
+>
+  <input
+    class="peer sr-only"
+    name="demo"
+    type="radio"
+    value="a"
+  />
+  <div
+    class="flex items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-all peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--brand-color)] peer-checked:border-[var(--brand-color)] peer-checked:bg-brand-light hover:bg-gray-50"
+  >
+    Option
+  </div>
+</label>
+`;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -22,3 +22,4 @@ export { default as ToggleSwitch } from './ToggleSwitch';
 export { default as NotificationCard } from './NotificationCard';
 export { default as LocationMapModal } from './LocationMapModal';
 export { default as ProgressBar } from './ProgressBar';
+export { default as SelectableCard } from './SelectableCard';


### PR DESCRIPTION
## Summary
- introduce SelectableCard for card-style radio inputs
- refactor VenueStep and SoundStep to use SelectableCard
- document the new component in design docs and README
- add unit test and snapshots for SelectableCard

## Testing
- `./scripts/test-all.sh` *(fails: git fetch origin main)*
- `npx jest src/components/ui/__tests__/SelectableCard.test.tsx --updateSnapshot`

------
https://chatgpt.com/codex/tasks/task_e_688647363d28832eabfda880825d1da8