### PR TITLE
Use road distance metrics for travel estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,9 @@ duration fields from Google. When omitted or set to `false`, the proxy strips
 parameters and raw Google response to help diagnose issues like unexpected
 `ZERO_RESULTS`.
 When `includeDuration=true`, helpers like `getDrivingMetrics()` parse both the
-distance and estimated driving time.
+distance and estimated driving time. All travel cost estimates in the booking
+wizard now rely on this API via `getDrivingMetrics` instead of great-circle
+distance calculations.
 
 ### Travel Mode Decision
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -19,8 +19,8 @@ import {
   getService,
   calculateQuote,
 } from '@/lib/api';
-import { geocodeAddress, calculateDistanceKm } from '@/lib/geo';
-import { calculateTravelMode, TravelResult } from '@/lib/travel';
+import { geocodeAddress } from '@/lib/geo';
+import { calculateTravelMode, TravelResult, getDrivingMetrics } from '@/lib/travel';
 
 import { BookingRequestCreate } from '@/types';
 import Stepper from '../ui/Stepper';
@@ -221,7 +221,12 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       const travelRate = svcRes.data.travel_rate || 2.5;
       const numTravelMembers = svcRes.data.travel_members || 1;
 
-      const directDistanceKm = calculateDistanceKm(artistPos, eventPos);
+      const metrics = await getDrivingMetrics(artistLocation, details.location);
+      if (!metrics.distanceKm) {
+        console.error('Unable to fetch driving metrics during review calculation');
+        throw new Error('Could not fetch driving metrics');
+      }
+      const directDistanceKm = metrics.distanceKm;
       const drivingEstimateCost = directDistanceKm * travelRate * 2;
 
       const quoteResponse = await calculateQuote({

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -5,8 +5,8 @@ import { act } from "react";
 import BookingWizard from "../BookingWizard";
 import { BookingProvider, useBooking } from "@/contexts/BookingContext";
 import * as api from "@/lib/api";
-import { geocodeAddress, calculateDistanceKm } from "@/lib/geo";
-import { calculateTravelMode } from "@/lib/travel";
+import { geocodeAddress } from "@/lib/geo";
+import { calculateTravelMode, getDrivingMetrics } from "@/lib/travel";
 
 jest.mock("@/lib/api");
 jest.mock("@/lib/geo");
@@ -55,7 +55,7 @@ describe("BookingWizard flow", () => {
       data: { travel_rate: 2.5, travel_members: 1 },
     });
     (geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
-    (calculateDistanceKm as jest.Mock).mockReturnValue(10);
+    (getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
     (calculateTravelMode as jest.Mock).mockResolvedValue({
       mode: "drive",
       totalCost: 100,
@@ -115,7 +115,9 @@ describe("BookingWizard flow", () => {
       (window as any).__setStep(8);
     });
     await flushPromises();
-    expect(calculateTravelMode).toHaveBeenCalled();
+    expect(calculateTravelMode).toHaveBeenCalledWith(
+      expect.objectContaining({ drivingEstimate: 50 })
+    );
   });
 
   it("advances to the next step when pressing Enter on desktop", async () => {

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -5,8 +5,8 @@ import WizardNav from '../WizardNav';
 import { useBooking } from '@/contexts/BookingContext';
 import { useState, useEffect } from 'react';
 import { calculateQuote, getService } from '@/lib/api';
-import { geocodeAddress, calculateDistanceKm } from '@/lib/geo';
-import { calculateTravelMode, TravelResult } from '@/lib/travel';
+import { geocodeAddress } from '@/lib/geo';
+import { calculateTravelMode, TravelResult, getDrivingMetrics } from '@/lib/travel';
 import TravelSummaryCard from '../TravelSummaryCard';
 import { formatCurrency } from '@/lib/utils';
 
@@ -48,7 +48,12 @@ export default function ReviewStep({
           geocodeAddress(details.location),
         ]);
         if (!artistPos || !eventPos) return;
-        const distance = calculateDistanceKm(artistPos, eventPos);
+        const metrics = await getDrivingMetrics(artistLocation, details.location);
+        if (!metrics.distanceKm) {
+          console.error('Unable to fetch driving metrics for review step');
+          return;
+        }
+        const distance = metrics.distanceKm;
         const quote = await calculateQuote({
           base_fee: Number(svcRes.data.price),
           distance_km: distance,

--- a/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
@@ -4,8 +4,8 @@ import { act } from 'react';
 import ReviewStep from '../ReviewStep';
 import { useBooking } from '@/contexts/BookingContext';
 import { calculateQuote, getService } from '@/lib/api';
-import { geocodeAddress, calculateDistanceKm } from '@/lib/geo';
-import { calculateTravelMode } from '@/lib/travel';
+import { geocodeAddress } from '@/lib/geo';
+import { calculateTravelMode, getDrivingMetrics } from '@/lib/travel';
 
 jest.mock('@/contexts/BookingContext');
 jest.mock('@/lib/api');
@@ -23,7 +23,7 @@ describe('ReviewStep summary', () => {
     (getService as jest.Mock).mockResolvedValue({ data: { price: 100 } });
     (calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 150 } });
     (geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
-    (calculateDistanceKm as jest.Mock).mockReturnValue(10);
+    (getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
     (calculateTravelMode as jest.Mock).mockResolvedValue({
       mode: 'drive',
       totalCost: 100,
@@ -74,5 +74,8 @@ describe('ReviewStep summary', () => {
     expect(container.querySelectorAll('h3').length).toBeGreaterThan(1);
     expect(container.textContent).toContain('Estimated Price');
     expect(container.textContent).toContain('Travel Mode');
+    expect(calculateTravelMode).toHaveBeenCalledWith(
+      expect.objectContaining({ drivingEstimate: 50 })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- fetch driving distance with `getDrivingMetrics` in ReviewStep
- fetch driving distance with `getDrivingMetrics` in BookingWizard
- update unit tests for new driving metrics
- document Distance Matrix API reliance in README

## Testing
- `./scripts/test-all.sh` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68890a8a436c832eb0083564d7c6a829