### PR TITLE
Fix flight mode transfer distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ response are logged to help diagnose issues like unexpected `ZERO_RESULTS`.
 
 ### Travel Mode Decision
 
-`calculateTravelMode()` in `frontend/src/lib/travel.ts` automatically decides whether an artist should fly or drive to an event. The helper geocodes the artist and event towns, finds the closest airport using great-circle distance, checks for supported routes and then compares the full flying cost (flights, transfers and car rental) with the driving estimate. The function works with any South African location and returns a detailed cost breakdown.
+`calculateTravelMode()` in `frontend/src/lib/travel.ts` automatically decides whether an artist should fly or drive to an event. The helper geocodes the artist and event towns, finds the closest airport using great-circle distance, checks for supported routes and then compares the full flying cost (flights, transfers and car rental) with the driving estimate. Transfer distances use full airport names rather than raw coordinates so Google can find a drivable route from the traveller's location to the departure airport and from the arrival airport to the final destination. The function works with any South African location and returns a detailed cost breakdown.
 
 ```ts
 import { calculateTravelMode } from '@/lib/travel';

--- a/frontend/src/lib/__tests__/travel.test.ts
+++ b/frontend/src/lib/__tests__/travel.test.ts
@@ -28,8 +28,8 @@ describe('calculateTravelMode', () => {
       if (city.startsWith('Johannesburg')) return 'JNB';
       return null;
     });
-    const distanceStub = jest.fn(async (from: string, to: string) => {
-      if (from.includes('Cape Town')) return 20;
+    const distanceStub = jest.fn(async (_from: string, to: string) => {
+      if (to.includes('International Airport')) return 20;
       if (to.includes('Johannesburg')) return 30;
       return 0;
     });

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -40,6 +40,19 @@ export const AIRPORT_LOCATIONS: Record<string, { lat: number; lng: number }> = {
   PLZ: { lat: -33.9849, lng: 25.6173 },
 };
 
+// Readable airport addresses improve Distance Matrix lookups. Using
+// coordinates sometimes yields ZERO_RESULTS because the lat/lng may not
+// represent a road-accessible point. Names resolve to the correct drop-off
+// location so transfer distances are accurate.
+export const AIRPORT_ADDRESSES: Record<string, string> = {
+  CPT: 'Cape Town International Airport, Cape Town, South Africa',
+  GRJ: 'George Airport, George, South Africa',
+  JNB: 'O. R. Tambo International Airport, Kempton Park, South Africa',
+  DUR: 'King Shaka International Airport, Durban, South Africa',
+  BFN: 'Bram Fischer International Airport, Bloemfontein, South Africa',
+  PLZ: 'Chief Dawid Stuurman International Airport, Gqeberha, South Africa',
+};
+
 const FLIGHT_ROUTES: Record<string, string[]> = {
   CPT: ['JNB', 'BFN', 'DUR', 'PLZ', 'GRJ'],
   GRJ: ['JNB', 'CPT'],
@@ -236,12 +249,14 @@ export async function calculateTravelMode(
 
   const departureLoc = AIRPORT_LOCATIONS[departure];
   const arrivalLoc = AIRPORT_LOCATIONS[arrival];
+  const departureAddress = AIRPORT_ADDRESSES[departure];
+  const arrivalAddress = AIRPORT_ADDRESSES[arrival];
   const departureTransferKm = await distanceFn(
     input.artistLocation,
-    `${departureLoc.lat},${departureLoc.lng}`,
+    departureAddress || `${departureLoc.lat},${departureLoc.lng}`,
   );
   const localTransferKm = await distanceFn(
-    `${arrivalLoc.lat},${arrivalLoc.lng}`,
+    arrivalAddress || `${arrivalLoc.lat},${arrivalLoc.lng}`,
     input.eventLocation,
   );
   const flightSubtotal = input.numTravellers * FLIGHT_COST_PER_PERSON;


### PR DESCRIPTION
## Summary
- map airport codes to descriptive addresses for Distance Matrix lookups
- use airport address strings when calculating transfer distances
- adjust travel tests for new airport addresses
- document improved airport transfer handling in README

## Testing
- `./venv/bin/python -m pytest -q` *(fails: SettingsError parsing CORS_ORIGINS)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0a1750c832ea6be9fb120d3e411