### PR TITLE
Fix travel members reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,8 +913,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * **Add Service** button now opens a full-screen wizard. Steps appear in a coral-accented stepper with keyboard focus trapping. The final review mirrors earlier steps with image thumbnails before publishing.
 * Add Service wizard validates fields on each keystroke with dynamic hints like "Need 3 more characters" and the **Next** button enables automatically once inputs are valid.
 * Selecting **Live Performance** now reveals travel-related fields beneath the duration input. Artists can specify a travel rate in Rand per km (default R2.5) and the number of members travelling.
-* The **Edit Service** modal now includes these travel fields so artists can update their rate per km and members travelling from the dashboard.
-* The **Review Your Service** step now shows these travel details so they can be confirmed before publishing.
+* The **Edit Service** modal now includes these travel fields so artists can update their rate per km and members travelling from the dashboard. These values are stored server-side so edits persist.
+* The **Review Your Service** step now shows these travel details so they can be confirmed before publishing and accurately feed into travel cost calculations.
 * A new tip in the **Upload Media** step reminds artists to use high-resolution images or short video clips (1920x1080) for a polished listing.
 * The wizard uses a plain white overlay (`bg-white`) so the modal stands out and clicking outside closes it.
 * "Total Services" card now links to `/services?artist=<your_id>` so you only see your listings.

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -48,6 +48,10 @@ class Service(BaseModel):
         default=ServiceType.LIVE_PERFORMANCE,
     )
 
+    # New travel fields so quotes can accurately reflect costs
+    travel_rate = Column(Numeric(10, 2), nullable=True, default=2.5)
+    travel_members = Column(Integer, nullable=True, default=1)
+
     # Link back to the ArtistProfileV2
     artist = relationship("ArtistProfileV2", back_populates="services")
 

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -15,6 +15,8 @@ class ServiceBase(BaseModel):
     currency: Optional[str] = "ZAR"
     display_order: Optional[int] = None
     service_type: Optional[ServiceType] = None
+    travel_rate: Optional[Decimal] = None
+    travel_members: Optional[int] = None
 
 
 # Properties to receive on item creation


### PR DESCRIPTION
## Summary
- persist travel fields in Service model
- document persistent travel rate and member fields

## Testing
- `./scripts/test-backend.sh` *(fails: OperationalError table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6888c9f1807c832e82769e3a4c34a843