### PR TITLE
Fix distance calculation API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ NEXT_PUBLIC_GOOGLE_MAPS_KEY=<your-distance-matrix-key>
 enabled. It powers the `LocationInput` autocomplete fields used in the artist
 filters, search bar, and booking steps.
 
-`NEXT_PUBLIC_GOOGLE_MAPS_KEY` is used server-side and client-side to query the
-Distance Matrix API when estimating travel costs.
+`NEXT_PUBLIC_GOOGLE_MAPS_KEY` is still required for geocoding but the frontend
+no longer contacts Google directly for distance calculations. Instead it calls
+`/api/v1/distance`, and the backend forwards the request using your server key.
 
-Set `GOOGLE_MAPS_API_KEY` in your `.env` to allow the backend to proxy Distance
-Matrix requests. This should be a server key since it is never exposed to the
-browser.
+Set `GOOGLE_MAPS_API_KEY` in your `.env` so this proxy works. The key is never
+exposed to the browser.
 
 If you source the same `.env` file for the backend, the API configuration now
 includes `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` as an optional setting. The backend

--- a/frontend/src/lib/__tests__/travel.test.ts
+++ b/frontend/src/lib/__tests__/travel.test.ts
@@ -91,7 +91,7 @@ describe('getDrivingDistance', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...originalEnv, NEXT_PUBLIC_GOOGLE_MAPS_KEY: 'abc123' };
+    process.env = { ...originalEnv, NEXT_PUBLIC_API_URL: 'http://api' };
   });
 
   afterEach(() => {
@@ -100,20 +100,18 @@ describe('getDrivingDistance', () => {
     globals.fetch?.mockRestore?.();
   });
 
-  it('calls Google API and returns kilometers', async () => {
+  it('calls distance endpoint and returns kilometers', async () => {
     const globals = global as typeof global & { fetch: jest.Mock };
     globals.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        status: 'OK',
         rows: [{ elements: [{ status: 'OK', distance: { value: 1234 } }] }],
       }),
     });
     const km = await getDrivingDistance('A', 'B');
     expect(globals.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('distancematrix'),
+      'http://api/api/v1/distance?from_location=A&to_location=B',
     );
-    expect(globals.fetch.mock.calls[0][0]).toContain('key=abc123');
     expect(km).toBeCloseTo(1.234);
   });
 

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -140,36 +140,31 @@ export function getMockCoordinates(
  * is invalid. Errors are logged to aid debugging but will not throw.
  */
 export async function getDrivingDistance(from: string, to: string): Promise<number> {
-  const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_KEY;
-  if (!key) {
-    console.warn('NEXT_PUBLIC_GOOGLE_MAPS_KEY not set');
-    return 0;
-  }
-
+  const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const url =
-    `https://maps.googleapis.com/maps/api/distancematrix/json?units=metric&origins=${encodeURIComponent(
+    `${base}/api/v1/distance?from_location=${encodeURIComponent(
       from,
-    )}&destinations=${encodeURIComponent(to)}&key=${key}`;
+    )}&to_location=${encodeURIComponent(to)}`;
 
   try {
     const res = await fetch(url);
     if (!res.ok) {
-      console.error('Distance Matrix API HTTP error', res.status);
+      console.error('Distance endpoint HTTP error', res.status);
       return 0;
     }
     const data = await res.json();
-    if (data.status !== 'OK') {
-      console.error('Distance Matrix API response status:', data.status);
+    if (data.error) {
+      console.error('Distance endpoint error:', data.error);
       return 0;
     }
     const element = data.rows?.[0]?.elements?.[0];
     if (!element || element.status !== 'OK' || !element.distance?.value) {
-      console.error('Distance Matrix element status:', element?.status);
+      console.error('Distance element status:', element?.status);
       return 0;
     }
     return element.distance.value / 1000;
   } catch (err) {
-    console.error('Distance Matrix API fetch failed:', err);
+    console.error('Distance endpoint fetch failed:', err);
     return 0;
   }
 }


### PR DESCRIPTION
## Summary
- fetch driving distance via backend `/api/v1/distance`
- update travel tests for new proxy endpoint
- clarify README on Distance Matrix proxy

## Testing
- `./scripts/test-all.sh` *(fails: `git fetch` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68889d132160832e93f30b11070ce588