### PR TITLE
Update login prompts

### DIFF
--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MessageThread from '@/components/booking/MessageThread';
@@ -46,7 +47,16 @@ export default function BookingRequestDetailPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view this request.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view this request.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
@@ -107,7 +108,16 @@ export default function BookingRequestsPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view booking requests.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view booking requests.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/booking/page.tsx
+++ b/frontend/src/app/booking/page.tsx
@@ -28,10 +28,16 @@ export default function BookingPage() {
     return (
       <MainLayout>
         <div className="flex justify-center items-center min-h-screen text-center space-y-4 flex-col">
-          <p>You must log in to create a booking.</p>
-          <Link href="/login" className="text-brand-dark underline">
-            Login
-          </Link>
+          <p>
+            You must{' '}
+            <Link
+              href="/login"
+              className="text-brand-dark no-underline hover:no-underline"
+            >
+              log in
+            </Link>{' '}
+            to create a booking.
+          </p>
         </div>
       </MainLayout>
     );

--- a/frontend/src/app/dashboard/bookings/page.tsx
+++ b/frontend/src/app/dashboard/bookings/page.tsx
@@ -85,7 +85,16 @@ export default function ArtistBookingsPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view your bookings.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view your bookings.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/dashboard/client/bookings/page.tsx
+++ b/frontend/src/app/dashboard/client/bookings/page.tsx
@@ -245,7 +245,16 @@ export default function ClientBookingsPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view your bookings.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view your bookings.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/dashboard/client/quotes/page.tsx
+++ b/frontend/src/app/dashboard/client/quotes/page.tsx
@@ -42,7 +42,16 @@ export default function ClientQuotesPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view your quotes.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view your quotes.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useMemo } from "react";
+import React, { useEffect, useState, useRef, useMemo, ReactNode } from "react";
 import clsx from 'clsx';
 import { useRouter, usePathname } from "next/navigation";
+import Link from 'next/link';
+import axios from 'axios';
 import MainLayout from "@/components/layout/MainLayout";
 import { useAuth } from "@/contexts/AuthContext";
 import { Booking, Service, ArtistProfile, BookingRequest } from "@/types";
@@ -160,7 +162,7 @@ export default function DashboardPage() {
   const [requestSearch, setRequestSearch] = useState('');
   const [requestVisibleCount, setRequestVisibleCount] = useState(5);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ReactNode | null>(null);
   const [isAddServiceModalOpen, setIsAddServiceModalOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
   const [requestToUpdate, setRequestToUpdate] = useState<BookingRequest | null>(null);
@@ -279,7 +281,20 @@ export default function DashboardPage() {
         }
       } catch (err) {
         console.error("Dashboard fetch error:", err);
-        setError("Failed to load dashboard data. Please try again.");
+        if (axios.isAxiosError(err) && err.response?.status === 401) {
+          setError(
+            <>Please{' '}
+            <Link
+              href="/login"
+              className="text-brand-dark no-underline hover:no-underline"
+            >
+              log in
+            </Link>{' '}
+            to view your dashboard.</>
+          );
+        } else {
+          setError('Failed to load dashboard data. Please try again.');
+        }
       } finally {
         setLoading(false);
       }

--- a/frontend/src/app/dashboard/profile/quote-templates/page.tsx
+++ b/frontend/src/app/dashboard/profile/quote-templates/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import type { QuoteTemplate, ServiceItem } from '@/types';
@@ -153,7 +154,16 @@ export default function QuoteTemplatesPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to manage templates.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to manage templates.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/dashboard/quotes/page.tsx
+++ b/frontend/src/app/dashboard/quotes/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import MainLayout from '@/components/layout/MainLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import toast from '@/components/ui/Toast';
@@ -94,7 +95,16 @@ export default function ArtistQuotesPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view your quotes.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view your quotes.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/messages/thread/[threadId]/page.tsx
+++ b/frontend/src/app/messages/thread/[threadId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MessageThread from '@/components/booking/MessageThread';
@@ -41,7 +42,16 @@ export default function ThreadPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view this conversation.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view this conversation.
+        </div>
       </MainLayout>
     );
   }

--- a/frontend/src/app/quotes/[quoteId]/page.tsx
+++ b/frontend/src/app/quotes/[quoteId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import QuoteCard from '@/components/booking/QuoteCard';
@@ -34,7 +35,16 @@ export default function QuoteDetailPage() {
   if (!user) {
     return (
       <MainLayout>
-        <div className="p-8">Please log in to view this quote.</div>
+        <div className="p-8">
+          Please{' '}
+          <Link
+            href="/login"
+            className="text-brand-dark no-underline hover:no-underline"
+          >
+            log in
+          </Link>{' '}
+          to view this quote.
+        </div>
       </MainLayout>
     );
   }


### PR DESCRIPTION
## Summary
- link all login prompts to the login page
- show login link when the dashboard request fails with 401

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: could not fetch dependencies)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails to run Jest suites)*

------
https://chatgpt.com/codex/tasks/task_e_6888860cf17c832e8cff3ed86a15e33f