### PR TITLE
Fix booking wizard width

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -118,7 +118,8 @@
 
   /* Booking wizard common styles */
   .wizard-step-container {
-    @apply mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8;
+    /* Ensure a consistent width across all booking steps */
+    @apply w-full mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8;
   }
 
   .instruction-text {


### PR DESCRIPTION
## Summary
- keep width constant for wizard steps

## Testing
- `./scripts/test-all.sh` *(fails: sqlite3.OperationalError table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6887979c6950832ea5bd370a0e0a652e