### PR TITLE
Add gmaps location input to edit profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ homepage and artist page search bars. The Google Maps script still loads lazily
 via the `loadPlaces()` helper so it is only injected once and avoids the "API
 included multiple times" warning.
 
+The **Edit Profile** page now uses this same component and requires a location
+to be entered so travel fees can be estimated correctly.
+
 The previous built-in autocomplete is deprecated. The location picker still
 opens a minimalist modal when the **Map** button is clicked. The modal contains
 just the search field and closes via a soft "Close" button. Closing the modal

--- a/frontend/src/app/dashboard/profile/edit/page.tsx
+++ b/frontend/src/app/dashboard/profile/edit/page.tsx
@@ -21,6 +21,7 @@ import {
 import { getFullImageUrl } from '@/lib/utils';
 import { DEFAULT_CURRENCY } from '@/lib/constants';
 import { Spinner } from '@/components/ui';
+import LocationInput from '@/components/ui/LocationInput';
 
 import dynamic from 'next/dynamic';
 import {
@@ -237,6 +238,11 @@ export default function EditArtistProfilePage(): JSX.Element {
 
     if (!businessNameInput.trim()) {
       setError('Business name is required.');
+      return;
+    }
+
+    if (!locationInput.trim()) {
+      setError('Location is required.');
       return;
     }
 
@@ -736,13 +742,13 @@ export default function EditArtistProfilePage(): JSX.Element {
                   <label htmlFor="location" className={labelClasses}>
                     Location
                   </label>
-                  <input
-                    type="text"
-                    id="location"
+                  <LocationInput
                     value={locationInput}
-                    onChange={(e) => setLocationInput(e.target.value)}
-                    className={inputClasses}
+                    onValueChange={setLocationInput}
+                    onPlaceSelect={() => {}}
                     placeholder="e.g., City, State or Studio Address"
+                    inputClassName={inputClasses}
+                    required
                   />
                 </div>
               </div>

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -12,6 +12,7 @@ interface CustomLocationInputProps {
   placeholder?: string;
   className?: string;
   inputClassName?: string;
+  required?: boolean;
 }
 
 export default function CustomLocationInput({
@@ -21,6 +22,7 @@ export default function CustomLocationInput({
   placeholder = 'Search location',
   className,
   inputClassName,
+  required = false,
 }: CustomLocationInputProps) {
   const [predictions, setPredictions] = useState<google.maps.places.AutocompletePrediction[]>([]);
   const [isDropdownVisible, setDropdownVisible] = useState(false);
@@ -127,6 +129,7 @@ export default function CustomLocationInput({
           if (predictions.length > 0) setDropdownVisible(true);
         }}
         placeholder={placeholder}
+        required={required}
         className={clsx(
           'w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none',
           inputClassName,


### PR DESCRIPTION
## Summary
- use the shared `<LocationInput>` component on Edit Profile
- require location before saving
- support `required` prop in `LocationInput`
- document the new edit profile requirement

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: test suites errors)*
- `pytest` *(fails: SettingsError loading CORS_ORIGINS)*

------
https://chatgpt.com/codex/tasks/task_e_6887e12e918c832eaa9f6389390470ab