### PR TITLE
Add DateInput component and pass className through inputs

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -6,6 +6,7 @@ import 'react-calendar/dist/Calendar.css';
 import { format, parseISO } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import useIsMobile from '@/hooks/useIsMobile';
+import { DateInput } from '../../ui';
 
 interface Props {
   control: Control<FieldValues>;
@@ -54,15 +55,14 @@ export default function DateTimeStep({
                 ? parseISO(field.value)
                 : field.value;
             return isMobile ? (
-              <input
-                type="date"
-                className="input-base"
+              <DateInput
                 min={format(new Date(), 'yyyy-MM-dd')}
                 name={field.name}
                 ref={field.ref}
                 onBlur={field.onBlur}
                 value={currentValue ? format(currentValue, 'yyyy-MM-dd') : ''}
                 onChange={(e) => field.onChange(e.target.value)}
+                inputClassName="input-base"
               />
             ) : (
               <div className="mx-auto w-fit border border-gray-200 rounded-lg hover:shadow-lg">

--- a/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
@@ -67,6 +67,7 @@ describe('DateTimeStep mobile input', () => {
     const input = container.querySelector('input[type="date"]') as HTMLInputElement;
     expect(input).not.toBeNull();
     expect(input.value).toBe('2025-06-20');
+    expect(input.className).toContain('input-base');
     expect(errorSpy).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/ui/DateInput.tsx
+++ b/frontend/src/components/ui/DateInput.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { forwardRef, InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export interface DateInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  inputClassName?: string;
+}
+
+const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
+  function DateInput({ inputClassName, className, ...props }, ref) {
+    return (
+      <input
+        ref={ref}
+        type="date"
+        className={clsx('w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none', inputClassName, className)}
+        {...props}
+      />
+    );
+  },
+);
+
+export default DateInput;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -22,3 +22,4 @@ export { default as ToggleSwitch } from './ToggleSwitch';
 export { default as NotificationCard } from './NotificationCard';
 export { default as LocationMapModal } from './LocationMapModal';
 export { default as ProgressBar } from './ProgressBar';
+export { default as DateInput } from './DateInput';


### PR DESCRIPTION
## Summary
- implement `DateInput` wrapper to allow passing custom classes to the mobile date picker
- export `DateInput` from the UI library
- update `DateTimeStep` to use `DateInput`
- verify `input-base` styling in tests

## Testing
- `./scripts/test-all.sh` *(fails: could not fetch due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688659456338832e953d175b90c868bb