### PR TITLE
Implement styled Datepicker in booking wizard

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { Controller, Control, FieldValues } from 'react-hook-form';
 import WizardNav from '../WizardNav';
-import Calendar from 'react-calendar';
-import 'react-calendar/dist/Calendar.css';
+import ReactDatePicker from 'react-datepicker';
+import '../../styles/datepicker.css';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { format, parseISO } from 'date-fns';
-import { enUS } from 'date-fns/locale';
 import useIsMobile from '@/hooks/useIsMobile';
 import { DateInput } from '../../ui';
 
@@ -31,12 +31,10 @@ export default function DateTimeStep({
   onNext,
 }: Props) {
   const isMobile = useIsMobile();
-  const tileDisabled = ({ date }: { date: Date }) => {
+  const filterDate = (date: Date) => {
     const day = format(date, 'yyyy-MM-dd');
-    return unavailable.includes(day) || date < new Date();
+    return !unavailable.includes(day) && date >= new Date();
   };
-  const formatLongDate = (_locale: string | undefined, date: Date) =>
-    format(date, 'MMMM d, yyyy', { locale: enUS });
   return (
     <div className="wizard-step-container">
       {loading ? (
@@ -65,13 +63,48 @@ export default function DateTimeStep({
               />
             ) : (
               <div className="mx-auto w-fit border border-gray-200 rounded-lg hover:shadow-lg">
-                <Calendar
+                <ReactDatePicker
                   {...field}
-                  value={currentValue}
+                  selected={currentValue}
+                  inline
                   locale="en-US"
-                  formatLongDate={formatLongDate}
+                  filterDate={filterDate}
                   onChange={(date) => field.onChange(date as Date)}
-                  tileDisabled={tileDisabled}
+                  renderCustomHeader={({
+                    date,
+                    decreaseMonth,
+                    increaseMonth,
+                    prevMonthButtonDisabled,
+                    nextMonthButtonDisabled,
+                  }) => (
+                    <div className="flex justify-between items-center px-3 pt-2 pb-2">
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          decreaseMonth();
+                        }}
+                        disabled={prevMonthButtonDisabled}
+                        className="p-1 rounded-full hover:bg-gray-100"
+                      >
+                        <ChevronLeftIcon className="h-5 w-5 text-gray-500" />
+                      </button>
+                      <span className="text-base font-semibold text-gray-900">
+                        {date.toLocaleString('default', { month: 'long', year: 'numeric' })}
+                      </span>
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          increaseMonth();
+                        }}
+                        disabled={nextMonthButtonDisabled}
+                        className="p-1 rounded-full hover:bg-gray-100"
+                      >
+                        <ChevronRightIcon className="h-5 w-5 text-gray-500" />
+                      </button>
+                    </div>
+                  )}
                 />
               </div>
             );


### PR DESCRIPTION
## Summary
- switch DateTimeStep to use `react-datepicker` with custom header

## Testing
- `./setup.sh`
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: jest errors)*

------
https://chatgpt.com/codex/tasks/task_e_68869129c5a8832ebc0fbb28850c0bc0