### PR TITLE
Fix BookingWizard modal rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Progress and form values persist to `localStorage`. Reloading the page prompts
   you to resume or start over. Saved data clears automatically after submission
   or when you reset the wizard.
+* The wizard opens in a modal when clicking **Request Booking** on an artist page, avoiding a page navigation.
 
 ### Open Tasks
 

--- a/frontend/src/__tests__/accessibility.test.tsx
+++ b/frontend/src/__tests__/accessibility.test.tsx
@@ -37,7 +37,7 @@ describe('accessibility audits', () => {
     await act(async () => {
       root.render(
         <BookingProvider>
-          <BookingWizard artistId={1} />
+          <BookingWizard artistId={1} isOpen onClose={() => {}} />
         </BookingProvider>
       );
     });

--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -35,6 +35,8 @@ import {
 } from '@/lib/utils';
 import ArtistServiceCard from '@/components/artist/ArtistServiceCard';
 import { Button, Tag, Toast, Spinner, SkeletonList } from '@/components/ui';
+import BookingWizard from '@/components/booking/BookingWizard';
+import { BookingProvider } from '@/contexts/BookingContext';
 
 // This profile page now lazy loads each section (services, reviews, other
 // artists) separately so the main artist info appears faster. Images use the
@@ -56,6 +58,8 @@ export default function ArtistProfilePage() {
   const [othersLoading, setOthersLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [otherView, setOtherView] = useState<'grid' | 'list'>('grid');
+  const [isBookingOpen, setIsBookingOpen] = useState(false);
+  const [selectedService, setSelectedService] = useState<Service | null>(null);
 
 
   useEffect(() => {
@@ -133,7 +137,8 @@ export default function ArtistProfilePage() {
       service.service_type === 'Live Performance' ||
       service.service_type === 'Virtual Appearance'
     ) {
-      router.push(`/booking?artist_id=${artistId}&service_id=${service.id}`);
+      setSelectedService(service);
+      setIsBookingOpen(true);
       return;
     }
     try {
@@ -146,6 +151,11 @@ export default function ArtistProfilePage() {
       console.error('Failed to create request', err);
       Toast.error('Failed to create request');
     }
+  };
+
+  const closeBooking = () => {
+    setIsBookingOpen(false);
+    setSelectedService(null);
   };
 
 
@@ -493,6 +503,14 @@ export default function ArtistProfilePage() {
         </div>
       </div>
     </MainLayout>
+    <BookingProvider>
+      <BookingWizard
+        artistId={artistId}
+        serviceId={selectedService?.id}
+        isOpen={isBookingOpen}
+        onClose={closeBooking}
+      />
+    </BookingProvider>
     </>
   );
 }

--- a/frontend/src/app/booking/page.tsx
+++ b/frontend/src/app/booking/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import BookingWizard from '@/components/booking/BookingWizard';
@@ -10,6 +10,7 @@ import { Spinner } from '@/components/ui';
 export default function BookingPage() {
   const { user, loading } = useAuth();
   const params = useSearchParams();
+  const router = useRouter();
   const artistId = Number(params.get('artist_id') || 0);
   const serviceIdParam = params.get('service_id');
   const serviceId = serviceIdParam ? Number(serviceIdParam) : undefined;
@@ -39,7 +40,12 @@ export default function BookingPage() {
     <MainLayout>
       <div className="max-w-3xl mx-auto p-4">
         <BookingProvider>
-          <BookingWizard artistId={artistId} serviceId={serviceId} />
+          <BookingWizard
+            artistId={artistId}
+            serviceId={serviceId}
+            isOpen
+            onClose={() => router.back()}
+          />
         </BookingProvider>
       </div>
     </MainLayout>

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -221,11 +221,9 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       case 4: return <SoundStep control={control} {...common} />;
       case 5: return <NotesStep control={control} setValue={setValue} />;
       case 6: return <ReviewStep {...common} onNext={submitRequest} submitting={submitting} submitLabel="Submit Request" />;
-      console.log('[BookingWizard]: isOpen =', isOpen);
       default: return null;
     }
   };
-  console.log('[BookingWizard]: isOpen =', isOpen);
   if (!isOpen) return null;
 
   return (

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -12,7 +12,7 @@ function Wrapper() {
   return (
     <BookingProvider>
       <ExposeSetter />
-      <BookingWizard artistId={1} />
+      <BookingWizard artistId={1} isOpen onClose={() => {}} />
     </BookingProvider>
   );
 }


### PR DESCRIPTION
## Summary
- make BookingWizard appear as modal
- open booking modal from artist page
- adjust /booking page usage for the modal
- update related tests and docs

## Testing
- `npm install --silent` in frontend
- `npm test -- -i` *(fails: cannot read properties of undefined, network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6887864f3790832e9e4c82121ba3bc78