### PR TITLE
Update flight summary text

### DIFF
--- a/frontend/src/components/booking/TravelSummaryCard.tsx
+++ b/frontend/src/components/booking/TravelSummaryCard.tsx
@@ -34,11 +34,8 @@ export default function TravelSummaryCard({ result }: Props) {
       {mode === 'fly' ? (
         <ul className="text-sm space-y-1">
           <li>
-            Flights: {formatCurrency(fly.flightSubtotal)}{' '}
-            <span className="text-xs text-gray-500">
-              (avg price for {fly.travellers} travelling{' '}
-              {fly.travellers === 1 ? 'member' : 'members'})
-            </span>
+            Flights ({fly.travellers}): {formatCurrency(fly.flightSubtotal)}{' '}
+            <span className="text-xs text-gray-500">(avg price)</span>
           </li>
           <li>Car Rental: {formatCurrency(fly.carRental)}</li>
           <li>Transfers: {formatCurrency(fly.transferCost)}</li>

--- a/frontend/src/components/booking/__tests__/TravelSummaryCard.test.tsx
+++ b/frontend/src/components/booking/__tests__/TravelSummaryCard.test.tsx
@@ -31,9 +31,9 @@ describe('TravelSummaryCard', () => {
         />,
       );
     });
-    expect(div.textContent).toContain('Flights:');
+    expect(div.textContent).toContain('Flights (2):');
     expect(div.textContent).toContain(formatCurrency(5560));
-    expect(div.textContent).toContain('avg price for 2 travelling members');
+    expect(div.textContent).toContain('avg price');
     act(() => {
       root.unmount();
     });


### PR DESCRIPTION
## Summary
- adjust flight cost label to include traveller count before cost
- update TravelSummaryCard tests

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: `git fetch origin main`)*
- `./scripts/docker-test.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893bceb0d4832ebde07febc668e998