### PR TITLE
Start travel calc at guests step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,9 +1196,9 @@ const mode = await calculateTravelMode({
 console.log(mode.mode, mode.totalCost);
 ```
 
-The Booking Wizard now waits until you reach the Review step to run this check.
-Once both the artist and event locations are confirmed, the travel mode and
-cost are calculated and shown in a summary card.
+The Booking Wizard now waits until you reach the **Guests** step to run this
+check. Once both the artist and event locations are confirmed, the travel mode
+and cost are calculated and shown in a summary card.
 
 When submitting the booking request, the frontend now sends three extra fields:
 

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -253,10 +253,12 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     }
   }, [serviceId, artistLocation, details.location, setTravelResult]);
 
-  // Trigger the calculation function whenever its dependencies change
+  // Trigger the calculation when at or beyond the Guests step
   useEffect(() => {
-    void calculateReviewData();
-  }, [calculateReviewData]);
+    if (step >= 4) {
+      void calculateReviewData();
+    }
+  }, [step, calculateReviewData]);
 
   // --- Navigation & Submission Handlers ---
 

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -96,7 +96,7 @@ describe("BookingWizard flow", () => {
     expect(window.scrollTo).toHaveBeenCalled();
   });
 
-  it("calculates travel only on the review step", async () => {
+  it("calculates travel starting at the guests step", async () => {
     act(() => {
       root.unmount();
     });
@@ -112,7 +112,7 @@ describe("BookingWizard flow", () => {
     expect(calculateTravelMode).not.toHaveBeenCalled();
 
     await act(async () => {
-      (window as any).__setStep(8);
+      (window as any).__setStep(4);
     });
     await flushPromises();
     expect(calculateTravelMode).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- start travel estimate updates at the Guests step
- update booking wizard test
- document Guests step travel logic

## Testing
- `./scripts/test-all.sh` *(fails: unable to fetch remote for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68890c71d64c832ead52ac09cf5494ba