### PR TITLE
Improve booking wizard step styling

### DIFF
--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -5,7 +5,6 @@ import useIsMobile from '@/hooks/useIsMobile';
 import { uploadBookingAttachment } from '@/lib/api';
 import toast from '../../ui/Toast';
 import { useState } from 'react';
-import { Button } from '../../ui';
 import WizardNav from '../WizardNav';
 
 interface Props {
@@ -55,16 +54,18 @@ export default function NotesStep({
   }
   return (
     <div className="space-y-4">
-      <p className="text-sm text-gray-600">Anything else we should know?</p>
-      <label className="block text-sm font-medium">Extra notes</label>
+      <p className="text-sm text-gray-600">Please add any specific notes or attachments for your booking.</p>
+      <label htmlFor="notes" className="block text-sm font-medium text-gray-700">Extra notes</label>
       <Controller
         name="notes"
         control={control}
         render={({ field }) => (
           <textarea
-            rows={3}
-            className="border p-2 rounded w-full min-h-[44px]"
             {...field}
+            id="notes"
+            rows={4}
+            placeholder="E.g., Special requests, parking instructions, specific stage requirements..."
+            className="w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand min-h-[100px]"
             autoFocus={!isMobile}
           />
         )}
@@ -74,11 +75,12 @@ export default function NotesStep({
         control={control}
         render={({ field }) => <input type="hidden" {...field} />}
       />
-      <label className="block text-sm font-medium">Attachment (optional)</label>
+      <label htmlFor="attachment" className="block text-sm font-medium text-gray-700">Attachment (optional)</label>
       <input
+        id="attachment"
         type="file"
         aria-label="Upload attachment"
-        className="min-h-[44px]"
+        className="w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand min-h-[44px] text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-light file:text-brand-dark hover:file:bg-brand-light transition-all duration-200 ease-in-out"
         onChange={handleFileChange}
       />
       {uploading && (
@@ -95,7 +97,7 @@ export default function NotesStep({
           <div className="w-full bg-gray-200 rounded h-2">
             <div className="bg-brand h-2 rounded" style={{ width: `${progress}%` }} />
           </div>
-          <span className="text-xs">{progress}%</span>
+          <span className="text-xs text-gray-600">{progress}%</span>
         </div>
       )}
       <WizardNav

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -22,10 +22,10 @@ export default function ReviewStep({
 }: Props) {
   return (
     <div className="space-y-4">
-      <SummarySidebar />
-      <p className="text-gray-600 text-sm">
-        Please confirm the information above before sending your request.
-      </p>
+      <p className="text-sm text-gray-600">Please review your booking details before submitting your request.</p>
+      <div className="space-y-6 p-4 border rounded-lg bg-white shadow-sm">
+        <SummarySidebar />
+      </div>
       <WizardNav
         step={step}
         steps={steps}

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,7 +1,12 @@
 'use client';
 import { Control, Controller, FieldValues } from 'react-hook-form';
-import { Button } from '../../ui';
 import WizardNav from '../WizardNav';
+import clsx from 'clsx';
+
+const SOUND_OPTIONS = [
+  { value: 'yes', label: 'Yes' },
+  { value: 'no', label: 'No' },
+];
 
 interface Props {
   control: Control<FieldValues>;
@@ -27,28 +32,44 @@ export default function SoundStep({
         name="sound"
         control={control}
         render={({ field }) => (
-          <fieldset className="space-y-2">
-            <legend className="font-medium">Is sound needed?</legend>
-            <label className="flex items-center space-x-2 py-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="yes"
-                checked={field.value === 'yes'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>Yes</span>
-            </label>
-            <label className="flex items-center space-x-2 py-2">
-              <input
-                type="radio"
-                name={field.name}
-                value="no"
-                checked={field.value === 'no'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <span>No</span>
-            </label>
+          <fieldset className="space-y-4">
+            <legend className="font-medium sr-only">Is sound needed?</legend>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {SOUND_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  htmlFor={field.name + '-' + option.value}
+                  className={clsx(
+                    'block cursor-pointer border rounded-lg p-4 transition-all duration-200 ease-in-out',
+                    'hover:border-gray-400 hover:shadow-sm',
+                    {
+                      'border-brand bg-brand-light': field.value === option.value,
+                      'border-gray-200 bg-white': field.value !== option.value,
+                    },
+                  )}
+                >
+                  <input
+                    type="radio"
+                    id={field.name + '-' + option.value}
+                    name={field.name}
+                    value={option.value}
+                    checked={field.value === option.value}
+                    onChange={(e) => {
+                      field.onChange(e.target.value);
+                    }}
+                    className="sr-only"
+                  />
+                  <span
+                    className={clsx('font-medium text-lg', {
+                      'text-brand': field.value === option.value,
+                      'text-gray-900': field.value !== option.value,
+                    })}
+                  >
+                    {option.label}
+                  </span>
+                </label>
+              ))}
+            </div>
           </fieldset>
         )}
       />

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
 import { BottomSheet, Button } from '../../ui';
 import WizardNav from '../WizardNav';
+import clsx from 'clsx';
 
 interface Props {
   control: Control<FieldValues>;
@@ -82,20 +83,42 @@ export default function VenueStep({
                 </BottomSheet>
               </>
             ) : (
-              <fieldset className="space-y-2">
-                <legend className="font-medium">Venue Type</legend>
-                {options.map((opt) => (
-                  <label key={opt.value} className="flex items-center space-x-2 py-2">
-                    <input
-                      type="radio"
-                      name={field.name}
-                      value={opt.value}
-                      checked={field.value === opt.value}
-                      onChange={(e) => field.onChange(e.target.value)}
-                    />
-                    <span>{opt.label}</span>
-                  </label>
-                ))}
+              <fieldset className="space-y-4">
+                <legend className="font-medium sr-only">Venue Type</legend>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  {options.map((opt) => (
+                    <label
+                      key={opt.value}
+                      htmlFor={field.name + '-' + opt.value}
+                      className={clsx(
+                        'block cursor-pointer border rounded-lg p-4 transition-all duration-200 ease-in-out',
+                        'hover:border-gray-400 hover:shadow-sm',
+                        {
+                          'border-brand bg-brand-light': field.value === opt.value,
+                          'border-gray-200 bg-white': field.value !== opt.value,
+                        },
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        id={field.name + '-' + opt.value}
+                        name={field.name}
+                        value={opt.value}
+                        checked={field.value === opt.value}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        className="sr-only"
+                      />
+                      <span
+                        className={clsx('font-medium text-lg', {
+                          'text-brand': field.value === opt.value,
+                          'text-gray-900': field.value !== opt.value,
+                        })}
+                      >
+                        {opt.label}
+                      </span>
+                    </label>
+                  ))}
+                </div>
               </fieldset>
             )}
           </>


### PR DESCRIPTION
## Summary
- redesign SoundStep radio buttons as selectable cards using clsx
- revamp VenueStep radio group styling for desktop
- polish NotesStep inputs and add instructions
- tidy ReviewStep layout and instructions

## Testing
- `./scripts/test-backend.sh` *(fails: OperationalError creating tables)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_688647a74494832e9aa77c8f3c8d48bb