### PR TITLE
Improve CSS variables for neutrals

### DIFF
--- a/docs/css_best_practices.md
+++ b/docs/css_best_practices.md
@@ -9,7 +9,9 @@ typography and component patterns.
 - Theme values such as colors and spacing are defined in
   `frontend/tailwind.config.js` using semantic names
   (`primary`, `secondary`, `accent`). Utility classes refer to these tokens
-  so colors and sizes stay consistent across the app.
+  so colors and sizes stay consistent across the app. Neutral grays like
+  `--color-gray-100` and `--color-gray-700` are also defined to avoid
+  scattering hard-coded gray values throughout stylesheets.
 - Update a token in the config to change its value everywhere.
   Avoid hard–coding hex values or pixel numbers in JSX.
 
@@ -58,4 +60,3 @@ typography and component patterns.
 - Could repeated class strings be moved into a shared component?
 
 Following these practices helps the codebase scale as features grow.
-

--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -34,6 +34,19 @@ The application uses a small brand palette:
 
 These values power Tailwind classes such as `bg-brand`, `text-brand-dark` and `border-brand`. The light tint `--brand-color-light` (`#FFEAEA`) is used for subtle gradients.
 
+### Neutral Grays
+
+The design system includes a small set of gray tokens for backgrounds and text:
+
+| Token              | Hex       |
+| ------------------ | --------- |
+| `--color-gray-100` | `#F3F4F6` |
+| `--color-gray-400` | `#CBD5E1` |
+| `--color-gray-500` | `#9CA3AF` |
+| `--color-gray-700` | `#374151` |
+
+Use these tokens in custom CSS rather than hard-coding gray values. They map to Tailwind's neutral palette and keep the UI consistent.
+
 ### Dashboard Palette
 
 The analytics dashboard uses a complementary set of tokens for charts and status badges:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -22,6 +22,11 @@
   --dashboard-accent: #ff6347;
   /* 10% tint of the accent color for subtle backgrounds */
   --color-accent-10: rgb(255 122 133 / 0.1);
+  /* neutral grays used across components */
+  --color-gray-100: #f3f4f6;
+  --color-gray-400: #cbd5e1;
+  --color-gray-500: #9ca3af;
+  --color-gray-700: #374151;
 }
 
 @layer base {

--- a/frontend/src/styles/datepicker.css
+++ b/frontend/src/styles/datepicker.css
@@ -63,7 +63,9 @@
 
 /* Hover effect for navigation buttons */
 .react-datepicker__navigation:hover {
-  background-color: #f3f4f6; /* Equivalent to Tailwind's hover:bg-gray-100 */
+  background-color: var(
+    --color-gray-100
+  ); /* Equivalent to Tailwind's hover:bg-gray-100 */
   border-radius: 9999px; /* Equivalent to Tailwind's rounded-full */
   transition: background-color 0.2s ease;
 }
@@ -91,7 +93,7 @@
   line-height: 2.25rem; /* Centers text vertically */
   font-size: 0.875rem; /* Equivalent to Tailwind's text-sm */
   text-align: center;
-  color: #374151; /* Equivalent to Tailwind's text-gray-700 */
+  color: var(--color-gray-700); /* Equivalent to Tailwind's text-gray-700 */
   border-radius: 0.5rem; /* Slight rounding for day cells */
   transition: background-color 0.2s ease;
   cursor: pointer; /* Ensures pointer cursor on days */
@@ -105,7 +107,9 @@
 
 /* Hover effect for individual day numbers */
 .react-datepicker__day:hover {
-  background-color: #f3f4f6; /* Equivalent to Tailwind's hover:bg-gray-100 */
+  background-color: var(
+    --color-gray-100
+  ); /* Equivalent to Tailwind's hover:bg-gray-100 */
 }
 
 /* Styles for the selected day or keyboard-selected day */
@@ -121,7 +125,7 @@
 
 /* Styles for disabled days (e.g., days outside the min/max date range) */
 .react-datepicker__day--disabled {
-  color: #cbd5e1; /* Tailwind's text-gray-400 */
+  color: var(--color-gray-400); /* Tailwind's text-gray-400 */
   cursor: not-allowed;
 }
 .react-datepicker__day--disabled:hover {
@@ -130,5 +134,5 @@
 
 /* Styles for days of the previous or next month that are visible */
 .react-datepicker__day--outside-month {
-  color: #9ca3af; /* Tailwind's text-gray-500 */
+  color: var(--color-gray-500); /* Tailwind's text-gray-500 */
 }


### PR DESCRIPTION
## Summary
- centralize gray palette tokens in `globals.css`
- document neutral grays in the design guidelines
- reference gray tokens in CSS best practices doc
- use gray tokens inside `datepicker.css`

## Testing
- `./scripts/test-all.sh` *(fails: TypeError in api_artist.py)*

------
https://chatgpt.com/codex/tasks/task_e_688676535ba0832e8c032e844270fcc6