### PR TITLE
Add fallback distance calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,10 @@ Returns a 3-day weather outlook for the provided location using data from `wttr.
 GET /api/v1/distance?from_location={origin}&to_location={destination}
 ```
 This endpoint proxies the Google Distance Matrix API so the browser avoids CORS
-errors. It returns Google's JSON payload or a descriptive error message.
+errors. It returns Google's JSON payload or a descriptive error message. When
+Google cannot find a route (status `ZERO_RESULTS`), the frontend falls back to
+geocoding both locations and calculates the approximate distance using the
+haversine formula.
 
 ### Travel Mode Decision
 

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -139,7 +139,11 @@ export function getMockCoordinates(
  * Returns `0` if the request fails, the API key is missing, or the response
  * is invalid. Errors are logged to aid debugging but will not throw.
  */
-export async function getDrivingDistance(from: string, to: string): Promise<number> {
+export async function getDrivingDistance(
+  from: string,
+  to: string,
+  coordFn: typeof getCoordinates = getCoordinates,
+): Promise<number> {
   const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const url =
     `${base}/api/v1/distance?from_location=${encodeURIComponent(
@@ -148,25 +152,34 @@ export async function getDrivingDistance(from: string, to: string): Promise<numb
 
   try {
     const res = await fetch(url);
-    if (!res.ok) {
+    if (res.ok) {
+      const data = await res.json();
+      if (!data.error) {
+        const element = data.rows?.[0]?.elements?.[0];
+        if (element && element.status === 'OK' && element.distance?.value) {
+          return element.distance.value / 1000;
+        }
+        console.error('Distance element status:', element?.status);
+      } else {
+        console.error('Distance endpoint error:', data.error);
+      }
+    } else {
       console.error('Distance endpoint HTTP error', res.status);
-      return 0;
     }
-    const data = await res.json();
-    if (data.error) {
-      console.error('Distance endpoint error:', data.error);
-      return 0;
-    }
-    const element = data.rows?.[0]?.elements?.[0];
-    if (!element || element.status !== 'OK' || !element.distance?.value) {
-      console.error('Distance element status:', element?.status);
-      return 0;
-    }
-    return element.distance.value / 1000;
   } catch (err) {
     console.error('Distance endpoint fetch failed:', err);
-    return 0;
   }
+
+  // Fallback: approximate distance using geocoded coordinates
+  const fromCoords = await coordFn(from);
+  const toCoords = await coordFn(to);
+  if (fromCoords && toCoords) {
+    const km = haversineDistance(fromCoords, toCoords);
+    console.warn('Using haversine fallback distance:', km);
+    return km;
+  }
+
+  return 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
- handle zero results from Distance Matrix by geocoding locations and calculating haversine distance
- document the fallback in README
- test haversine fallback logic

## Testing
- `./scripts/test-all.sh` *(fails: OperationalError table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6888a5148824832eb7abef874c1aebca