### PR TITLE
Refine booking resume prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,9 +795,9 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Steps now animate with **framer-motion** and the progress dots stay clickable for all completed steps.
 * Redesigned wizard uses animated stepper circles and spacious rounded cards for each step. Buttons have improved focus styles and align responsively.
 * The flow now begins with **Event Type** and **Event Details** steps so clients can describe their occasion before selecting the date.
-* Progress and form values persist to `localStorage`. Reloading the page prompts
-  you to resume or start over. Saved data clears automatically after submission
-  or when you reset the wizard.
+* Progress and form values persist to `localStorage`. Opening the booking wizard
+  again prompts you to resume or start over. Saved data clears automatically
+  after submission or when you reset the wizard.
 * The wizard opens in a modal when clicking **Request Booking** on an artist page, avoiding a page navigation.
 
 ### Open Tasks

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -108,6 +108,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     setRequestId,
     setServiceId,
     resetBooking,
+    loadSavedProgress,
   } = useBooking();
 
   const [unavailable, setUnavailable] = useState<string[]>([]);
@@ -118,6 +119,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   const [error, setError] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const isMobile = useIsMobile();
+  const hasLoaded = useRef(false);
 
   const {
     control,
@@ -137,6 +139,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     getArtistAvailability(artistId).then((res) => setUnavailable(res.data.unavailable_dates));
     getArtist(artistId).then((res) => setArtistLocation(res.data.location || null));
   }, [artistId]);
+
+  // Prompt to restore saved progress only when the wizard first opens
+  useEffect(() => {
+    if (!isOpen || hasLoaded.current) return;
+    loadSavedProgress();
+    hasLoaded.current = true;
+  }, [isOpen, loadSavedProgress]);
 
   useEffect(() => {
     if (serviceId) setServiceId(serviceId);

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -40,7 +40,7 @@ export default function Stepper({
       aria-label={ariaLabel || 'Booking progress'}
       className={clsx(
         // Base flex properties for the nav container
-        'relative flex px-2 mb-8',
+        'relative flex px-2',
         orientation === 'vertical'
           ? 'flex-col items-start space-y-4 lg:space-y-6' // Adjust space-y for vertical text steps
           : 'items-center justify-between',

--- a/frontend/src/components/ui/__tests__/Stepper.test.tsx
+++ b/frontend/src/components/ui/__tests__/Stepper.test.tsx
@@ -24,7 +24,7 @@ describe('Stepper progress bar', () => {
     act(() => {
       root.render(<Stepper steps={["One", "Two", "Three"]} currentStep={1} />);
     });
-    const wrapper = container.querySelector('div[role="list"]');
+    const wrapper = container.querySelector('nav[role="list"]');
     expect(wrapper).not.toBeNull();
     const items = container.querySelectorAll('[role="listitem"]');
     expect(items).toHaveLength(3);
@@ -36,7 +36,7 @@ describe('Stepper progress bar', () => {
     act(() => {
       root.render(<Stepper steps={["One", "Two"]} currentStep={0} ariaLabel="Booking progress" />);
     });
-    const wrapper = container.querySelector('div[role="list"]');
+    const wrapper = container.querySelector('nav[role="list"]');
     expect(wrapper?.getAttribute('aria-label')).toBe('Booking progress');
   });
 
@@ -157,7 +157,7 @@ describe('Stepper progress bar', () => {
         <Stepper steps={["One", "Two"]} currentStep={0} orientation="vertical" />,
       );
     });
-    const wrapper = container.querySelector('div[role="list"]');
+    const wrapper = container.querySelector('nav[role="list"]');
     expect(wrapper?.className).toContain('flex-col');
   });
 });


### PR DESCRIPTION
## Summary
- update stepper style to remove excess margin
- defer resume prompt check until wizard open
- expose `loadSavedProgress` from booking context
- document booking restore behavior
- update stepper tests for new markup

## Testing
- `./scripts/test-all.sh` *(fails: 26 failed, 69 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887d0e7672c832e84d7ed00dee92948