### PR TITLE
Fix booking summary heading

### DIFF
--- a/frontend/src/components/booking/SummarySidebar.tsx
+++ b/frontend/src/components/booking/SummarySidebar.tsx
@@ -14,7 +14,7 @@ export default function SummarySidebar() {
       animate={{ x: 0, opacity: 1 }}
       className="space-y-4"
     >
-      <h2 className="text-lg font-medium">Summary</h2>
+      <h3 className="text-lg font-semibold mt-4 mb-2">Booking Summary</h3>
       <dl className="bg-gray-50 p-4 rounded-lg text-sm space-y-1">
         {details.date && isValid(dateValue) && (
           <div className="flex justify-between">

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -103,7 +103,7 @@ describe("BookingWizard flow", () => {
 
   it("shows summary only on the review step", async () => {
     expect(container.querySelector("h2")?.textContent).toContain("Event Type");
-    expect(container.textContent).not.toContain("Summary");
+    expect(container.textContent).not.toContain("Booking Summary");
     const setStep = (window as unknown as { __setStep: (s: number) => void })
       .__setStep;
     await act(async () => {
@@ -111,7 +111,7 @@ describe("BookingWizard flow", () => {
     });
     await flushPromises();
     expect(container.querySelector("h2")?.textContent).toContain("Review");
-    expect(container.textContent).toContain("Summary");
+    expect(container.textContent).toContain("Booking Summary");
   });
 
   it("allows navigating back via the progress bar", async () => {

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -38,7 +38,6 @@ export default function ReviewStep({
   return (
     <div className="wizard-step-container">
       <SummarySidebar />
-      <h3 className="text-lg font-semibold mt-4 mb-2">Booking Summary</h3>
       <p><strong>Date:</strong> {details.date ? format(details.date, 'PPP') : 'N/A'}</p>
       <p><strong>Location:</strong> {details.location || 'N/A'}</p>
       <p><strong>Guests:</strong> {details.guests || 'N/A'}</p>


### PR DESCRIPTION
## Summary
- update ReviewStep to rely on SummarySidebar heading
- adjust SummarySidebar heading style
- update tests for new "Booking Summary" heading

## Testing
- `./scripts/test-all.sh` *(fails: `git fetch origin main`)*

------
https://chatgpt.com/codex/tasks/task_e_6887d41603a0832e8a4f188a2def7d8a