### PR TITLE
Fix travel members not persisting

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -104,6 +104,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
     mode: "onChange",
     reValidateMode: "onChange",
     criteriaMode: "all",
+    shouldUnregister: false,
     defaultValues: {
       service_type: undefined,
       title: "",

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -38,6 +38,7 @@ export default function EditServiceModal({
     watch,
     formState: { errors, isSubmitting },
   } = useForm<ServiceFormData>({
+    shouldUnregister: false,
     defaultValues: {
       title: service.title,
       description: service.description,


### PR DESCRIPTION
## Summary
- keep `travel_members` and `travel_rate` values when navigating steps
- preserve travel fields when editing a service

## Testing
- `pip install -r backend/requirements.txt -r requirements-dev.txt`
- `PYTHONPATH=.. pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm install`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 27 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_e_6888c515c6bc832e856fa7d35f1861a2