### PR TITLE
Integrate Google Distance Matrix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,15 @@ By default it calls `http://localhost:8000`. To point elsewhere, create `fronten
 NEXT_PUBLIC_API_URL=http://192.168.3.203:8000
 NEXT_PUBLIC_WS_URL=ws://192.168.3.203:8000
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyDm-BKmMtzMSMd-XUdfapjEUU6O5mYy2bk
+NEXT_PUBLIC_GOOGLE_MAPS_KEY=<your-distance-matrix-key>
 ```
 
 `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` should be a browser key with the Places API
 enabled. It powers the `LocationInput` autocomplete fields used in the artist
 filters, search bar, and booking steps.
+
+`NEXT_PUBLIC_GOOGLE_MAPS_KEY` is used server-side and client-side to query the
+Distance Matrix API when estimating travel costs.
 
 If you source the same `.env` file for the backend, the API configuration now
 includes `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` as an optional setting. The backend

--- a/frontend/src/lib/__tests__/travel.test.ts
+++ b/frontend/src/lib/__tests__/travel.test.ts
@@ -1,4 +1,4 @@
-import { calculateTravelMode } from '../travel';
+import { calculateTravelMode, getDrivingDistance } from '../travel';
 
 describe('calculateTravelMode', () => {
   it('returns drive when no direct flight route exists', async () => {
@@ -52,6 +52,46 @@ describe('calculateTravelMode', () => {
 
     expect(result.mode).toBe('drive');
     expect(result.totalCost).toBe(2000);
+  });
+});
+
+describe('getDrivingDistance', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, NEXT_PUBLIC_GOOGLE_MAPS_KEY: 'abc123' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    const globals = global as typeof global & { fetch?: jest.Mock };
+    globals.fetch?.mockRestore?.();
+  });
+
+  it('calls Google API and returns kilometers', async () => {
+    const globals = global as typeof global & { fetch: jest.Mock };
+    globals.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'OK',
+        rows: [{ elements: [{ status: 'OK', distance: { value: 1234 } }] }],
+      }),
+    });
+
+    const km = await getDrivingDistance('A', 'B');
+    expect(globals.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('distancematrix'),
+    );
+    expect(globals.fetch.mock.calls[0][0]).toContain('key=abc123');
+    expect(km).toBeCloseTo(1.234);
+  });
+
+  it('returns 0 on fetch error', async () => {
+    const globals = global as typeof global & { fetch: jest.Mock };
+    globals.fetch = jest.fn().mockRejectedValue(new Error('fail'));
+    const km = await getDrivingDistance('A', 'B');
+    expect(km).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- fetch driving distance from Google's Distance Matrix API
- add tests for `getDrivingDistance`
- document `NEXT_PUBLIC_GOOGLE_MAPS_KEY` env var

## Testing
- `npm ci` *(fails: many peer dependency warnings)*
- `npm test --silent -- --maxWorkers=25%` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688886eea214832e9324ef768f9c44f5