### PR TITLE
Improve Distance Matrix debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,7 +1166,9 @@ Returns a 3-day weather outlook for the provided location using data from `wttr.
 GET /api/v1/distance?from_location={origin}&to_location={destination}
 ```
 This endpoint proxies the Google Distance Matrix API so the browser avoids CORS
-errors. It returns Google's JSON payload or a descriptive error message.
+errors. It returns Google's JSON payload or a descriptive error message. When
+debug logging is enabled on the backend, the request parameters and raw Google
+response are logged to help diagnose issues like unexpected `ZERO_RESULTS`.
 
 ### Travel Mode Decision
 

--- a/backend/routes/distance.py
+++ b/backend/routes/distance.py
@@ -26,10 +26,18 @@ def get_distance(from_location: str, to_location: str):
         "destinations": to_location,
         "key": api_key,
     }
+    logger.debug(
+        "Distance Matrix request: origins=%s destinations=%s",
+        from_location,
+        to_location,
+    )
+    logger.debug("Distance Matrix request params: %s", params)
     try:
         resp = httpx.get(url, params=params, timeout=10)
+        logger.debug("Distance Matrix raw response: %s", resp.text)
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        return data
     except Exception as exc:  # pragma: no cover - network failure
         logger.error("Distance Matrix request failed: %s", exc, exc_info=True)
         return JSONResponse(

--- a/backend/tests/test_distance_endpoint.py
+++ b/backend/tests/test_distance_endpoint.py
@@ -14,6 +14,10 @@ def test_get_distance_success(monkeypatch):
             def json(self):
                 return {"rows": []}
 
+            @property
+            def text(self):
+                return "{\"rows\": []}"
+
         return Resp()
 
     monkeypatch.setenv("GOOGLE_MAPS_API_KEY", "test-key")

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -146,6 +146,12 @@ export async function getDrivingDistance(from: string, to: string): Promise<numb
       from,
     )}&to_location=${encodeURIComponent(to)}`;
 
+  // Log the fully constructed URL so we can inspect the exact request
+  // sent to the backend proxy. This helps diagnose encoding or
+  // formatting issues that may lead to ZERO_RESULTS from Google.
+  // eslint-disable-next-line no-console
+  console.log('Fetching distance from:', url);
+
   try {
     const res = await fetch(url);
     if (!res.ok) {
@@ -155,6 +161,10 @@ export async function getDrivingDistance(from: string, to: string): Promise<numb
     const data = await res.json();
     if (data.error) {
       console.error('Distance endpoint error:', data.error);
+      return 0;
+    }
+    if (data.status && data.status !== 'OK') {
+      console.error('Distance API status:', data.status);
       return 0;
     }
     const element = data.rows?.[0]?.elements?.[0];


### PR DESCRIPTION
## Summary
- log request URL in `getDrivingDistance`
- add debug logging for backend `/distance` API
- check Google API top-level status on the frontend
- update tests for backend distance endpoint
- document new backend logging in README

## Testing
- `pytest backend/tests/test_distance_endpoint.py -q`
- `npm test -- --maxWorkers=50% src/lib/__tests__/travel.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6888a881c13c832ea05b6e4617798cd1