### PR TITLE
Fix map styles

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -106,6 +106,18 @@
   .selectable-card-input:checked + .selectable-card {
     @apply border-brand bg-brand-light;
   }
+
+  .map-container {
+    @apply w-full transition-[height] duration-300 ease-in-out;
+  }
+
+  .map-container-collapsed {
+    @apply h-0 overflow-hidden;
+  }
+
+  .map-container-expanded {
+    @apply h-[250px];
+  }
 }
 
 /* ... (rest of your globals.css content) ... */

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -5,6 +5,7 @@ import { Controller, Control, FieldValues } from 'react-hook-form';
 import dynamic from 'next/dynamic';
 import { loadPlaces } from '@/lib/loadPlaces';
 import LocationInput from '../../ui/LocationInput';
+import clsx from 'clsx';
 const GoogleMap = dynamic(
   () => import('@react-google-maps/api').then((m) => m.GoogleMap),
   { ssr: false },
@@ -30,19 +31,6 @@ interface Props {
   onSaveDraft: () => void;
   onNext: () => void;
 }
-
-const mapContainerCollapsed = {
-  width: '100%',
-  height: 0,
-  overflow: 'hidden',
-  transition: 'height 0.3s ease',
-};
-
-const mapContainerExpanded = {
-  width: '100%',
-  height: '250px',
-  transition: 'height 0.3s ease',
-};
 
 function GoogleMapsLoader({
   children,
@@ -152,7 +140,10 @@ export default function LocationStep({
                   )}
                 />
                 <div
-                  style={marker ? mapContainerExpanded : mapContainerCollapsed}
+                  className={clsx(
+                    'map-container',
+                    marker ? 'map-container-expanded' : 'map-container-collapsed',
+                  )}
                   data-testid="map-container"
                 >
                   <Map isLoaded={loaded} />
@@ -183,7 +174,10 @@ export default function LocationStep({
               )}
             />
             <div
-              style={marker ? mapContainerExpanded : mapContainerCollapsed}
+              className={clsx(
+                'map-container',
+                marker ? 'map-container-expanded' : 'map-container-collapsed',
+              )}
               data-testid="map-container"
             />
           </>


### PR DESCRIPTION
## Summary
- refactor location step map to use CSS classes instead of inline styles
- add map-container classes to global styles

## Testing
- `./scripts/test-all.sh` *(fails: `git fetch origin`)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688672667618832eb744c3504cf2a7eb