### PR TITLE
Add reduced-motion CSS rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Further refined the price slider so both handles stay clickable even when they overlap.
 - Consolidated slider styling into Tailwind utilities, removing custom CSS from
   `globals.css` for simpler maintenance.
+- Animations now respect the user's `prefers-reduced-motion` setting via a
+  global rule in `globals.css`.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
 - Fixed an initial load bug where a selected date sent an invalid `when` value and caused a 422 error.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -153,4 +153,15 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ... (rest of your globals.css content) ... */

--- a/frontend/src/styles/datepicker.css
+++ b/frontend/src/styles/datepicker.css
@@ -17,6 +17,12 @@
   animation: fadeIn 0.2s ease-out; /* Smooth fade-in animation */
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .react-datepicker {
+    animation: none;
+  }
+}
+
 /* Keyframe animation for fade-in effect */
 @keyframes fadeIn {
   from {


### PR DESCRIPTION
## Summary
- add prefers-reduced-motion rule in `globals.css`
- apply same motion reduction for datepicker animations
- document the new accessibility rule in README

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68867f06d188832e8d85133907ca5b54