### PR TITLE
Show travel info in service review

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Add Service wizard validates fields on each keystroke with dynamic hints like "Need 3 more characters" and the **Next** button enables automatically once inputs are valid.
 * Selecting **Live Performance** now reveals travel-related fields beneath the duration input. Artists can specify a travel rate in Rand per km (default R2.5) and the number of members travelling.
 * The **Edit Service** modal now includes these travel fields so artists can update their rate per km and members travelling from the dashboard.
+* The **Review Your Service** step now shows these travel details so they can be confirmed before publishing.
 * A new tip in the **Upload Media** step reminds artists to use high-resolution images or short video clips (1920x1080) for a polished listing.
 * The wizard uses a plain white overlay (`bg-white`) so the modal stands out and clicking outside closes it.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -574,6 +574,18 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                             <h3 className="font-medium">Duration</h3>
                             <p>{watch("duration_minutes") || 0} minutes</p>
                           </div>
+                          {watchServiceType === "Live Performance" && (
+                            <>
+                              <div className="border rounded-md p-4">
+                                <h3 className="font-medium">Travelling (Rand per km)</h3>
+                                <p>{watch("travel_rate") || 0}</p>
+                              </div>
+                              <div className="border rounded-md p-4">
+                                <h3 className="font-medium">Members travelling</h3>
+                                <p>{watch("travel_members") || 1}</p>
+                              </div>
+                            </>
+                          )}
                           <div className="border rounded-md p-4 col-span-full">
                             <h3 className="font-medium">Packages</h3>
                             {packages.map((p, idx) => (

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -113,6 +113,10 @@ describe("AddServiceModal wizard", () => {
       next4.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
+    // Review step should show travel details before publishing
+    expect(container.textContent).toContain("Travelling (Rand per km)");
+    expect(container.textContent).toContain("Members travelling");
+
     const publish = container.querySelector(
       'button[type="submit"]',
     ) as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- show Rand per km and members travelling on the "Review Your Service" step
- document that travel details appear in the review step
- update AddServiceModal test to expect travel fields

## Testing
- `npm install` (to get Jest)
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 27 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6888c77bc498832e97fd053987a0ddfc