### PR TITLE
Document Tailwind CSS practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1243,6 +1243,8 @@ accessible from the main navigation on desktop and through the mobile menu.
 
 For an overview of layout spacing, typography and component styles, see
 [docs/design_guidelines.md](docs/design_guidelines.md).
+Additional CSS conventions are documented in
+[docs/css_best_practices.md](docs/css_best_practices.md).
 
 ## Contributing
 

--- a/docs/css_best_practices.md
+++ b/docs/css_best_practices.md
@@ -1,0 +1,61 @@
+# Tailwind CSS Strategy
+
+This document outlines how we keep styles maintainable and performant.
+It complements `docs/design_guidelines.md` which covers spacing,
+typography and component patterns.
+
+## Design Tokens
+
+- Theme values such as colors and spacing are defined in
+  `frontend/tailwind.config.js` using semantic names
+  (`primary`, `secondary`, `accent`). Utility classes refer to these tokens
+  so colors and sizes stay consistent across the app.
+- Update a token in the config to change its value everywhere.
+  Avoid hard–coding hex values or pixel numbers in JSX.
+
+## Reusable Components
+
+- Common UI elements live in `frontend/src/components/ui`.
+  Components like `Button`, `Card` and `TextInput` map variant props
+  to Tailwind class strings using `clsx`.
+- Variant props ensure only approved color and size combinations are used.
+  Prefer `<Button variant="primary">` over manually composing class names.
+
+## Organising Utility Classes
+
+- Tailwind classes are sorted automatically by Prettier using the
+  `prettier-plugin-tailwindcss` plugin. Run `npx prettier --write` before
+  committing to keep ordering consistent.
+- Use shorthand utilities such as `py-4` or `mx-8` and break long class
+  lists across lines when necessary for readability.
+
+## Headless UI and Heroicons
+
+- Modal dialogs, menus and transitions use Headless UI components with
+  Tailwind classes applied for styling.
+- Icons come from `@heroicons/react` so sizes and colors align with the
+  design tokens (e.g. `className="h-5 w-5 text-primary"`).
+
+## Performance
+
+- Tailwind JIT mode generates only the classes used in the project.
+  Ensure the `content` array in `tailwind.config.js` covers all source
+  files so unused CSS is purged.
+- Production builds are minified automatically by Next.js. Keep animations
+  lightweight by relying on transforms or opacity when using Framer Motion.
+
+## Accessibility and Semantics
+
+- Use semantic HTML elements (`<button>`, `<header>`, `<main>` etc.) and
+  ensure interactive controls retain focus styles.
+- Components accept `aria-label` and `data-testid` props so tests and
+  assistive technologies have meaningful hooks.
+
+## Code Review Checklist
+
+- Do new styles rely on design tokens rather than hard–coded values?
+- Are utility classes sorted and grouped logically?
+- Could repeated class strings be moved into a shared component?
+
+Following these practices helps the codebase scale as features grow.
+

--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -59,3 +59,5 @@ Cards use `rounded-xl` corners with a `shadow-sm` and `border` in the brand bord
 `SelectableCard` replaces plain radio buttons in the booking wizard. It hides the native input and styles the associated label as a clickable card using Tailwind `peer` classes. This provides large touch targets, hover states and a subtle brand-colored highlight when selected.
 
 These guidelines ensure a cohesive look and feel as the app evolves.
+For tips on organising Tailwind utility classes and performance
+optimisations, see [css_best_practices.md](css_best_practices.md).

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,6 +61,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "jsdom": "20.0.3",
         "postcss": "^8.4.31",
+        "prettier": "^3.6.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^3.3.5",
         "ts-jest": "^29.1.1",
         "typescript": "^5.3.2"
@@ -9756,6 +9758,109 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,8 @@
     "@typescript-eslint/parser": "^6.21.0",
     "autoprefixer": "^10.4.16",
     "babel-jest": "^29.7.0",
+    "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "eslint": "^8.54.0",
     "eslint-config-next": "14.0.3",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Summary
- add `prettier-plugin-tailwindcss` so class names are sorted
- document CSS strategy in `docs/css_best_practices.md`
- reference new doc from README and design guidelines
- configure Prettier for Tailwind

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: combine() argument 1 must be datetime.date, not Query)*

------
https://chatgpt.com/codex/tasks/task_e_68866d849038832e8422c4a12b109263