### PR TITLE
Refactor wizard nav buttons

### DIFF
--- a/docs/css_best_practices.md
+++ b/docs/css_best_practices.md
@@ -66,5 +66,7 @@ and extends the `stylelint-config-standard` rules.
 - Do new styles rely on design tokens rather than hard–coded values?
 - Are utility classes sorted and grouped logically?
 - Could repeated class strings be moved into a shared component?
+- Are you reusing existing UI components (like `Button`) instead of repeating
+  long utility class lists?
 
 Following these practices helps the codebase scale as features grow.

--- a/frontend/src/components/booking/WizardNav.tsx
+++ b/frontend/src/components/booking/WizardNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 import clsx from 'clsx';
+import { Button } from '../ui';
 
 interface Props {
   step: number;
@@ -25,33 +26,31 @@ export default function WizardNav({
     <div className="mt-8">
       <div className="flex flex-col-reverse sm:flex-row sm:justify-between gap-2">
         {onBack && step > 0 && (
-          <button
+          <Button
             type="button"
+            variant="secondary"
             onClick={onBack}
-            className="bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-lg px-6 py-2 w-full sm:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 order-3 sm:order-1"
+            className="order-3 w-full sm:order-1 sm:w-auto"
           >
             Back
-          </button>
+          </Button>
         )}
-        <button
+        <Button
           type="button"
+          variant="secondary"
           onClick={onSaveDraft}
-          className="bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-lg px-6 py-2 w-full sm:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 order-2 sm:order-2"
+          className="order-2 w-full sm:w-auto"
         >
           Save Draft
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          disabled={submitting}
-          aria-busy={submitting}
           onClick={onNext}
-          className={clsx(
-            'bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg px-6 py-2 w-full sm:w-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 order-1 sm:order-3',
-            submitting && 'opacity-75',
-          )}
+          isLoading={submitting}
+          className={clsx('order-1 w-full sm:order-3 sm:w-auto', submitting && 'opacity-75')}
         >
           {submitLabel || (lastStep ? 'Submit' : 'Next')}
-        </button>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- reuse Button component in WizardNav to reduce duplicate CSS
- document using shared UI components in CSS best practices

## Testing
- `./scripts/test-all.sh` *(fails: could not fetch git remote)*

------
https://chatgpt.com/codex/tasks/task_e_6886833a3ab4832eb331d9d10bdfbd49