### PR TITLE
Implement early travel mode calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,8 +1170,9 @@ const mode = await calculateTravelMode({
 console.log(mode.mode); // "fly" or "drive"
 ```
 
-The Booking Wizard automatically runs this check on the Review step and shows a
-summary card with the selected travel mode and estimated cost.
+The Booking Wizard automatically runs this check as soon as both the artist and
+event locations are provided, storing the result for the Review step where a
+summary card displays the selected travel mode and estimated cost.
 
 
 ### Invoices


### PR DESCRIPTION
## Summary
- compute travel mode once artist & event locations are set
- persist result in BookingContext
- test that travel mode calculation runs when locations are available
- document earlier calculation in README

## Testing
- `npm install` in frontend
- `./scripts/test-all.sh` *(fails: TypeError in several Jest suites)*

------
https://chatgpt.com/codex/tasks/task_e_68888b9d023c832ebbf72647d8455f7c