### PR TITLE
Update flight rate and add review disclaimer

### DIFF
--- a/frontend/src/components/booking/TravelSummaryCard.tsx
+++ b/frontend/src/components/booking/TravelSummaryCard.tsx
@@ -34,7 +34,9 @@ export default function TravelSummaryCard({ result }: Props) {
       {mode === 'fly' ? (
         <ul className="text-sm space-y-1">
           <li>
-            Flights ({fly.travellers}): {formatCurrency(fly.flightSubtotal)}
+            Flights (avg price) ({fly.travellers}): {formatCurrency(
+              fly.flightSubtotal,
+            )}
           </li>
           <li>Car Rental: {formatCurrency(fly.carRental)}</li>
           <li>Transfers: {formatCurrency(fly.transferCost)}</li>

--- a/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
@@ -30,7 +30,7 @@ describe('ReviewStep summary', () => {
       breakdown: {
         drive: { estimate: 100 },
         fly: {
-          perPerson: 2500,
+          perPerson: 2780,
           travellers: 1,
           flightSubtotal: 0,
           carRental: 1000,

--- a/frontend/src/lib/travel.ts
+++ b/frontend/src/lib/travel.ts
@@ -31,7 +31,7 @@ export interface TravelResult {
   };
 }
 
-const DEFAULT_FLIGHT_COST_PER_PERSON = 2500;
+const DEFAULT_FLIGHT_COST_PER_PERSON = 2780;
 const CAR_RENTAL_COST = 1000;
 const RATE_PER_KM = 2.5;
 


### PR DESCRIPTION
## Summary
- show an average price note in TravelSummaryCard
- raise hardcoded flight cost to R2780
- update related unit tests

## Testing
- `npm test` *(fails: Test Suites: 28 failed, 1 skipped, 70 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688932fb8b64832ebe2478d53328b216