### PR TITLE
Enable Enter key for wizard steps

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -151,6 +151,16 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     if (serviceId) setServiceId(serviceId);
   }, [serviceId, setServiceId]);
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    if (e.key !== 'Enter' || e.shiftKey || isMobile) return;
+    e.preventDefault();
+    if (step < steps.length - 1) {
+      void next();
+    } else {
+      void submitRequest();
+    }
+  };
+
   const next = async () => {
     const stepFields: (keyof EventDetails)[][] = [
       ['date'],
@@ -313,6 +323,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                   if (step < steps.length - 1) next();
                   else submitRequest();
                 }}
+                onKeyDown={handleKeyDown}
                 className="flex-1 overflow-y-scroll p-6 space-y-6"
               >
                 <AnimatePresence mode="wait">
@@ -324,7 +335,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                     variants={stepVariants}
                     transition={stepVariants.transition}
                   >
-                    <h2 className="text-2xl font-bold mb-1" ref={headingRef}>{steps[step]}</h2>
+                    <h2
+                      className="text-2xl font-bold mb-1"
+                      ref={headingRef}
+                      data-testid="step-heading"
+                    >
+                      {steps[step]}
+                    </h2>
                     <p className="text-gray-600 mb-4">{instructions[step]}</p>
                     {renderStep()}
                     {warning && <p className="text-orange-600 text-sm mt-4">{warning}</p>}

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -76,7 +76,9 @@ describe("BookingWizard flow", () => {
     Object.defineProperty(window, "innerWidth", { value: 1024, writable: true });
     const form = container.querySelector("form") as HTMLFormElement;
     await act(async () => {
-      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      form.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      );
     });
     await flushPromises();
     const heading = container.querySelector('[data-testid="step-heading"]');


### PR DESCRIPTION
## Summary
- allow pressing Enter to move through BookingWizard steps
- test updated to fire Enter key events

## Testing
- `./scripts/test-all.sh` *(fails: node fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688864c421a0832e96c67499da0c0f58