### PR TITLE
Update booking wizard styles

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -37,8 +37,8 @@ export default function DateTimeStep({
   const formatLongDate = (_locale: string | undefined, date: Date) =>
     format(date, 'MMMM d, yyyy', { locale: enUS });
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">When should we perform?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">When should we perform?</p>
       {loading ? (
         <div
           data-testid="calendar-skeleton"
@@ -56,7 +56,7 @@ export default function DateTimeStep({
             return isMobile ? (
               <input
                 type="date"
-                className="w-full border border-gray-200 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                className="input-base"
                 min={format(new Date(), 'yyyy-MM-dd')}
                 name={field.name}
                 ref={field.ref}

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -23,8 +23,8 @@ export default function GuestsStep({
 }: Props) {
   const isMobile = useIsMobile();
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">How many people?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">How many people?</p>
       <Controller
         name="guests"
         control={control}
@@ -33,7 +33,7 @@ export default function GuestsStep({
             type="number"
             min={1}
             label="Number of guests"
-            className="text-lg"
+            className="input-base text-lg"
             {...field}
             autoFocus={!isMobile}
           />

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -124,8 +124,8 @@ export default function LocationStep({
   }
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">Where is the show?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">Where is the show?</p>
       <div ref={containerRef}>
         {shouldLoadMap ? (
           <GoogleMapsLoader>
@@ -147,7 +147,7 @@ export default function LocationStep({
                         }
                       }}
                       placeholder="Search address"
-                      className="block w-full rounded-md border border-gray-300 focus-within:border-brand focus-within:ring-brand sm:text-sm p-2"
+                      inputClassName="input-base"
                     />
                   )}
                 />
@@ -178,7 +178,7 @@ export default function LocationStep({
                     }
                   }}
                   placeholder="Search address"
-                  className="block w-full rounded-md border border-gray-300 focus-within:border-brand focus-within:ring-brand sm:text-sm p-2"
+                  inputClassName="input-base"
                 />
               )}
             />

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -54,8 +54,8 @@ export default function NotesStep({
     }
   }
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">Anything else we should know?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">Anything else we should know?</p>
       <label className="block text-sm font-medium">Extra notes</label>
       <Controller
         name="notes"
@@ -63,7 +63,7 @@ export default function NotesStep({
         render={({ field }) => (
           <textarea
             rows={3}
-            className="border p-2 rounded w-full min-h-[44px]"
+            className="input-base"
             {...field}
             autoFocus={!isMobile}
           />
@@ -78,7 +78,7 @@ export default function NotesStep({
       <input
         type="file"
         aria-label="Upload attachment"
-        className="min-h-[44px]"
+        className="input-base"
         onChange={handleFileChange}
       />
       {uploading && (

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -21,11 +21,11 @@ export default function ReviewStep({
   submitting,
 }: Props) {
   return (
-    <div className="space-y-4">
-      <SummarySidebar />
-      <p className="text-gray-600 text-sm">
+    <div className="wizard-step-container">
+      <p className="instruction-text">
         Please confirm the information above before sending your request.
       </p>
+      <SummarySidebar />
       <WizardNav
         step={step}
         steps={steps}

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -21,17 +21,18 @@ export default function SoundStep({
   onNext,
 }: Props) {
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">Will sound equipment be needed?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">Will sound equipment be needed?</p>
       <Controller
         name="sound"
         control={control}
         render={({ field }) => (
           <fieldset className="space-y-2">
             <legend className="font-medium">Is sound needed?</legend>
-            <label className="flex items-center space-x-2 py-2">
+            <label className="selectable-card">
               <input
                 type="radio"
+                className="selectable-card-input"
                 name={field.name}
                 value="yes"
                 checked={field.value === 'yes'}
@@ -39,9 +40,10 @@ export default function SoundStep({
               />
               <span>Yes</span>
             </label>
-            <label className="flex items-center space-x-2 py-2">
+            <label className="selectable-card">
               <input
                 type="radio"
+                className="selectable-card-input"
                 name={field.name}
                 value="no"
                 checked={field.value === 'no'}

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -34,8 +34,8 @@ export default function VenueStep({
   ];
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-600">What type of venue is it?</p>
+    <div className="wizard-step-container">
+      <p className="instruction-text">What type of venue is it?</p>
       <Controller
         name="venueType"
         control={control}
@@ -63,10 +63,11 @@ export default function VenueStep({
                   <fieldset className="p-4 space-y-2">
                     <legend className="font-medium">Venue Type</legend>
                     {options.map((opt, idx) => (
-                      <label key={opt.value} className="flex items-center space-x-2 py-2">
+                      <label key={opt.value} className="selectable-card">
                         <input
                           ref={idx === 0 ? firstRadioRef : undefined}
                           type="radio"
+                          className="selectable-card-input"
                           name={field.name}
                           value={opt.value}
                           checked={field.value === opt.value}
@@ -85,9 +86,10 @@ export default function VenueStep({
               <fieldset className="space-y-2">
                 <legend className="font-medium">Venue Type</legend>
                 {options.map((opt) => (
-                  <label key={opt.value} className="flex items-center space-x-2 py-2">
+                  <label key={opt.value} className="selectable-card">
                     <input
                       type="radio"
+                      className="selectable-card-input"
                       name={field.name}
                       value={opt.value}
                       checked={field.value === opt.value}


### PR DESCRIPTION
## Summary
- wrap step components with wizard-step-container
- add instruction-text prompts to each booking step
- apply input-base and selectable-card styles

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 22 failed, 1 skipped, 72 passed, 94 of 95 total)*

------
https://chatgpt.com/codex/tasks/task_e_68865745b6e4832ea5753b84a63e12d9