### PR TITLE
Load .env in backend main

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The SQLite database path is automatically resolved to the project root, so you c
 
 `uvicorn` loads environment variables from `backend/.env` because the `Settings` class uses that file by default. Copy `.env.example` to both `.env` and `backend/.env` so the API and tests share the same configuration, or set `ENV_FILE` to point to another path if needed. Missing SMTP fields cause the application to exit on startup so the email confirmation feature cannot be misconfigured.
 
+`backend/main.py` also calls `load_dotenv()` so these variables are available when running the script directly. This ensures features such as the travel distance API work with your configured credentials.
+
 ### Database migrations
 
 Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,9 @@
 from fastapi.openapi.utils import get_openapi
+from dotenv import load_dotenv
 from app.main import app
+
+# Load environment variables for development and tests
+load_dotenv()  # This reads .env into os.environ
 
 
 def custom_openapi() -> dict:


### PR DESCRIPTION
## Summary
- load environment variables in `backend/main.py`
- document `load_dotenv` behavior in README

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: Google OAuth test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6888a32a7f88832ebdeb83bb9c25a510