### PR TITLE
Improve CSS tokens for dashboard

### DIFF
--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -10,12 +10,12 @@ All spacing is based on a **4&nbsp;px** scale so margins and padding remain cons
 
 Headings follow a clear typographic hierarchy:
 
-| Element | Size | Weight |
-|---------|------|--------|
-| `h1`    | `2rem` (32px) | `700` |
-| `h2`    | `1.5rem` (24px) | `600` |
-| `h3`    | `1.25rem` (20px) | `600` |
-| Body    | `1rem` (16px) | `400` |
+| Element | Size             | Weight |
+| ------- | ---------------- | ------ |
+| `h1`    | `2rem` (32px)    | `700`  |
+| `h2`    | `1.5rem` (24px)  | `600`  |
+| `h3`    | `1.25rem` (20px) | `600`  |
+| Body    | `1rem` (16px)    | `400`  |
 
 The base font family is Inter via the CSS variable `--font-sans` defined in `globals.css`.
 
@@ -23,16 +23,28 @@ The base font family is Inter via the CSS variable `--font-sans` defined in `glo
 
 The application uses a small brand palette:
 
-| Token | Hex |
-|-------|-----|
-| `--color-primary` | `#FF5A5F` |
-| `--color-secondary` | `#E04852` |
-| `--color-accent` | `#FF7A85` |
-| `--color-border` | `#FFD0D3` |
+| Token                | Hex       |
+| -------------------- | --------- |
+| `--color-primary`    | `#FF5A5F` |
+| `--color-secondary`  | `#E04852` |
+| `--color-accent`     | `#FF7A85` |
+| `--color-border`     | `#FFD0D3` |
 | `--color-background` | `#ffffff` |
 | `--color-foreground` | `#111827` |
 
 These values power Tailwind classes such as `bg-brand`, `text-brand-dark` and `border-brand`. The light tint `--brand-color-light` (`#FFEAEA`) is used for subtle gradients.
+
+### Dashboard Palette
+
+The analytics dashboard uses a complementary set of tokens for charts and status badges:
+
+| Token                   | Hex       |
+| ----------------------- | --------- |
+| `--dashboard-primary`   | `#0047AB` |
+| `--dashboard-secondary` | `#FFD700` |
+| `--dashboard-accent`    | `#FF6347` |
+
+Utility classes like `bg-brand-primary` and `text-brand-secondary` map to these variables so you can update the dashboard theme in one place.
 
 ## Component Styles
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4,18 +4,22 @@
 
 :root {
   --font-sans: var(--font-inter);
-  --color-primary: #FF5A5F;
-  --color-secondary: #E04852;
-  --color-accent: #FF7A85;
-  --color-border: #FFD0D3;
+  --color-primary: #ff5a5f;
+  --color-secondary: #e04852;
+  --color-accent: #ff7a85;
+  --color-border: #ffd0d3;
   --color-background: #ffffff;
   --color-foreground: #111827;
   --brand-color: var(--color-primary);
   --brand-color-dark: var(--color-secondary);
   /* lighter tint used for subtle page gradients */
-  --brand-color-light: #FFEAEA;
+  --brand-color-light: #ffeaea;
   --color-link: var(--brand-color-dark);
   --color-link-hover: var(--brand-color);
+  /* dashboard palette for charts and stats */
+  --dashboard-primary: #0047ab;
+  --dashboard-secondary: #ffd700;
+  --dashboard-accent: #ff6347;
 }
 
 @layer base {
@@ -63,17 +67,16 @@
 }
 
 @layer components {
-/* --- ADD THIS CODE --- */
-.pac-container {
-  /* This makes the Google Maps dropdown appear on top of the modal */
-  z-index: 9999 !important;
-}
+  /* --- ADD THIS CODE --- */
+  .pac-container {
+    /* This makes the Google Maps dropdown appear on top of the modal */
+    z-index: 9999 !important;
+  }
 
-
-html[data-headlessui-focus-visible] {
-  overflow: visible !important;
-  padding-right: 0 !important;
-}
+  html[data-headlessui-focus-visible] {
+    overflow: visible !important;
+    padding-right: 0 !important;
+  }
 
   /* Booking wizard common styles */
   .wizard-step-container {
@@ -85,7 +88,7 @@ html[data-headlessui-focus-visible] {
   }
 
   .input-base {
-    @apply w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand min-h-[44px];
+    @apply min-h-[44px] w-full rounded-md border-gray-300 shadow-sm focus:border-brand focus:ring-brand;
   }
 
   .selectable-card-input {
@@ -104,6 +107,5 @@ html[data-headlessui-focus-visible] {
     @apply border-brand bg-brand-light;
   }
 }
-
 
 /* ... (rest of your globals.css content) ... */

--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -1,5 +1,5 @@
 .overview-card {
-  @apply flex items-center justify-between p-4 rounded-xl bg-white border border-gray-200 shadow-sm;
+  @apply flex items-center justify-between rounded-xl border border-gray-200 bg-white p-4 shadow-sm;
 }
 .overview-label {
   @apply text-sm text-gray-600;
@@ -9,29 +9,49 @@
 }
 
 /* --- Dashboard redesign colors --- */
-.bg-brand-primary { background-color: #0047AB; }
-.text-brand-primary { color: #0047AB; }
-.bg-brand-secondary { background-color: #FFD700; }
-.text-brand-secondary { color: #FFD700; }
-.bg-brand-accent { background-color: #FF6347; }
-.text-brand-accent { color: #FF6347; }
-.shadow-custom { box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08); }
+.bg-brand-primary {
+  background-color: var(--dashboard-primary);
+}
+.text-brand-primary {
+  color: var(--dashboard-primary);
+}
+.bg-brand-secondary {
+  background-color: var(--dashboard-secondary);
+}
+.text-brand-secondary {
+  color: var(--dashboard-secondary);
+}
+.bg-brand-accent {
+  background-color: var(--dashboard-accent);
+}
+.text-brand-accent {
+  color: var(--dashboard-accent);
+}
+.shadow-custom {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+}
 .progress-bar-fill {
-  @apply h-2.5 rounded-full bg-brand-secondary transition-[width] duration-500 ease-in-out;
+  @apply bg-brand-secondary h-2.5 rounded-full transition-[width] duration-500 ease-in-out;
 }
 
 .progress-bar {
-  @apply relative w-full bg-gray-200 rounded-full overflow-hidden;
+  @apply relative w-full overflow-hidden rounded-full bg-gray-200;
 }
 
 @keyframes progress-indeterminate {
-  0% { left: -40%; width: 40%; }
-  100% { left: 100%; width: 40%; }
+  0% {
+    left: -40%;
+    width: 40%;
+  }
+  100% {
+    left: 100%;
+    width: 40%;
+  }
 }
 
 .progress-bar-indeterminate::before {
   content: "";
-  @apply absolute inset-y-0 bg-brand-secondary;
+  @apply bg-brand-secondary absolute inset-y-0;
   animation: progress-indeterminate 1.5s infinite;
 }
 .status-badge {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,49 +1,54 @@
-const colors = require('tailwindcss/colors');
+const colors = require("tailwindcss/colors");
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
     // include shared style files so Tailwind preserves classes
-    './src/styles/**/*.{js,ts,jsx,tsx}',
+    "./src/styles/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-sans)'],
+        sans: ["var(--font-sans)"],
       },
       borderRadius: {
-        xxl: '1.25rem',
+        xxl: "1.25rem",
       },
       colors: {
         brand: {
-          DEFAULT: 'var(--brand-color)',
-          dark: 'var(--brand-color-dark)',
-          light: 'var(--brand-color-light)',
+          DEFAULT: "var(--brand-color)",
+          dark: "var(--brand-color-dark)",
+          light: "var(--brand-color-light)",
         },
         wizard: {
-          step: 'var(--color-primary)',
-          pending: '#e5e7eb',
+          step: "var(--color-primary)",
+          pending: "#e5e7eb",
         },
         primary: {
-          DEFAULT: 'var(--color-primary)',
-          50: '#FFEAEA',
-          600: '#FF5A5F',
-          700: '#E04852',
+          DEFAULT: "var(--color-primary)",
+          50: "#FFEAEA",
+          600: "#FF5A5F",
+          700: "#E04852",
         },
-        secondary: 'var(--color-secondary)',
-        accent: 'var(--color-accent)',
-        border: 'var(--color-border)',
-        background: 'var(--color-background)',
-        foreground: 'var(--color-foreground)',
+        secondary: "var(--color-secondary)",
+        accent: "var(--color-accent)",
+        border: "var(--color-border)",
+        background: "var(--color-background)",
+        foreground: "var(--color-foreground)",
         orange: colors.orange,
         yellow: colors.yellow,
+        dashboard: {
+          primary: "var(--dashboard-primary)",
+          secondary: "var(--dashboard-secondary)",
+          accent: "var(--dashboard-accent)",
+        },
       },
       ringOffsetWidth: {
-        default: '1px',
+        default: "1px",
       },
     },
   },
-  plugins: [require('@tailwindcss/line-clamp')],
-}
+  plugins: [require("@tailwindcss/line-clamp")],
+};


### PR DESCRIPTION
## Summary
- add dashboard color variables in global CSS
- reference variables from Tailwind config
- update dashboard styles to use CSS variables
- document dashboard palette in design guide

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: no git remote)*

------
https://chatgpt.com/codex/tasks/task_e_68866fe2c4e0832e8bf4ce5415fadc5b