### PR TITLE
Fix duplicate import in dashboard

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -35,7 +35,6 @@ import BookingRequestCard from "@/components/dashboard/BookingRequestCard";
 import { Spinner, Button } from '@/components/ui';
 import DashboardTabs from "@/components/dashboard/DashboardTabs";
 import QuickActionButton from "@/components/dashboard/QuickActionButton";
-import Link from "next/link";
 import {
   DndContext,
   closestCenter,
@@ -43,6 +42,7 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  type DragEndEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -360,7 +360,7 @@ export default function DashboardPage() {
     hintTimer.current = setTimeout(() => setShowReorderHint(false), 1500);
   };
 
-  const handleDragEnd = (event: any) => {
+  const handleDragEnd = (event: DragEndEvent) => {
     setIsReordering(false);
     const { active, over } = event;
     if (!over || active.id === over.id) {


### PR DESCRIPTION
## Summary
- remove duplicated `Link` import in dashboard page
- type drag event handler to satisfy linter

## Testing
- `FAST=1 ./scripts/test-all.sh` *(fails: ESLint found too many warnings)*
- `./scripts/test-all.sh` *(failed: numerous Jest test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688889b0fe04832ea59dee7bcc6c2680