### PR TITLE
Fix Google autocomplete crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ The location input now reuses the `LocationInput` component powered by the
 homepage and artist page search bars. The Google Maps script still loads lazily
 via the `loadPlaces()` helper so it is only injected once and avoids the "API
 included multiple times" warning.
+`LocationInput` waits for this helper to resolve before creating the
+autocomplete service. When the API key is missing the field degrades to a plain
+text input instead of throwing a runtime error.
 
 The **Edit Profile** page now uses this same component and requires a location
 to be entered so travel fees can be estimated correctly.

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -4,6 +4,10 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import LocationStep from '../LocationStep';
 
+jest.mock('@/lib/loadPlaces', () => ({
+  loadPlaces: () => Promise.resolve({}),
+}));
+
 jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => {
   const React = require('react');
   return () => {
@@ -65,6 +69,7 @@ describe('LocationStep selection', () => {
   it('shows map after selecting a place', async () => {
     await act(async () => {
       root.render(React.createElement(Wrapper));
+      await Promise.resolve();
     });
     const input = container.querySelector('input') as HTMLInputElement;
     await act(async () => {
@@ -81,6 +86,7 @@ describe('LocationStep selection', () => {
   it('reveals tooltip on focus', async () => {
     await act(async () => {
       root.render(React.createElement(Wrapper));
+      await Promise.resolve();
     });
     const tooltipButton = container.querySelector('button[aria-describedby]') as HTMLButtonElement;
     act(() => {

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -3,6 +3,10 @@ import { act } from 'react-dom/test-utils';
 import { createRoot } from 'react-dom/client';
 import SearchBarInline from '../SearchBarInline';
 
+jest.mock('@/lib/loadPlaces', () => ({
+  loadPlaces: () => Promise.resolve({}),
+}));
+
 jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => () => ({
   placesService: null,
   placePredictions: [],
@@ -14,15 +18,16 @@ describe('SearchBarInline', () => {
     document.body.innerHTML = '';
   });
 
-  it('expands and triggers onSearch', () => {
+  it('expands and triggers onSearch', async () => {
     const onSearch = jest.fn();
     const onChange = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
+      await Promise.resolve();
     });
 
     const trigger = container.querySelector('button') as HTMLButtonElement;
@@ -45,15 +50,16 @@ describe('SearchBarInline', () => {
     container.remove();
   });
 
-  it('closes on Escape without searching', () => {
+  it('closes on Escape without searching', async () => {
     const onSearch = jest.fn();
     const onChange = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
+      await Promise.resolve();
     });
 
     const trigger = container.querySelector('button') as HTMLButtonElement;
@@ -75,14 +81,15 @@ describe('SearchBarInline', () => {
     container.remove();
   });
 
-  it('location label does not wrap and is truncated', () => {
+  it('location label does not wrap and is truncated', async () => {
     const onSearch = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root.render(<SearchBarInline onSearch={onSearch} />);
+      await Promise.resolve();
     });
 
     const locationDiv = container.querySelector('button > div:nth-child(2)') as HTMLDivElement;
@@ -94,14 +101,15 @@ describe('SearchBarInline', () => {
     container.remove();
   });
 
-  it('uses smaller max width when collapsed and expands to full width', () => {
+  it('uses smaller max width when collapsed and expands to full width', async () => {
     const onSearch = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
-    act(() => {
+    await act(async () => {
       root.render(<SearchBarInline onSearch={onSearch} />);
+      await Promise.resolve();
     });
 
     const wrapper = container.querySelector('div') as HTMLDivElement;

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import usePlacesService from 'react-google-autocomplete/lib/usePlacesAutocompleteService';
+import { loadPlaces } from '@/lib/loadPlaces';
 import { MapPinIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 
@@ -15,7 +16,7 @@ interface CustomLocationInputProps {
   required?: boolean;
 }
 
-export default function CustomLocationInput({
+function LocationInputInner({
   value,
   onValueChange,
   onPlaceSelect,
@@ -160,4 +161,40 @@ export default function CustomLocationInput({
       )}
     </div>
   );
+}
+
+export default function CustomLocationInput(props: CustomLocationInputProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const api = await loadPlaces();
+      if (mounted && api) setLoaded(true);
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!loaded) {
+    const { value, onValueChange, placeholder = 'Search location', className, inputClassName, required = false } = props;
+    return (
+      <div className={clsx('relative w-full', className)}>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          placeholder={placeholder}
+          required={required}
+          className={clsx(
+            'w-full text-sm text-gray-700 placeholder-gray-400 bg-transparent focus:outline-none',
+            inputClassName,
+          )}
+        />
+      </div>
+    );
+  }
+
+  return <LocationInputInner {...props} />;
 }


### PR DESCRIPTION
## Summary
- load Google Places before initializing LocationInput
- handle missing API key gracefully
- mock `loadPlaces` in location-related tests
- document fallback behaviour in README

## Testing
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: 28 failed, 1 skipped, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6889136116ec832ea1524414002b1245