### PR TITLE
Add travel fields to booking request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,14 @@ console.log(mode.mode); // "fly" or "drive"
 The Booking Wizard automatically runs this check on the Review step and shows a
 summary card with the selected travel mode and estimated cost.
 
+When submitting the booking request, the frontend now sends three extra fields:
+
+* `travel_mode` – either `fly` or `drive`
+* `travel_cost` – numeric estimate of the chosen mode
+* `travel_breakdown` – JSON object with flight or driving details
+
+These values are stored with the request and returned in the API response.
+
 
 ### Invoices
 

--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum as SQLAlchemyEnum, Numeric
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum as SQLAlchemyEnum, Numeric, JSON
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import enum
@@ -36,6 +36,10 @@ class BookingRequest(Base):
     attachment_url = Column(String, nullable=True)
     proposed_datetime_1 = Column(DateTime, nullable=True)
     proposed_datetime_2 = Column(DateTime, nullable=True)
+
+    travel_mode = Column(String, nullable=True)
+    travel_cost = Column(Numeric(10, 2), nullable=True)
+    travel_breakdown = Column(JSON, nullable=True)
     
     status = Column(SQLAlchemyEnum(BookingRequestStatus), nullable=False, default=BookingRequestStatus.PENDING_QUOTE)
 

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -16,6 +16,9 @@ class BookingRequestBase(BaseModel):
     attachment_url: Optional[str] = None
     proposed_datetime_1: Optional[datetime] = None
     proposed_datetime_2: Optional[datetime] = None
+    travel_mode: Optional[str] = None
+    travel_cost: Optional[Decimal] = None
+    travel_breakdown: Optional[dict] = None
 
 class BookingRequestCreate(BookingRequestBase):
     artist_id: int # Client must specify the artist they are requesting
@@ -27,6 +30,9 @@ class BookingRequestUpdateByClient(BaseModel): # Client can withdraw or update m
     attachment_url: Optional[str] = None
     proposed_datetime_1: Optional[datetime] = None
     proposed_datetime_2: Optional[datetime] = None
+    travel_mode: Optional[str] = None
+    travel_cost: Optional[Decimal] = None
+    travel_breakdown: Optional[dict] = None
     status: Optional[BookingRequestStatus] = None # e.g. REQUEST_WITHDRAWN
 
 class BookingRequestUpdateByArtist(BaseModel): # Artist can decline
@@ -39,6 +45,9 @@ class BookingRequestResponse(BookingRequestBase):
     status: BookingRequestStatus
     created_at: datetime
     updated_at: Optional[datetime] = None
+    travel_mode: Optional[str] = None
+    travel_cost: Optional[Decimal] = None
+    travel_breakdown: Optional[dict] = None
     
     client: Optional[UserResponse] = None
     artist: Optional[UserResponse] = None # Artist's UserResponse

--- a/backend/tests/test_booking_request_travel.py
+++ b/backend/tests/test_booking_request_travel.py
@@ -1,0 +1,40 @@
+import json
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import User, UserType, BookingRequestStatus
+from app.models.base import BaseModel
+from app.api import api_booking_request
+from app.schemas import BookingRequestCreate
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_create_request_with_travel():
+    db = setup_db()
+    client = User(email='c@test.com', password='x', first_name='C', last_name='Client', user_type=UserType.CLIENT)
+    artist = User(email='a@test.com', password='x', first_name='A', last_name='Artist', user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    req_in = BookingRequestCreate(
+        artist_id=artist.id,
+        status=BookingRequestStatus.PENDING_QUOTE,
+        travel_mode='fly',
+        travel_cost=Decimal('123.45'),
+        travel_breakdown={'mode': 'fly'}
+    )
+
+    br = api_booking_request.create_booking_request(req_in, db, current_user=client)
+
+    assert br.travel_mode == 'fly'
+    assert br.travel_cost == Decimal('123.45')
+    assert br.travel_breakdown == {'mode': 'fly'}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1567,7 +1567,7 @@
           "Reviews"
         ],
         "summary": "Create Review For Booking",
-        "description": "Create a review for a specific booking. \nOnly the client who made the booking can review it, and only if it's completed.",
+        "description": "Create a review for a specific booking.\nOnly the client who made the booking can review it, and only if it's completed.",
         "operationId": "create_review_for_booking_api_v1_reviews_bookings__booking_id__reviews_post",
         "security": [
           {
@@ -4063,6 +4063,49 @@
         }
       }
     },
+    "/api/v1/travel-forecast": {
+      "get": {
+        "tags": [
+          "travel-forecast",
+          "travel-forecast"
+        ],
+        "summary": "Travel Forecast",
+        "description": "Return a 3-day weather forecast for the destination.",
+        "operationId": "travel_forecast_api_v1_travel_forecast_get",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Location"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",
@@ -5026,6 +5069,43 @@
             ],
             "title": "Proposed Datetime 2"
           },
+          "travel_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Mode"
+          },
+          "travel_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Cost"
+          },
+          "travel_breakdown": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Breakdown"
+          },
           "artist_id": {
             "type": "integer",
             "title": "Artist Id"
@@ -5106,6 +5186,40 @@
               }
             ],
             "title": "Proposed Datetime 2"
+          },
+          "travel_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Mode"
+          },
+          "travel_cost": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Cost"
+          },
+          "travel_breakdown": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Breakdown"
           },
           "id": {
             "type": "integer",
@@ -5288,6 +5402,43 @@
               }
             ],
             "title": "Proposed Datetime 2"
+          },
+          "travel_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Mode"
+          },
+          "travel_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Cost"
+          },
+          "travel_breakdown": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Travel Breakdown"
           },
           "status": {
             "anyOf": [

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -107,6 +107,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     requestId,
     setRequestId,
     setServiceId,
+    travelResult,
     resetBooking,
     loadSavedProgress,
   } = useBooking();
@@ -194,6 +195,9 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       message: vals.notes,
       attachment_url: vals.attachment_url,
       status: 'draft',
+      travel_mode: travelResult?.mode,
+      travel_cost: travelResult?.totalCost,
+      travel_breakdown: travelResult?.breakdown,
     };
     try {
       if (requestId) await updateBookingRequest(requestId, payload);
@@ -216,6 +220,9 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       message: vals.notes,
       attachment_url: vals.attachment_url,
       status: 'pending_quote',
+      travel_mode: travelResult?.mode,
+      travel_cost: travelResult?.totalCost,
+      travel_breakdown: travelResult?.breakdown,
     };
   
     try {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -115,7 +115,11 @@ export interface BookingRequestCreate {
   message?: string;
   attachment_url?: string;
   proposed_datetime_1?: string; // ISO‐formatted date‐time string
+  proposed_datetime_2?: string;
   status?: string;
+  travel_mode?: 'fly' | 'drive';
+  travel_cost?: number;
+  travel_breakdown?: Record<string, unknown>;
 }
 
 // This is what the backend returns when you GET a booking request:
@@ -128,6 +132,9 @@ export interface BookingRequest {
   attachment_url?: string | null;
   proposed_datetime_1?: string | null;
   proposed_datetime_2?: string | null;
+  travel_mode?: 'fly' | 'drive' | null;
+  travel_cost?: number | null;
+  travel_breakdown?: Record<string, unknown> | null;
   status: string; // e.g. "pending_quote", "quote_provided", etc.
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- support travel mode/cost/breakdown on backend booking requests
- document travel fields in README
- send travel fields from BookingWizard
- update frontend types
- generate updated OpenAPI docs
- test persistence of travel fields

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_booking_request_travel.py -q`
- `SKIP_BACKEND=1 SKIP_FRONTEND=1 ./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688888de0df0832e9bf02712491818a3