### PR TITLE
Enable Enter key to advance BookingWizard

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -306,7 +306,15 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                 noCircles
               />
 
-              <form className="flex-1 overflow-y-scroll p-6 space-y-6">
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (isMobile) return;
+                  if (step < steps.length - 1) next();
+                  else submitRequest();
+                }}
+                className="flex-1 overflow-y-scroll p-6 space-y-6"
+              >
                 <AnimatePresence mode="wait">
                   <motion.div
                     key={step}
@@ -331,7 +339,11 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                   {step === 0 ? 'Cancel' : 'Back'}
                 </Button>
                 {step < steps.length - 1 ? (
-                  <Button onClick={next} data-testid={step === 0 ? 'date-next-button' : undefined}>
+                  <Button
+                    onClick={next}
+                    data-testid={step === 0 ? 'date-next-button' : undefined}
+                    className="w-32"
+                  >
                     Next
                   </Button>
                 ) : (

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -72,6 +72,17 @@ describe("BookingWizard flow", () => {
     expect(window.scrollTo).toHaveBeenCalled();
   });
 
+  it("advances to the next step when pressing Enter on desktop", async () => {
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true });
+    const form = container.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flushPromises();
+    const heading = container.querySelector('[data-testid="step-heading"]');
+    expect(heading?.textContent).toContain("Event Type");
+  });
+
   it("shows step heading and updates on next", async () => {
     const heading = () =>
       container.querySelector('[data-testid="step-heading"]')?.textContent;


### PR DESCRIPTION
## Summary
- allow Enter key to move to the next step in `BookingWizard`
- expand "Next" button width for better desktop usability
- test advancing with Enter key

## Testing
- `./scripts/test-all.sh` *(fails: tests throw console errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888615a9ff4832e98834f23a0d234cd