### PR TITLE
Implement travel mode logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,23 @@ GET /api/v1/travel-forecast?location={city}
 ```
 Returns a 3-day weather outlook for the provided location using data from `wttr.in`. Invalid locations return a structured 422 response with `{"location": "Unknown location"}` in `field_errors`.
 
+### Travel Mode Decision
+
+`calculateTravelMode()` in `frontend/src/lib/travel.ts` automatically decides whether an artist should fly or drive to an event. It looks up the nearest airports, checks for direct routes and compares the total flying cost against a provided driving estimate.
+
+```ts
+import { calculateTravelMode } from '@/lib/travel';
+
+const mode = await calculateTravelMode({
+  artistLocation: 'Cape Town, South Africa',
+  eventLocation: 'Johannesburg, South Africa',
+  numTravellers: 1,
+  drivingEstimate: 5000,
+});
+console.log(mode.mode); // "fly" or "drive"
+```
+
+
 ### Invoices
 
 ```

--- a/frontend/src/lib/__tests__/travel.test.ts
+++ b/frontend/src/lib/__tests__/travel.test.ts
@@ -1,0 +1,57 @@
+import { calculateTravelMode } from '../travel';
+
+describe('calculateTravelMode', () => {
+  it('returns drive when no direct flight route exists', async () => {
+    const result = await calculateTravelMode(
+      {
+        artistLocation: 'George, South Africa',
+        eventLocation: 'Durban, South Africa',
+        numTravellers: 2,
+        drivingEstimate: 1500,
+      },
+      async () => 10,
+    );
+
+    expect(result.mode).toBe('drive');
+    expect(result.totalCost).toBe(1500);
+  });
+
+  it('selects fly when cheaper than driving', async () => {
+    const distanceStub = jest.fn(async (from: string, to: string) => {
+      if (from.startsWith('Cape Town') && to === 'CPT') return 20;
+      if (from === 'JNB' && to.startsWith('Johannesburg')) return 30;
+      return 0;
+    });
+
+    const result = await calculateTravelMode(
+      {
+        artistLocation: 'Cape Town, South Africa',
+        eventLocation: 'Johannesburg, South Africa',
+        numTravellers: 1,
+        drivingEstimate: 5000,
+      },
+      distanceStub,
+    );
+
+    expect(result.mode).toBe('fly');
+    expect(result.totalCost).toBeCloseTo(3625);
+    expect(result.breakdown.fly.flightSubtotal).toBe(2500);
+    expect(distanceStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('defaults to drive when driving is cheaper', async () => {
+    const result = await calculateTravelMode(
+      {
+        artistLocation: 'Cape Town, South Africa',
+        eventLocation: 'Johannesburg, South Africa',
+        numTravellers: 1,
+        drivingEstimate: 2000,
+      },
+      async () => 50,
+    );
+
+    expect(result.mode).toBe('drive');
+    expect(result.totalCost).toBe(2000);
+  });
+});
+

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -1,0 +1,157 @@
+// Utilities for deciding the most cost-effective travel mode.
+
+export interface TravelInput {
+  artistLocation: string;
+  eventLocation: string;
+  numTravellers: number;
+  drivingEstimate: number;
+}
+
+export interface FlyBreakdown {
+  perPerson: number;
+  travellers: number;
+  flightSubtotal: number;
+  carRental: number;
+  localTransferKm: number;
+  departureTransferKm: number;
+  transferCost: number;
+  total: number;
+}
+
+export interface TravelResult {
+  mode: 'fly' | 'drive';
+  totalCost: number;
+  breakdown: {
+    drive: { estimate: number };
+    fly: FlyBreakdown;
+  };
+}
+
+const FLIGHT_COST_PER_PERSON = 2500;
+const CAR_RENTAL_COST = 1000;
+const RATE_PER_KM = 2.5;
+
+const CITY_TO_AIRPORT: Record<string, string> = {
+  'Cape Town': 'CPT',
+  George: 'GRJ',
+  Johannesburg: 'JNB',
+  Durban: 'DUR',
+  Bloemfontein: 'BFN',
+  'Port Elizabeth': 'PLZ',
+};
+
+const FLIGHT_ROUTES: Record<string, string[]> = {
+  CPT: ['JNB', 'BFN', 'DUR', 'PLZ', 'GRJ'],
+  GRJ: ['JNB', 'CPT'],
+  JNB: ['CPT', 'BFN', 'DUR', 'PLZ', 'GRJ'],
+  DUR: ['CPT', 'JNB'],
+  BFN: ['CPT', 'JNB'],
+  PLZ: ['CPT', 'JNB'],
+};
+
+/**
+ * Placeholder distance service. Replace with a real call to a mapping API.
+ */
+export async function getDrivingDistance(from: string, to: string): Promise<number> {
+  // TODO: integrate with real distance API
+  return 50;
+}
+
+/**
+ * Determine whether flying or driving is cheaper between two locations.
+ */
+export async function calculateTravelMode(
+  input: TravelInput,
+  distanceFn: typeof getDrivingDistance = getDrivingDistance,
+): Promise<TravelResult> {
+  const artistCity = input.artistLocation.split(',')[0].trim();
+  const eventCity = input.eventLocation.split(',')[0].trim();
+
+  const departure = CITY_TO_AIRPORT[artistCity];
+  const arrival = CITY_TO_AIRPORT[eventCity];
+
+  if (!departure || !arrival) {
+    return {
+      mode: 'drive',
+      totalCost: input.drivingEstimate,
+      breakdown: {
+        drive: { estimate: input.drivingEstimate },
+        fly: {
+          perPerson: FLIGHT_COST_PER_PERSON,
+          travellers: input.numTravellers,
+          flightSubtotal: 0,
+          carRental: CAR_RENTAL_COST,
+          localTransferKm: 0,
+          departureTransferKm: 0,
+          transferCost: 0,
+          total: 0,
+        },
+      },
+    };
+  }
+
+  if (!FLIGHT_ROUTES[departure]?.includes(arrival)) {
+    return {
+      mode: 'drive',
+      totalCost: input.drivingEstimate,
+      breakdown: {
+        drive: { estimate: input.drivingEstimate },
+        fly: {
+          perPerson: FLIGHT_COST_PER_PERSON,
+          travellers: input.numTravellers,
+          flightSubtotal: 0,
+          carRental: CAR_RENTAL_COST,
+          localTransferKm: 0,
+          departureTransferKm: 0,
+          transferCost: 0,
+          total: 0,
+        },
+      },
+    };
+  }
+
+  const departureTransferKm = await distanceFn(input.artistLocation, departure);
+  const localTransferKm = await distanceFn(arrival, input.eventLocation);
+  const flightSubtotal = input.numTravellers * FLIGHT_COST_PER_PERSON;
+  const transferCost = (departureTransferKm + localTransferKm) * RATE_PER_KM;
+  const flyTotal = flightSubtotal + CAR_RENTAL_COST + transferCost;
+
+  if (flyTotal < input.drivingEstimate) {
+    return {
+      mode: 'fly',
+      totalCost: flyTotal,
+      breakdown: {
+        drive: { estimate: input.drivingEstimate },
+        fly: {
+          perPerson: FLIGHT_COST_PER_PERSON,
+          travellers: input.numTravellers,
+          flightSubtotal,
+          carRental: CAR_RENTAL_COST,
+          localTransferKm,
+          departureTransferKm,
+          transferCost,
+          total: flyTotal,
+        },
+      },
+    };
+  }
+
+  return {
+    mode: 'drive',
+    totalCost: input.drivingEstimate,
+    breakdown: {
+      drive: { estimate: input.drivingEstimate },
+      fly: {
+        perPerson: FLIGHT_COST_PER_PERSON,
+        travellers: input.numTravellers,
+        flightSubtotal,
+        carRental: CAR_RENTAL_COST,
+        localTransferKm,
+        departureTransferKm,
+        transferCost,
+        total: flyTotal,
+      },
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `calculateTravelMode` utility to evaluate flying vs driving
- document travel mode decision in README
- test travel calculation logic

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Test Suites: 26 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887eed37ff8832e9488235061abe1a7