### PR TITLE
Add auto-migration for booking request travel fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The SQLite database path is automatically resolved to the project root, so you c
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, and `calendar_accounts.email` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
+Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
 
 ### Service type enum
 

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -215,3 +215,26 @@ def ensure_user_profile_picture_column(engine: Engine) -> None:
         "profile_picture_url VARCHAR",
     )
 
+
+def ensure_booking_request_travel_columns(engine: Engine) -> None:
+    """Add travel-related columns to ``booking_requests`` if missing."""
+
+    add_column_if_missing(
+        engine,
+        "booking_requests",
+        "travel_mode",
+        "travel_mode VARCHAR",
+    )
+    add_column_if_missing(
+        engine,
+        "booking_requests",
+        "travel_cost",
+        "travel_cost NUMERIC(10, 2)",
+    )
+    add_column_if_missing(
+        engine,
+        "booking_requests",
+        "travel_breakdown",
+        "travel_breakdown JSON",
+    )
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from .db_utils import (
     ensure_booking_simple_columns,
     ensure_calendar_account_email_column,
     ensure_user_profile_picture_column,
+    ensure_booking_request_travel_columns,
 )
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
@@ -84,6 +85,7 @@ ensure_mfa_columns(engine)
 ensure_booking_simple_columns(engine)
 ensure_calendar_account_email_column(engine)
 ensure_user_profile_picture_column(engine)
+ensure_booking_request_travel_columns(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -9,6 +9,7 @@ from app.db_utils import (
     ensure_booking_simple_columns,
     ensure_mfa_columns,
     ensure_calendar_account_email_column,
+    ensure_booking_request_travel_columns,
 )
 
 
@@ -126,6 +127,24 @@ def setup_calendar_account_engine() -> Engine:
     return engine
 
 
+def setup_booking_request_engine() -> Engine:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE booking_requests (
+                    id INTEGER PRIMARY KEY,
+                    client_id INTEGER,
+                    artist_id INTEGER,
+                    status VARCHAR
+                )
+                """
+            )
+        )
+    return engine
+
+
 def test_add_price_visible_column():
     engine = setup_artist_engine()
     ensure_price_visible_column(engine)
@@ -171,4 +190,14 @@ def test_calendar_account_email_column():
     inspector = inspect(engine)
     cols = [c["name"] for c in inspector.get_columns("calendar_accounts")]
     assert "email" in cols
+
+
+def test_booking_request_travel_columns():
+    engine = setup_booking_request_engine()
+    ensure_booking_request_travel_columns(engine)
+    inspector = inspect(engine)
+    cols = [c["name"] for c in inspector.get_columns("booking_requests")]
+    assert "travel_mode" in cols
+    assert "travel_cost" in cols
+    assert "travel_breakdown" in cols
 


### PR DESCRIPTION
## Summary
- ensure booking_requests table includes travel fields
- apply new ensure function at app startup
- document auto-migration in README
- test that travel columns get added

## Testing
- `./scripts/test-all.sh` *(fails: TypeError in `test_google_calendar`)*
- `pytest tests/test_db_utils.py -k test_booking_request_travel_columns -q`

------
https://chatgpt.com/codex/tasks/task_e_68888df20160832ebc23d6a0469b119b