### PR TITLE
Add wizard layout utilities

### DIFF
--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -56,4 +56,6 @@ Buttons use a `rounded-lg` radius and display a subtle shadow on hover.
 
 Cards use `rounded-xl` corners with a `shadow-sm` and `border` in the brand border color. They respect the same spacing scale so content aligns with other components.
 
+`SelectableCard` replaces plain radio buttons in the booking wizard. It hides the native input and styles the associated label as a clickable card using Tailwind `peer` classes. This provides large touch targets, hover states and a subtle brand-colored highlight when selected.
+
 These guidelines ensure a cohesive look and feel as the app evolves.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -74,6 +74,35 @@ html[data-headlessui-focus-visible] {
   overflow: visible !important;
   padding-right: 0 !important;
 }
+
+  /* Booking wizard common styles */
+  .wizard-step-container {
+    @apply mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 shadow-xl md:p-8;
+  }
+
+  .instruction-text {
+    @apply text-sm text-gray-600;
+  }
+
+  .input-base {
+    @apply w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand min-h-[44px];
+  }
+
+  .selectable-card-input {
+    @apply peer sr-only;
+  }
+
+  .selectable-card {
+    @apply flex cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white p-4 text-sm transition-all hover:border-gray-400 hover:shadow-sm;
+  }
+
+  .selectable-card-input:focus-visible + .selectable-card {
+    @apply ring-2 ring-brand;
+  }
+
+  .selectable-card-input:checked + .selectable-card {
+    @apply border-brand bg-brand-light;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- create global CSS utilities for booking wizard elements
- document new SelectableCard pattern in design guidelines

## Testing
- `npm ci` in `frontend`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_6886555d9998832ea57ea840eb165564