### PR TITLE
Fix notifications 500 due to missing service columns

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -125,6 +125,23 @@ def ensure_currency_column(engine: Engine) -> None:
     )
 
 
+def ensure_service_travel_columns(engine: Engine) -> None:
+    """Add travel-related columns to ``services`` if missing."""
+
+    add_column_if_missing(
+        engine,
+        "services",
+        "travel_rate",
+        "travel_rate NUMERIC(10, 2)",
+    )
+    add_column_if_missing(
+        engine,
+        "services",
+        "travel_members",
+        "travel_members INTEGER",
+    )
+
+
 def ensure_booking_simple_columns(engine: Engine) -> None:
     """Add missing columns on ``bookings_simple``."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from .db_utils import (
     ensure_price_visible_column,
     ensure_portfolio_image_urls_column,
     ensure_currency_column,
+    ensure_service_travel_columns,
     ensure_mfa_columns,
     ensure_request_attachment_column,
     ensure_booking_simple_columns,
@@ -82,6 +83,7 @@ ensure_custom_subtitle_column(engine)
 ensure_price_visible_column(engine)
 ensure_portfolio_image_urls_column(engine)
 ensure_currency_column(engine)
+ensure_service_travel_columns(engine)
 ensure_mfa_columns(engine)
 ensure_booking_simple_columns(engine)
 ensure_calendar_account_email_column(engine)

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -6,6 +6,7 @@ from app.db_utils import (
     ensure_notification_link_column,
     ensure_price_visible_column,
     ensure_currency_column,
+    ensure_service_travel_columns,
     ensure_booking_simple_columns,
     ensure_mfa_columns,
     ensure_calendar_account_email_column,
@@ -159,6 +160,15 @@ def test_add_currency_column():
     inspector = inspect(engine)
     column_names = [col["name"] for col in inspector.get_columns("services")]
     assert "currency" in column_names
+
+
+def test_service_travel_columns():
+    engine = setup_service_engine()
+    ensure_service_travel_columns(engine)
+    inspector = inspect(engine)
+    cols = [c["name"] for c in inspector.get_columns("services")]
+    assert "travel_rate" in cols
+    assert "travel_members" in cols
 
 
 def test_booking_simple_columns():


### PR DESCRIPTION
## Summary
- ensure new travel-related columns exist on the `services` table
- call the new helper at startup
- test coverage for the new helper

## Testing
- `./scripts/test-backend.sh` *(fails: Google OAuth callback test)*

------
https://chatgpt.com/codex/tasks/task_e_6888cda987c0832e88e0959f55cbba13