### PR TITLE
Add vertical sidebar stepper

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -327,29 +327,33 @@ export default function BookingWizard({
   };
 
   return (
-    <div className="px-4 py-16">
-      <div
-        className="sticky z-20"
-        style={{ top: isMobile ? '4rem' : 0 }}
-        data-testid="progress-container"
-      >
-        <Stepper
-          steps={steps}
-          currentStep={step}
-          maxStepCompleted={maxStepCompleted}
-          onStepClick={handleStepClick}
-          ariaLabel={`Progress: step ${step + 1} of ${steps.length}`}
-          variant="neutral"
-        />
+    <div className="px-4 py-16 lg:grid lg:grid-cols-[200px_1fr] lg:gap-8">
+      <aside className="lg:w-[200px] lg:pr-4">
         <div
-          aria-live="polite"
-          aria-atomic="true"
-          className="sr-only"
-          data-testid="progress-status"
+          className="sticky z-20"
+          style={{ top: isMobile ? '4rem' : '5rem' }}
+          data-testid="progress-container"
         >
-          {`Step ${step + 1} of ${steps.length}`}
+          <Stepper
+            steps={steps}
+            currentStep={step}
+            maxStepCompleted={maxStepCompleted}
+            onStepClick={handleStepClick}
+            ariaLabel={`Progress: step ${step + 1} of ${steps.length}`}
+            variant="neutral"
+            orientation={isMobile ? 'horizontal' : 'vertical'}
+            className="lg:space-y-6"
+          />
+          <div
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+            data-testid="progress-status"
+          >
+            {`Step ${step + 1} of ${steps.length}`}
+          </div>
         </div>
-      </div>
+      </aside>
       {isMobile ? (
         <div className="space-y-4">
           {steps.map((label, i) => (

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -11,6 +11,10 @@ interface StepperProps {
   ariaLabel?: string;
   /** Color style variant */
   variant?: 'brand' | 'neutral';
+  /** Orientation of the stepper */
+  orientation?: 'horizontal' | 'vertical';
+  /** Additional classes */
+  className?: string;
 }
 
 export default function Stepper({
@@ -20,6 +24,8 @@ export default function Stepper({
   onStepClick,
   ariaLabel,
   variant = 'brand',
+  orientation = 'horizontal',
+  className,
 }: StepperProps) {
   const maxAllowed =
     typeof maxStepCompleted === 'number' ? maxStepCompleted + 1 : currentStep;
@@ -28,7 +34,13 @@ export default function Stepper({
       layout
       role="list"
       aria-label={ariaLabel || 'Add service progress'}
-      className="relative flex items-center justify-between px-2 mb-8"
+      className={clsx(
+        'relative flex px-2 mb-8',
+        orientation === 'vertical'
+          ? 'flex-col items-start space-y-6'
+          : 'items-center justify-between',
+        className,
+      )}
     >
       {/*
        * The previous design used a horizontal line behind the stepper circles.
@@ -78,12 +90,19 @@ export default function Stepper({
           </span>
         );
 
-        const content = (
-          <div className="flex flex-col items-center">
-            {circle}
-            {labelEl}
-          </div>
-        );
+        const content = orientation === 'vertical'
+          ? (
+              <div className="flex items-center space-x-3">
+                {circle}
+                {labelEl}
+              </div>
+            )
+          : (
+              <div className="flex flex-col items-center">
+                {circle}
+                {labelEl}
+              </div>
+            );
         if (canButton) {
           return (
             <button
@@ -94,7 +113,10 @@ export default function Stepper({
               aria-current={isActive ? 'step' : undefined}
               aria-disabled={!isClickable ? 'true' : undefined}
               className={clsx(
-                'flex flex-col items-center focus:outline-none focus-visible:ring-2',
+                'focus:outline-none focus-visible:ring-2',
+                orientation === 'vertical'
+                  ? 'flex items-center'
+                  : 'flex flex-col items-center',
                 variant === 'neutral'
                   ? 'focus-visible:ring-gray-700'
                   : 'focus-visible:ring-[var(--brand-color-dark)]',
@@ -111,7 +133,12 @@ export default function Stepper({
             role="listitem"
             aria-current={isActive ? 'step' : undefined}
             aria-disabled="true"
-            className="flex flex-col items-center cursor-default"
+            className={clsx(
+              'cursor-default',
+              orientation === 'vertical'
+                ? 'flex items-center'
+                : 'flex flex-col items-center',
+            )}
           >
             {content}
           </div>

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -150,4 +150,14 @@ describe('Stepper progress bar', () => {
     expect(activeCircle.className).toContain('border-gray-900');
     expect(activeCircle.className).toContain('border-2');
   });
+
+  it('renders vertically when orientation is set to vertical', () => {
+    act(() => {
+      root.render(
+        <Stepper steps={["One", "Two"]} currentStep={0} orientation="vertical" />,
+      );
+    });
+    const wrapper = container.querySelector('div[role="list"]');
+    expect(wrapper?.className).toContain('flex-col');
+  });
 });


### PR DESCRIPTION
## Summary
- redesign Stepper component to support a vertical orientation
- adjust BookingWizard layout to use a sticky vertical sidebar stepper on large screens
- update unit tests for new Stepper orientation

## Testing
- `npm test` *(fails: 23 failed, 1 skipped, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688723071a8c832ea6d952ff6b5244c8