### PR TITLE
Fix event details min length

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -46,7 +46,7 @@ type EventDetails = {
 
 const schema = yup.object<EventDetails>().shape({
   eventType: yup.string().required(),
-  eventDescription: yup.string().required().min(10),
+  eventDescription: yup.string().required().min(5),
   date: yup.date().required().min(new Date()),
   location: yup.string().required(),
   guests: yup.string().required().matches(/^\d+$/, 'Must be a number'),


### PR DESCRIPTION
## Summary
- relax event details validation to minimum 5 characters

## Testing
- `npm test --silent` *(fails: cannot run jest - many failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6887c7c618d8832eb91421d15728ceb6