### PR TITLE
Add travel fields to AddServiceModal

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a full-screen wizard. Steps appear in a coral-accented stepper with keyboard focus trapping. The final review mirrors earlier steps with image thumbnails before publishing.
 * Add Service wizard validates fields on each keystroke with dynamic hints like "Need 3 more characters" and the **Next** button enables automatically once inputs are valid.
+* Selecting **Live Performance** now reveals travel-related fields beneath the duration input. Artists can specify a travel rate in Rand per km (default R2.5) and the number of members travelling.
 * A new tip in the **Upload Media** step reminds artists to use high-resolution images or short video clips (1920x1080) for a polished listing.
 * The wizard uses a plain white overlay (`bg-white`) so the modal stands out and clicking outside closes it.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -78,6 +78,8 @@ interface ServiceFormData {
   description: string;
   duration_minutes: number | "";
   is_remote: boolean;
+  travel_rate?: number | "";
+  travel_members?: number | "";
 }
 
 export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: AddServiceModalProps) {
@@ -108,6 +110,8 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
       description: "",
       duration_minutes: 60,
       is_remote: false,
+      travel_rate: 2.5,
+      travel_members: 1,
     },
   });
 
@@ -122,6 +126,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
 
   const watchTitle = watch("title");
   const watchDescription = watch("description");
+  const watchServiceType = watch("service_type");
   const isMobile = useIsMobile();
 
   // Optimized image thumbnails from uploaded files
@@ -242,6 +247,10 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
         ...data,
         price,
         duration_minutes: Number(data.duration_minutes || 0),
+        travel_rate: data.travel_rate ? Number(data.travel_rate) : undefined,
+        travel_members: data.travel_members
+          ? Number(data.travel_members)
+          : undefined,
       };
       const res = await apiCreateService(serviceData);
       onServiceAdded(res.data);
@@ -428,6 +437,27 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                           })}
                           error={errors.duration_minutes?.message}
                         />
+                        {watchServiceType === "Live Performance" && (
+                          <>
+                            <TextInput
+                              label="Travelling (Rand per km)"
+                              type="number"
+                              step="0.1"
+                              placeholder="2.5"
+                              {...register("travel_rate", {
+                                valueAsNumber: true,
+                              })}
+                            />
+                            <TextInput
+                              label="Members travelling"
+                              type="number"
+                              step="1"
+                              {...register("travel_members", {
+                                valueAsNumber: true,
+                              })}
+                            />
+                          </>
+                        )}
                         <div className="flex items-center gap-2">
                           <ToggleSwitch
                             checked={watch("is_remote")}

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -128,6 +128,8 @@ describe("AddServiceModal wizard", () => {
         service_type: "Live Performance",
         duration_minutes: 30,
         price: 100,
+        travel_rate: 2.5,
+        travel_members: 1,
       }),
     );
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -63,6 +63,8 @@ export interface Service {
     | "Custom Song"
     | "Other";
   duration_minutes: number;
+  travel_rate?: number;
+  travel_members?: number;
   display_order: number;
   price: number;
   artist: ArtistProfile;


### PR DESCRIPTION
## Summary
- extend ServiceFormData and Service types with travel fields
- add Travelling rate and Members travelling inputs under Duration when Live Performance is selected
- pass new values to API on submit
- document travel fields in README
- update AddServiceModal test expectations

## Testing
- `npm ci` *(failed: peer dependency conflicts)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(failed to run tests: 26 failed, 1 skipped, 70 passed)*
- `./scripts/test-all.sh` *(failed: numerous frontend test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6887e796de40832ea57c519dad62575d