### PR TITLE
Fix search field datepicker css import

### DIFF
--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -3,7 +3,7 @@
 import { forwardRef, Fragment } from 'react';
 import ReactDatePicker from 'react-datepicker';
 
-import '../styles/datepicker.css';
+import '../../styles/datepicker.css';
 import { Listbox, Transition } from '@headlessui/react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';


### PR DESCRIPTION
## Summary
- fix incorrect datepicker.css path

## Testing
- `./scripts/test-all.sh` *(fails: sqlalchemy OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6886969f4abc832eb680786fd0e1411a