### PR TITLE
Implement smart travel mode logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ For setup instructions see [README.md](README.md).
 
 ### 3. Travel & Accommodation Agent
 
-* **Purpose:** Calculates travel distance and optional lodging costs so quotes stay accurate. The agent also retrieves 3-day weather forecasts for trip planning.
+* **Purpose:** Calculates travel distance and optional lodging costs so quotes stay accurate. The agent also retrieves 3-day weather forecasts for trip planning. `calculateTravelMode()` geocodes any South African town to find the closest airport and compares flight costs with driving.
 * **Frontend:** `quote-calculator/page.tsx` lets artists preview travel and accommodation fees.
 * **Backend:** `booking_quote.py` exposes helpers used by the quote API. `/api/v1/travel-forecast` lives in `api_weather.py` and fetches forecast data from `wttr.in`.
 

--- a/README.md
+++ b/README.md
@@ -1156,7 +1156,7 @@ Returns a 3-day weather outlook for the provided location using data from `wttr.
 
 ### Travel Mode Decision
 
-`calculateTravelMode()` in `frontend/src/lib/travel.ts` automatically decides whether an artist should fly or drive to an event. It looks up the nearest airports, checks for direct routes and compares the total flying cost against a provided driving estimate.
+`calculateTravelMode()` in `frontend/src/lib/travel.ts` automatically decides whether an artist should fly or drive to an event. The helper geocodes the artist and event towns, finds the closest airport using great-circle distance, checks for supported routes and then compares the full flying cost (flights, transfers and car rental) with the driving estimate. The function works with any South African location and returns a detailed cost breakdown.
 
 ```ts
 import { calculateTravelMode } from '@/lib/travel';
@@ -1167,7 +1167,7 @@ const mode = await calculateTravelMode({
   numTravellers: 1,
   drivingEstimate: 5000,
 });
-console.log(mode.mode); // "fly" or "drive"
+console.log(mode.mode, mode.totalCost);
 ```
 
 The Booking Wizard automatically runs this check as soon as both the artist and

--- a/frontend/src/lib/__tests__/travel.test.ts
+++ b/frontend/src/lib/__tests__/travel.test.ts
@@ -2,6 +2,11 @@ import { calculateTravelMode, getDrivingDistance } from '../travel';
 
 describe('calculateTravelMode', () => {
   it('returns drive when no direct flight route exists', async () => {
+    const airportStub = jest.fn(async (city: string) => {
+      if (city.startsWith('George')) return 'GRJ';
+      if (city.startsWith('Durban')) return 'DUR';
+      return null;
+    });
     const result = await calculateTravelMode(
       {
         artistLocation: 'George, South Africa',
@@ -10,19 +15,24 @@ describe('calculateTravelMode', () => {
         drivingEstimate: 1500,
       },
       async () => 10,
+      airportStub,
     );
-
     expect(result.mode).toBe('drive');
     expect(result.totalCost).toBe(1500);
+    expect(airportStub).toHaveBeenCalledTimes(2);
   });
 
   it('selects fly when cheaper than driving', async () => {
+    const airportStub = jest.fn(async (city: string) => {
+      if (city.startsWith('Cape Town')) return 'CPT';
+      if (city.startsWith('Johannesburg')) return 'JNB';
+      return null;
+    });
     const distanceStub = jest.fn(async (from: string, to: string) => {
-      if (from.startsWith('Cape Town') && to === 'CPT') return 20;
-      if (from === 'JNB' && to.startsWith('Johannesburg')) return 30;
+      if (from.includes('Cape Town')) return 20;
+      if (to.includes('Johannesburg')) return 30;
       return 0;
     });
-
     const result = await calculateTravelMode(
       {
         artistLocation: 'Cape Town, South Africa',
@@ -31,15 +41,17 @@ describe('calculateTravelMode', () => {
         drivingEstimate: 5000,
       },
       distanceStub,
+      airportStub,
     );
-
     expect(result.mode).toBe('fly');
     expect(result.totalCost).toBeCloseTo(3625);
     expect(result.breakdown.fly.flightSubtotal).toBe(2500);
     expect(distanceStub).toHaveBeenCalledTimes(2);
+    expect(airportStub).toHaveBeenCalledTimes(2);
   });
 
   it('defaults to drive when driving is cheaper', async () => {
+    const airportStub = jest.fn(async () => 'CPT');
     const result = await calculateTravelMode(
       {
         artistLocation: 'Cape Town, South Africa',
@@ -48,10 +60,29 @@ describe('calculateTravelMode', () => {
         drivingEstimate: 2000,
       },
       async () => 50,
+      airportStub,
     );
-
     expect(result.mode).toBe('drive');
     expect(result.totalCost).toBe(2000);
+  });
+
+  it('falls back to drive on airport lookup failure', async () => {
+    const airportStub = jest.fn(async () => null);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await calculateTravelMode(
+      {
+        artistLocation: 'Nowhere',
+        eventLocation: 'Johannesburg, South Africa',
+        numTravellers: 1,
+        drivingEstimate: 3000,
+      },
+      async () => 20,
+      airportStub,
+    );
+    expect(result.mode).toBe('drive');
+    expect(result.totalCost).toBe(3000);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });
 
@@ -78,7 +109,6 @@ describe('getDrivingDistance', () => {
         rows: [{ elements: [{ status: 'OK', distance: { value: 1234 } }] }],
       }),
     });
-
     const km = await getDrivingDistance('A', 'B');
     expect(globals.fetch).toHaveBeenCalledWith(
       expect.stringContaining('distancematrix'),
@@ -94,4 +124,3 @@ describe('getDrivingDistance', () => {
     expect(km).toBe(0);
   });
 });
-


### PR DESCRIPTION
## Summary
- add geocoding-based airport lookup and haversine distance helpers
- update `calculateTravelMode` to handle any South African town
- provide new tests for travel mode calculations
- document the new behaviour in README and AGENTS docs

## Testing
- `cd frontend && npx jest src/lib/__tests__/travel.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68888fe2d054832eb47cdc65876e155e