### PR TITLE
Improve booking wizard layout responsiveness

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -1,68 +1,68 @@
-'use client';
+"use client";
 // Main wizard component controlling the multi-step booking flow.
 // On mobile devices sections collapse into accordions and the
 // progress indicator remains sticky as the user scrolls.
-import { useEffect, useState, useRef } from 'react';
-import type { Control, FieldValues } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
-import * as yup from 'yup';
-import { format } from 'date-fns';
-import Stepper from '../ui/Stepper'; // progress indicator
-import CollapsibleSection from '../ui/CollapsibleSection';
-import Card from '../ui/Card';
-import { AnimatePresence, motion } from 'framer-motion';
-import toast from '../ui/Toast';
+import { useEffect, useState, useRef } from "react";
+import type { Control, FieldValues } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import * as yup from "yup";
+import { format } from "date-fns";
+import Stepper from "../ui/Stepper"; // progress indicator
+import CollapsibleSection from "../ui/CollapsibleSection";
+import Card from "../ui/Card";
+import { AnimatePresence, motion } from "framer-motion";
+import toast from "../ui/Toast";
 import {
   getArtistAvailability,
   createBookingRequest,
   updateBookingRequest,
   postMessageToBookingRequest,
   getArtist,
-} from '@/lib/api';
-import { BookingRequestCreate } from '@/types';
-import { useBooking, EventDetails } from '@/contexts/BookingContext';
-import useBookingForm from '@/hooks/useBookingForm';
-import DateTimeStep from './steps/DateTimeStep';
-import LocationStep from './steps/LocationStep';
-import GuestsStep from './steps/GuestsStep';
-import SoundStep from './steps/SoundStep';
-import VenueStep from './steps/VenueStep';
-import NotesStep from './steps/NotesStep';
-import ReviewStep from './steps/ReviewStep';
-import useIsMobile from '@/hooks/useIsMobile';
+} from "@/lib/api";
+import { BookingRequestCreate } from "@/types";
+import { useBooking, EventDetails } from "@/contexts/BookingContext";
+import useBookingForm from "@/hooks/useBookingForm";
+import DateTimeStep from "./steps/DateTimeStep";
+import LocationStep from "./steps/LocationStep";
+import GuestsStep from "./steps/GuestsStep";
+import SoundStep from "./steps/SoundStep";
+import VenueStep from "./steps/VenueStep";
+import NotesStep from "./steps/NotesStep";
+import ReviewStep from "./steps/ReviewStep";
+import useIsMobile from "@/hooks/useIsMobile";
 
 const steps = [
-  'Date & Time',
-  'Location',
-  'Guests',
-  'Venue Type',
-  'Sound',
-  'Notes',
-  'Review',
+  "Date & Time",
+  "Location",
+  "Guests",
+  "Venue Type",
+  "Sound",
+  "Notes",
+  "Review",
 ];
 
 const instructions = [
-  'When should we perform?',
-  'Where is the show?',
-  'How many people?',
-  'What type of venue is it?',
-  'Will sound equipment be needed?',
-  'Anything else we should know?',
-  'Please confirm the information above before sending your request.',
+  "When should we perform?",
+  "Where is the show?",
+  "How many people?",
+  "What type of venue is it?",
+  "Will sound equipment be needed?",
+  "Anything else we should know?",
+  "Please confirm the information above before sending your request.",
 ];
 
 const schema = yup.object({
-  date: yup.date().required().min(new Date(), 'Pick a future date'),
-  location: yup.string().required('Location is required'),
+  date: yup.date().required().min(new Date(), "Pick a future date"),
+  location: yup.string().required("Location is required"),
   guests: yup
     .string()
-    .required('Number of guests is required')
-    .matches(/^\d+$/, 'Guests must be a number'),
+    .required("Number of guests is required")
+    .matches(/^\d+$/, "Guests must be a number"),
   venueType: yup
-    .mixed<'indoor' | 'outdoor' | 'hybrid'>()
-    .oneOf(['indoor', 'outdoor', 'hybrid'])
+    .mixed<"indoor" | "outdoor" | "hybrid">()
+    .oneOf(["indoor", "outdoor", "hybrid"])
     .required(),
-  sound: yup.string().oneOf(['yes', 'no']).required(),
+  sound: yup.string().oneOf(["yes", "no"]).required(),
   notes: yup.string().optional(),
   attachment_url: yup.string().optional(),
 });
@@ -101,19 +101,17 @@ export default function BookingWizard({
     setMaxStepCompleted((prev) => Math.max(prev, step));
   }, [step]);
 
-  const {
-    control,
-    handleSubmit,
-    trigger,
-    setValue,
-    errors,
-  } = useBookingForm(schema, details, setDetails);
+  const { control, handleSubmit, trigger, setValue, errors } = useBookingForm(
+    schema,
+    details,
+    setDetails,
+  );
 
   // Keep the start of each step visible on small screens
   // so navigation feels smooth on mobile devices.
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
     }
     headingRef.current?.focus();
   }, [step]);
@@ -141,19 +139,19 @@ export default function BookingWizard({
     let fields: (keyof EventDetails)[] = [];
     switch (step) {
       case 0:
-        fields = ['date'];
+        fields = ["date"];
         break;
       case 1:
-        fields = ['location'];
+        fields = ["location"];
         break;
       case 2:
-        fields = ['guests'];
+        fields = ["guests"];
         break;
       case 3:
-        fields = ['venueType'];
+        fields = ["venueType"];
         break;
       case 4:
-        fields = ['sound'];
+        fields = ["sound"];
         break;
       default:
         fields = [];
@@ -174,10 +172,12 @@ export default function BookingWizard({
     const payload: BookingRequestCreate = {
       artist_id: artistId,
       service_id: contextServiceId,
-      proposed_datetime_1: vals.date ? new Date(vals.date).toISOString() : undefined,
+      proposed_datetime_1: vals.date
+        ? new Date(vals.date).toISOString()
+        : undefined,
       message: vals.notes,
       attachment_url: vals.attachment_url,
-      status: 'draft',
+      status: "draft",
     };
     try {
       if (requestId) {
@@ -187,7 +187,7 @@ export default function BookingWizard({
         setRequestId(res.data.id);
       }
       setError(null);
-      toast.success('Draft saved');
+      toast.success("Draft saved");
     } catch (e) {
       const err = e as Error;
       setError(err.message);
@@ -199,10 +199,12 @@ export default function BookingWizard({
     const payload: BookingRequestCreate = {
       artist_id: artistId,
       service_id: contextServiceId,
-      proposed_datetime_1: vals.date ? new Date(vals.date).toISOString() : undefined,
+      proposed_datetime_1: vals.date
+        ? new Date(vals.date).toISOString()
+        : undefined,
       message: vals.notes,
       attachment_url: vals.attachment_url,
-      status: 'pending_quote',
+      status: "pending_quote",
     };
     try {
       let res;
@@ -214,7 +216,7 @@ export default function BookingWizard({
       }
       const idToUse = requestId || res.data.id;
       const lines = [
-        `Date: ${format(vals.date, 'yyyy-MM-dd')}`,
+        `Date: ${format(vals.date, "yyyy-MM-dd")}`,
         `Location: ${vals.location}`,
         `Guests: ${vals.guests}`,
         `Sound: ${vals.sound}`,
@@ -223,12 +225,12 @@ export default function BookingWizard({
       if (vals.notes) {
         lines.push(`Notes: ${vals.notes}`);
       }
-      const detailLines = lines.join('\n');
+      const detailLines = lines.join("\n");
       await postMessageToBookingRequest(idToUse, {
         content: `Booking details:\n${detailLines}`,
-        message_type: 'system',
+        message_type: "system",
       });
-      toast.success('Request submitted');
+      toast.success("Request submitted");
       resetBooking();
       router.push(`/booking-requests/${idToUse}`);
     } catch (e) {
@@ -304,7 +306,9 @@ export default function BookingWizard({
         return (
           <NotesStep
             control={control as unknown as Control<FieldValues>}
-            setValue={setValue as unknown as (name: string, value: unknown) => void}
+            setValue={
+              setValue as unknown as (name: string, value: unknown) => void
+            }
             step={index}
             steps={steps}
             onBack={prev}
@@ -327,13 +331,9 @@ export default function BookingWizard({
   };
 
   return (
-    <div className="px-4 py-16 lg:grid lg:grid-cols-[200px_1fr] lg:gap-8">
-      <aside className="lg:w-[200px] lg:pr-4">
-        <div
-          className="sticky z-20"
-          style={{ top: isMobile ? '4rem' : '5rem' }}
-          data-testid="progress-container"
-        >
+    <main className="mx-auto max-w-7xl px-4 lg:px-8">
+      <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[200px_1fr] lg:gap-8">
+        <aside aria-label="Booking steps">
           <Stepper
             steps={steps}
             currentStep={step}
@@ -341,8 +341,9 @@ export default function BookingWizard({
             onStepClick={handleStepClick}
             ariaLabel={`Progress: step ${step + 1} of ${steps.length}`}
             variant="neutral"
-            orientation={isMobile ? 'horizontal' : 'vertical'}
-            className="lg:space-y-6"
+            orientation={isMobile ? "horizontal" : "vertical"}
+            data-testid="progress-container"
+            className="w-full justify-center space-x-6 py-4 lg:sticky lg:top-16 lg:flex-col lg:items-start lg:space-x-0 lg:space-y-6 lg:border-r lg:border-gray-200 lg:pr-6 lg:pt-0"
           />
           <div
             aria-live="polite"
@@ -352,80 +353,84 @@ export default function BookingWizard({
           >
             {`Step ${step + 1} of ${steps.length}`}
           </div>
-        </div>
-      </aside>
-      {isMobile ? (
-        <div className="space-y-4">
-          {steps.map((label, i) => (
-            <CollapsibleSection
-              key={label}
-              title={label}
-              open={i === step}
-              onToggle={() => handleStepClick(i)}
-            >
-              {i === step && (
-                <>
-                  <h2
-                    className="sr-only"
-                    data-testid="step-heading"
-                    tabIndex={-1}
-                    ref={headingRef}
-                  >
-                    {label}
-                  </h2>
-                  <p className="instruction-text mb-2">{instructions[i]}</p>
-                  <AnimatePresence mode="wait">
-                    <motion.div
-                      key={step}
-                      initial={{ opacity: 0, x: 20 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: -20 }}
-                      transition={{ duration: 0.3 }}
+        </aside>
+        {isMobile ? (
+          <div className="space-y-4">
+            {steps.map((label, i) => (
+              <CollapsibleSection
+                key={label}
+                title={label}
+                open={i === step}
+                onToggle={() => handleStepClick(i)}
+              >
+                {i === step && (
+                  <>
+                    <h2
+                      className="sr-only"
+                      data-testid="step-heading"
+                      tabIndex={-1}
+                      ref={headingRef}
                     >
-                      <Card variant="wizard">{renderStep(i)}</Card>
-                    </motion.div>
-                  </AnimatePresence>
-                  {warning && (
-                    <p className="text-orange-600 text-sm">{warning}</p>
-                  )}
-                  {Object.values(errors).length > 0 && (
-                    <p className="text-red-600 text-sm">Please fix the errors above.</p>
-                  )}
-                  {error && <p className="text-red-600 text-sm">{error}</p>}
-                </>
-              )}
-            </CollapsibleSection>
-          ))}
-        </div>
-      ) : (
-        <Card variant="wizard" className="space-y-6">
-          <h2
-            className="text-2xl font-bold"
-            data-testid="step-heading"
-            tabIndex={-1}
-            ref={headingRef}
-          >
-            {steps[step]}
-          </h2>
-          <p className="instruction-text mb-2">{instructions[step]}</p>
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={step}
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -20 }}
-              transition={{ duration: 0.3 }}
+                      {label}
+                    </h2>
+                    <p className="instruction-text mb-2">{instructions[i]}</p>
+                    <AnimatePresence mode="wait">
+                      <motion.div
+                        key={step}
+                        initial={{ opacity: 0, x: 20 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        exit={{ opacity: 0, x: -20 }}
+                        transition={{ duration: 0.3 }}
+                      >
+                        <Card variant="wizard">{renderStep(i)}</Card>
+                      </motion.div>
+                    </AnimatePresence>
+                    {warning && (
+                      <p className="text-sm text-orange-600">{warning}</p>
+                    )}
+                    {Object.values(errors).length > 0 && (
+                      <p className="text-sm text-red-600">
+                        Please fix the errors above.
+                      </p>
+                    )}
+                    {error && <p className="text-sm text-red-600">{error}</p>}
+                  </>
+                )}
+              </CollapsibleSection>
+            ))}
+          </div>
+        ) : (
+          <Card variant="wizard" className="space-y-6">
+            <h2
+              className="text-2xl font-bold"
+              data-testid="step-heading"
+              tabIndex={-1}
+              ref={headingRef}
             >
-              {renderStep(step)}
-            </motion.div>
-          </AnimatePresence>
-          {warning && <p className="text-orange-600 text-sm">{warning}</p>}
-          {Object.values(errors).length > 0 && (
-            <p className="text-red-600 text-sm">Please fix the errors above.</p>
-          )}
-          {error && <p className="text-red-600 text-sm">{error}</p>}
-        </Card>
-      )}
-    </div>
+              {steps[step]}
+            </h2>
+            <p className="instruction-text mb-2">{instructions[step]}</p>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={step}
+                initial={{ opacity: 0, x: 20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -20 }}
+                transition={{ duration: 0.3 }}
+              >
+                {renderStep(step)}
+              </motion.div>
+            </AnimatePresence>
+            {warning && <p className="text-sm text-orange-600">{warning}</p>}
+            {Object.values(errors).length > 0 && (
+              <p className="text-sm text-red-600">
+                Please fix the errors above.
+              </p>
+            )}
+            {error && <p className="text-sm text-red-600">{error}</p>}
+          </Card>
+        )}
+      </div>
+    </main>
   );
 }

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -1,13 +1,12 @@
 import { flushPromises } from "@/test/utils/flush";
-import { createRoot } from 'react-dom/client';
-import React from 'react';
-import { act } from 'react';
-import BookingWizard from '../BookingWizard';
-import { BookingProvider, useBooking } from '@/contexts/BookingContext';
-import * as api from '@/lib/api';
+import { createRoot } from "react-dom/client";
+import React from "react";
+import { act } from "react";
+import BookingWizard from "../BookingWizard";
+import { BookingProvider, useBooking } from "@/contexts/BookingContext";
+import * as api from "@/lib/api";
 
-jest.mock('@/lib/api');
-
+jest.mock("@/lib/api");
 
 function Wrapper() {
   return (
@@ -18,23 +17,28 @@ function Wrapper() {
   );
 }
 
-  function ExposeSetter() {
-    const { setStep } = useBooking();
-    // Cast to unknown first to avoid eslint no-explicit-any complaint
-    (window as unknown as { __setStep: (step: number) => void }).__setStep = setStep;
-    return null;
-  }
+function ExposeSetter() {
+  const { setStep } = useBooking();
+  // Cast to unknown first to avoid eslint no-explicit-any complaint
+  (window as unknown as { __setStep: (step: number) => void }).__setStep =
+    setStep;
+  return null;
+}
 
-describe('BookingWizard flow', () => {
+describe("BookingWizard flow", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
   beforeEach(async () => {
-    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
-    (api.getArtistAvailability as jest.Mock).mockResolvedValue({ data: { unavailable_dates: [] } });
-    (api.getArtist as jest.Mock).mockResolvedValue({ data: { location: 'NYC' } });
+    Object.defineProperty(window, "innerWidth", { value: 500, writable: true });
+    (api.getArtistAvailability as jest.Mock).mockResolvedValue({
+      data: { unavailable_dates: [] },
+    });
+    (api.getArtist as jest.Mock).mockResolvedValue({
+      data: { location: "NYC" },
+    });
 
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
     // jsdom does not implement scrollTo, so provide a stub
@@ -55,88 +59,106 @@ describe('BookingWizard flow', () => {
   });
 
   function getButton(label: string): HTMLButtonElement {
-    return Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes(label),
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(label),
     ) as HTMLButtonElement;
   }
 
-  it('scrolls to top when advancing steps', async () => {
-    const nextButton = getButton('Next');
+  it("scrolls to top when advancing steps", async () => {
+    const nextButton = getButton("Next");
     await act(async () => {
-      nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      nextButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(window.scrollTo).toHaveBeenCalled();
   });
 
-  it('shows step heading and updates on next', async () => {
+  it("shows step heading and updates on next", async () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;
-    expect(heading()).toContain('Date & Time');
-    const next = getButton('Next');
+    expect(heading()).toContain("Date & Time");
+    const next = getButton("Next");
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushPromises();
-    expect(heading()).toContain('Location');
+    expect(heading()).toContain("Location");
   });
 
-  it('collapses inactive steps on mobile', async () => {
+  it("collapses inactive steps on mobile", async () => {
     const sections = () =>
-      Array.from(container.querySelectorAll('section button[aria-controls]')) as HTMLButtonElement[];
-    expect(sections()[0].getAttribute('aria-expanded')).toBe('true');
-    expect(sections()[1].getAttribute('aria-expanded')).toBe('false');
-    const next = getButton('Next');
+      Array.from(
+        container.querySelectorAll("section button[aria-controls]"),
+      ) as HTMLButtonElement[];
+    expect(sections()[0].getAttribute("aria-expanded")).toBe("true");
+    expect(sections()[1].getAttribute("aria-expanded")).toBe("false");
+    const next = getButton("Next");
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushPromises();
     const updated = sections();
-    expect(updated[0].getAttribute('aria-expanded')).toBe('false');
-    expect(updated[1].getAttribute('aria-expanded')).toBe('true');
+    expect(updated[0].getAttribute("aria-expanded")).toBe("false");
+    expect(updated[1].getAttribute("aria-expanded")).toBe("true");
   });
 
-  it('shows summary only on the review step', async () => {
-    expect(container.querySelector('h2')?.textContent).toContain('Date & Time');
-    expect(container.textContent).not.toContain('Summary');
-    const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
-    await act(async () => { setStep(6); });
-    await flushPromises();
-    expect(container.querySelector('h2')?.textContent).toContain('Review');
-    expect(container.textContent).toContain('Summary');
-  });
-
-  it('allows navigating back via the progress bar', async () => {
-    const next = getButton('Next');
+  it("shows summary only on the review step", async () => {
+    expect(container.querySelector("h2")?.textContent).toContain("Date & Time");
+    expect(container.textContent).not.toContain("Summary");
+    const setStep = (window as unknown as { __setStep: (s: number) => void })
+      .__setStep;
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      setStep(6);
     });
     await flushPromises();
-    const progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+    expect(container.querySelector("h2")?.textContent).toContain("Review");
+    expect(container.textContent).toContain("Summary");
+  });
+
+  it("allows navigating back via the progress bar", async () => {
+    const next = getButton("Next");
+    await act(async () => {
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushPromises();
+    const progressButtons = container.querySelectorAll(
+      '[aria-label="Progress"] button',
+    );
     expect(progressButtons.length).toBeGreaterThan(1);
     await act(async () => {
-      progressButtons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      progressButtons[0].dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
     await flushPromises();
     expect(
       container.querySelector('[data-testid="step-heading"]')?.textContent,
-    ).toContain('Date & Time');
+    ).toContain("Date & Time");
   });
 
-  it('keeps future completed steps clickable when rewinding', async () => {
-    const setStep = (window as unknown as { __setStep: (s: number) => void }).__setStep;
-    await act(async () => { setStep(2); });
-    await flushPromises();
-    let progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+  it("keeps future completed steps clickable when rewinding", async () => {
+    const setStep = (window as unknown as { __setStep: (s: number) => void })
+      .__setStep;
     await act(async () => {
-      progressButtons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      setStep(2);
+    });
+    await flushPromises();
+    let progressButtons = container.querySelectorAll(
+      '[aria-label="Progress"] button',
+    );
+    await act(async () => {
+      progressButtons[1].dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     });
     await flushPromises();
     // query again after DOM update
-    progressButtons = container.querySelectorAll('[aria-label="Progress"] button');
+    progressButtons = container.querySelectorAll(
+      '[aria-label="Progress"] button',
+    );
     expect((progressButtons[2] as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('shows a loader while fetching availability', async () => {
+  it("shows a loader while fetching availability", async () => {
     let resolve: (value: { data: { unavailable_dates: string[] } }) => void;
     (api.getArtistAvailability as jest.Mock).mockReturnValue(
       new Promise((res) => {
@@ -146,113 +168,124 @@ describe('BookingWizard flow', () => {
     act(() => {
       root.unmount();
     });
-    container.innerHTML = '';
+    container.innerHTML = "";
     root = createRoot(container);
     await act(async () => {
       root.render(React.createElement(Wrapper));
     });
-    const skeleton = container.querySelector('[data-testid="calendar-skeleton"]');
+    const skeleton = container.querySelector(
+      '[data-testid="calendar-skeleton"]',
+    );
     expect(skeleton).not.toBeNull();
     act(() => resolve({ data: { unavailable_dates: [] } }));
     await flushPromises();
-    expect(container.querySelector('[data-testid="calendar-skeleton"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="calendar-skeleton"]'),
+    ).toBeNull();
   });
 
-  it('renders a sticky progress indicator', () => {
-    const wrapper = container.querySelector('[data-testid="progress-container"]') as HTMLDivElement | null;
-    expect(wrapper?.className).toContain('sticky');
-    expect(wrapper?.style.top).toBe('4rem');
+  it("does not make the progress indicator sticky on mobile", () => {
+    const wrapper = container.querySelector(
+      '[data-testid="progress-container"]',
+    ) as HTMLDivElement | null;
+    expect(wrapper?.className).not.toContain("sticky");
   });
 
-  it('announces progress updates for screen readers', async () => {
+  it("announces progress updates for screen readers", async () => {
     const progress = () =>
       container.querySelector('[data-testid="progress-status"]')?.textContent;
-    expect(progress()).toBe('Step 1 of 7');
-    const next = getButton('Next');
+    expect(progress()).toBe("Step 1 of 7");
+    const next = getButton("Next");
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushPromises();
-    expect(progress()).toBe('Step 2 of 7');
+    expect(progress()).toBe("Step 2 of 7");
   });
 
-  it('moves focus to the step heading when advancing', async () => {
-    const next = getButton('Next');
+  it("moves focus to the step heading when advancing", async () => {
+    const next = getButton("Next");
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushPromises();
     const heading = container.querySelector('[data-testid="step-heading"]');
     expect(document.activeElement).toBe(heading);
   });
 
-  it('disables dates returned from Google Calendar', async () => {
+  it("disables dates returned from Google Calendar", async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
     (api.getArtistAvailability as jest.Mock).mockResolvedValue({
-      data: { unavailable_dates: ['2025-01-02'] },
+      data: { unavailable_dates: ["2025-01-02"] },
     });
     act(() => {
       root.unmount();
     });
-    container.innerHTML = '';
+    container.innerHTML = "";
     root = createRoot(container);
     await act(async () => {
       root.render(React.createElement(Wrapper));
     });
     await flushPromises();
-    const disabledButtons = container.querySelectorAll('button[disabled]');
+    const disabledButtons = container.querySelectorAll("button[disabled]");
     expect(disabledButtons.length).toBeGreaterThan(1);
     jest.useRealTimers();
   });
 
-  it('restores progress from localStorage on reload', async () => {
+  it("restores progress from localStorage on reload", async () => {
     (window as unknown as { confirm: jest.Mock }).confirm = jest.fn(() => true);
-    const next = getButton('Next');
+    const next = getButton("Next");
     await act(async () => {
-      next.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      next.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushPromises();
-    const stored = JSON.parse(localStorage.getItem('bookingState')!);
+    const stored = JSON.parse(localStorage.getItem("bookingState")!);
     expect(stored.step).toBe(1);
 
     act(() => {
       root.unmount();
     });
-    container.innerHTML = '';
+    container.innerHTML = "";
     root = createRoot(container);
     await act(async () => {
       root.render(React.createElement(Wrapper));
     });
     await flushPromises();
-    expect(container.querySelector('[data-testid="step-heading"]')?.textContent).toContain('Location');
+    expect(
+      container.querySelector('[data-testid="step-heading"]')?.textContent,
+    ).toContain("Location");
   });
 
-  it('clears saved progress when starting over', async () => {
+  it("clears saved progress when starting over", async () => {
     act(() => {
       root.unmount();
     });
     localStorage.setItem(
-      'bookingState',
+      "bookingState",
       JSON.stringify({
         step: 2,
         details: {
           date: new Date().toISOString(),
-          location: 'LA',
-          guests: '10',
-          venueType: 'indoor',
-          sound: 'yes',
+          location: "LA",
+          guests: "10",
+          venueType: "indoor",
+          sound: "yes",
         },
       }),
     );
-    (window as unknown as { confirm: jest.Mock }).confirm = jest.fn(() => false);
-    container.innerHTML = '';
+    (window as unknown as { confirm: jest.Mock }).confirm = jest.fn(
+      () => false,
+    );
+    container.innerHTML = "";
     root = createRoot(container);
     await act(async () => {
       root.render(React.createElement(Wrapper));
     });
     await flushPromises();
-    expect(localStorage.getItem('bookingState')).toBeNull();
-    expect(container.querySelector('[data-testid="step-heading"]')?.textContent).toContain('Date & Time');
+    expect(localStorage.getItem("bookingState")).toBeNull();
+    expect(
+      container.querySelector('[data-testid="step-heading"]')?.textContent,
+    ).toContain("Date & Time");
   });
 });


### PR DESCRIPTION
## Summary
- update the `BookingWizard` layout to better align the stepper on small and large screens
- adjust unit test expectations for the new stepper behaviour

## Testing
- `./scripts/test-all.sh` *(fails: many unit tests fail)*
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: many unit tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68872d1e3f98832eb01f886e174c28df