### PR TITLE
Fix booking wizard container size

### DIFF
--- a/docs/booking_wizard_layout.md
+++ b/docs/booking_wizard_layout.md
@@ -37,4 +37,4 @@ This snippet demonstrates the HTML structure and Tailwind CSS classes for the bo
 </main>
 ```
 
-The stepper text is bright red for the active step and muted gray for the rest. On small screens, the stepper stacks above the card and remains centered. The card expands to fill available space on larger screens.
+The stepper text is bright red for the active step and muted gray for the rest. On small screens, the stepper stacks above the card and remains centered. On larger screens, the card keeps a consistent width and minimum height across all steps so the layout doesn't shift as you progress.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -120,6 +120,8 @@
   .wizard-step-container {
     /* Ensure a consistent width across all booking steps */
     @apply w-full mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8;
+    /* Keep height stable so the card doesn't jump between steps */
+    @apply lg:min-h-[400px];
   }
 
   .instruction-text {


### PR DESCRIPTION
## Summary
- keep booking wizard panel width and height stable across steps
- note consistent dimensions in the booking wizard layout docs

## Testing
- `./scripts/test-all.sh` *(fails: backend OperationalError, frontend Jest failures)*


------
https://chatgpt.com/codex/tasks/task_e_68879f791038832e85742761f7f22e47