### PR TITLE
Remove line in progress container

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -329,7 +329,7 @@ export default function BookingWizard({
   return (
     <div className="px-4 py-16">
       <div
-        className="sticky z-20 bg-white"
+        className="sticky z-20"
         style={{ top: isMobile ? '4rem' : 0 }}
         data-testid="progress-container"
       >

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -30,11 +30,10 @@ export default function Stepper({
       aria-label={ariaLabel || 'Add service progress'}
       className="relative flex items-center justify-between px-2 mb-8"
     >
-      <motion.div
-        layout
-        className="absolute left-0 right-0 top-1/2 h-px bg-gray-200"
-        aria-hidden="true"
-      />
+      {/*
+       * The previous design used a horizontal line behind the stepper circles.
+       * It has been removed for a cleaner look across the booking flow.
+       */}
       {steps.map((label, i) => {
         const isClickable = !!onStepClick && i <= maxAllowed && i !== currentStep;
         const canButton = !!onStepClick && i <= maxAllowed;


### PR DESCRIPTION
## Summary
- clean up progress UI in BookingWizard
- remove the horizontal line from Stepper
- stop using a white background on the sticky progress container

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: ReferenceError getFullImageUrl is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68868e913c4c832ea8a47696120da68f