### PR TITLE
Remove redundant labels from booking wizard

### DIFF
--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -31,7 +31,6 @@ export default function GuestsStep({
           <TextInput
             type="number"
             min={1}
-            label="Number of guests"
             className="input-base text-lg"
             {...field}
             autoFocus={!isMobile}

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -55,7 +55,6 @@ export default function NotesStep({
   }
   return (
     <div className="wizard-step-container">
-      <label className="block text-sm font-medium">Extra notes</label>
       <Controller
         name="notes"
         control={control}

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -27,7 +27,6 @@ export default function SoundStep({
         control={control}
         render={({ field }) => (
           <fieldset className="space-y-2">
-            <legend className="font-medium">Is sound needed?</legend>
             <div>
               <input
                 id="sound-yes"

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -60,7 +60,6 @@ export default function VenueStep({
                   testId="bottom-sheet"
                 >
                   <fieldset className="p-4 space-y-2">
-                    <legend className="font-medium">Venue Type</legend>
                     {options.map((opt, idx) => (
                       <div key={opt.value}>
                         <input
@@ -89,7 +88,6 @@ export default function VenueStep({
               </>
             ) : (
               <fieldset className="space-y-2">
-                <legend className="font-medium">Venue Type</legend>
                 {options.map((opt) => (
                   <div key={opt.value}>
                     <input


### PR DESCRIPTION
## Summary
- streamline booking wizard UI
- remove `Venue Type` legend
- remove `Is sound needed?` legend
- remove `Extra notes` label
- remove `Number of guests` label

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: TypeError in backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_688699c5a798832eae1d0d01990edf34