### PR TITLE
Handle missing Google credentials early

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ If a stored refresh token becomes invalid (e.g. revoked), the calendar sync
 logic now removes the credentials and returns an empty availability list rather
 than failing with a 500 error. Artists will need to reconnect their Google
 Calendar account.
-If the API starts without `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` set, calendar syncing is disabled and a warning is logged.
+If the API starts without `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` set, calendar syncing is disabled and a warning is logged. Calls to the OAuth endpoints now return HTTP 500 instead of redirecting to a Google error page when these credentials are missing.
 
 After installing new dependencies, run `./scripts/test-all.sh` once to refresh the caches.
 

--- a/backend/app/services/calendar_service.py
+++ b/backend/app/services/calendar_service.py
@@ -25,6 +25,13 @@ SCOPES = [
 ]
 
 
+def _require_credentials() -> None:
+    """Ensure Google OAuth credentials are configured."""
+    if not settings.GOOGLE_CLIENT_ID or not settings.GOOGLE_CLIENT_SECRET:
+        logger.warning("Google Calendar credentials not configured")
+        raise HTTPException(500, "Google Calendar credentials not configured")
+
+
 def _flow(redirect_uri: str) -> Flow:
     return Flow.from_client_config(
         {
@@ -43,6 +50,7 @@ def _flow(redirect_uri: str) -> Flow:
 
 def get_auth_url(user_id: int, redirect_uri: str) -> str:
     """Return the Google OAuth authorization URL for the user."""
+    _require_credentials()
     flow = _flow(redirect_uri)
     auth_url, _ = flow.authorization_url(
         access_type="offline",
@@ -55,6 +63,7 @@ def get_auth_url(user_id: int, redirect_uri: str) -> str:
 
 def exchange_code(user_id: int, code: str, redirect_uri: str, db: Session) -> None:
     """Exchange OAuth code for tokens and store them."""
+    _require_credentials()
     flow = _flow(redirect_uri)
     flow.fetch_token(code=code)
     creds = flow.credentials

--- a/backend/tests/test_google_calendar.py
+++ b/backend/tests/test_google_calendar.py
@@ -93,6 +93,30 @@ def test_exchange_code_missing_refresh_token(monkeypatch):
     assert exc.value.status_code == 400
 
 
+def test_get_auth_url_missing_credentials(monkeypatch):
+    monkeypatch.setattr(calendar_service.settings, 'GOOGLE_CLIENT_ID', '', raising=False)
+    monkeypatch.setattr(calendar_service.settings, 'GOOGLE_CLIENT_SECRET', '', raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        calendar_service.get_auth_url(1, 'http://localhost')
+    assert exc.value.status_code == 500
+
+
+def test_exchange_code_missing_credentials(monkeypatch):
+    db = setup_db()
+    user = User(email='mc@test.com', password='x', first_name='Miss', last_name='Cred', user_type=UserType.ARTIST)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    monkeypatch.setattr(calendar_service.settings, 'GOOGLE_CLIENT_ID', '', raising=False)
+    monkeypatch.setattr(calendar_service.settings, 'GOOGLE_CLIENT_SECRET', '', raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        calendar_service.exchange_code(user.id, 'code', 'uri', db)
+    assert exc.value.status_code == 500
+
+
 def test_fetch_events_http_error(monkeypatch):
     db = setup_db()
     user = User(email='c@test.com', password='x', first_name='C', last_name='U', user_type=UserType.ARTIST)


### PR DESCRIPTION
## Summary
- check Google Calendar credentials before starting OAuth flows
- handle missing Google credentials early in exchange_code
- document that OAuth endpoints return HTTP 500 when credentials are missing
- add regression tests for new credential checks

## Testing
- `./scripts/test-backend.sh` *(fails: OperationalError: table users already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6889277dad30832ebdc3d2ddf4dc22d7