### PR TITLE
Store oauth tokens in session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,8 @@ keeps the current view, e.g.
 
 * Password strength meter and success toast.
 * Shared form components with optional Google/GitHub sign-in.
-* "Remember me" option persists sessions using `localStorage` or `sessionStorage`.
+* Standard logins and OAuth tokens persist in `sessionStorage` so refreshing the page keeps you logged in, but closing the tab signs you out.
+* Checking **Remember me** uses `localStorage` to keep you logged in across browser restarts.
 
 ---
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -68,7 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const urlToken = params.get('token');
 
     if (urlToken) {
-      localStorage.setItem('token', urlToken);
+      sessionStorage.setItem('token', urlToken);
       setToken(urlToken);
       params.delete('token');
       const newUrl = `${window.location.pathname}${
@@ -78,7 +78,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           const userData = await fetchCurrentUserWithArtist();
           setUser(userData);
-          localStorage.setItem('user', JSON.stringify(userData));
+          sessionStorage.setItem('user', JSON.stringify(userData));
         } catch (err) {
           console.error('Failed to fetch current user:', err);
         } finally {


### PR DESCRIPTION
## Summary
- keep OAuth login tokens in sessionStorage
- document new session behavior

## Testing
- `./scripts/test-all.sh` *(fails: table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6888bf947ca0832eb4bc61616b9ad566