### PR TITLE
Improve BookingWizard styling

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -118,7 +118,7 @@
 
   /* Booking wizard common styles */
   .wizard-step-container {
-    @apply mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 shadow-xl md:p-8;
+    @apply mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8 border border-gray-300;
   }
 
   .instruction-text {
@@ -134,15 +134,15 @@
   }
 
   .selectable-card {
-    @apply flex cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white p-4 text-sm transition-all hover:border-gray-400 hover:shadow-sm;
+    @apply flex cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-colors hover:bg-gray-50;
   }
 
   .selectable-card-input:focus-visible + .selectable-card {
-    @apply ring-2 ring-brand;
+    @apply ring-2 ring-gray-700;
   }
 
   .selectable-card-input:checked + .selectable-card {
-    @apply border-brand bg-brand-light;
+    @apply border-gray-800 bg-gray-100;
   }
 
   .map-container {

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -329,6 +329,7 @@ export default function BookingWizard({
           maxStepCompleted={maxStepCompleted}
           onStepClick={handleStepClick}
           ariaLabel={`Progress: step ${step + 1} of ${steps.length}`}
+          variant="neutral"
         />
         <div
           aria-live="polite"

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -9,6 +9,8 @@ interface StepperProps {
   maxStepCompleted?: number;
   onStepClick?: (index: number) => void;
   ariaLabel?: string;
+  /** Color style variant */
+  variant?: 'brand' | 'neutral';
 }
 
 export default function Stepper({
@@ -17,6 +19,7 @@ export default function Stepper({
   maxStepCompleted,
   onStepClick,
   ariaLabel,
+  variant = 'brand',
 }: StepperProps) {
   const maxAllowed =
     typeof maxStepCompleted === 'number' ? maxStepCompleted + 1 : currentStep;
@@ -42,11 +45,17 @@ export default function Stepper({
           <div
             className={clsx(
               'relative flex items-center justify-center w-5 h-5 rounded-full border',
-              isCompleted
-                ? 'bg-[var(--brand-color)] border-2 border-[var(--brand-color)] text-white'
-                : isActive
-                  ? 'bg-white border-2 border-[var(--brand-color)] text-[var(--brand-color)]'
-                  : 'bg-white border-gray-300 text-gray-400',
+              variant === 'neutral'
+                ? isCompleted
+                  ? 'bg-gray-900 border-2 border-gray-900 text-white'
+                  : isActive
+                    ? 'bg-white border-2 border-gray-900 text-gray-900'
+                    : 'bg-white border-gray-400 text-gray-400'
+                : isCompleted
+                  ? 'bg-[var(--brand-color)] border-2 border-[var(--brand-color)] text-white'
+                  : isActive
+                    ? 'bg-white border-2 border-[var(--brand-color)] text-[var(--brand-color)]'
+                    : 'bg-white border-gray-300 text-gray-400',
             )}
           >
             {isCompleted && <CheckIcon className="w-4 h-4" />}
@@ -57,7 +66,13 @@ export default function Stepper({
           <span
             className={clsx(
               'mt-1 text-xs font-semibold',
-              isActive ? 'text-[var(--brand-color)]' : 'text-gray-500',
+              variant === 'neutral'
+                ? isActive
+                  ? 'text-gray-900'
+                  : 'text-gray-500'
+                : isActive
+                  ? 'text-[var(--brand-color)]'
+                  : 'text-gray-500',
             )}
           >
             {label}
@@ -80,7 +95,10 @@ export default function Stepper({
               aria-current={isActive ? 'step' : undefined}
               aria-disabled={!isClickable ? 'true' : undefined}
               className={clsx(
-                'flex flex-col items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-color-dark)]',
+                'flex flex-col items-center focus:outline-none focus-visible:ring-2',
+                variant === 'neutral'
+                  ? 'focus-visible:ring-gray-700'
+                  : 'focus-visible:ring-[var(--brand-color-dark)]',
                 isClickable ? 'cursor-pointer' : 'cursor-default',
               )}
             >

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -138,4 +138,16 @@ describe('Stepper progress bar', () => {
     expect(button.className).toContain('focus-visible:ring-2');
     expect(button.className).toContain('focus-visible:ring-[var(--brand-color-dark)]');
   });
+
+  it('supports the neutral variant', () => {
+    act(() => {
+      root.render(
+        <Stepper steps={["One", "Two"]} currentStep={1} variant="neutral" />,
+      );
+    });
+    const circles = container.querySelectorAll('div.relative');
+    const activeCircle = circles[1] as HTMLDivElement;
+    expect(activeCircle.className).toContain('border-gray-900');
+    expect(activeCircle.className).toContain('border-2');
+  });
 });


### PR DESCRIPTION
## Summary
- flatten booking wizard layout
- add neutral variant to Stepper and tests
- center and unify booking wizard design in globals.css

## Testing
- `./setup.sh`
- `./scripts/test-all.sh` *(fails: 22 failed, 1 skipped, 72 passed)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688684ee0a18832e9e5419f833ebdeda