### PR TITLE
Fix lint issues and docs

### DIFF
--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -427,6 +427,8 @@ def test_google_oauth_token_error(monkeypatch):
     client = TestClient(app)
     res = client.get("/auth/google/callback?code=x&state=/done", follow_redirects=False)
     assert res.status_code == 400
-    assert res.json()["detail"] == "Google authentication failed"
+    data = res.json()
+    assert data["detail"]["message"] == "Google authentication failed"
+    assert data["detail"]["field_errors"] == {}
 
     app.dependency_overrides.pop(get_db, None)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,7 @@
         "stylelint-config-standard": "^29.0.0",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.3.2"
+        "typescript": "5.3.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -12630,10 +12630,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,6 +76,6 @@
     "stylelint-config-standard": "^29.0.0",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.2"
+    "typescript": "5.3.2"
   }
 }

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -19,7 +19,7 @@ import {
   calculateQuote,
 } from '@/lib/api';
 import { geocodeAddress } from '@/lib/geo';
-import { calculateTravelMode, TravelResult, getDrivingMetrics } from '@/lib/travel';
+import { calculateTravelMode, getDrivingMetrics } from '@/lib/travel';
 
 import { BookingRequestCreate } from '@/types';
 import Stepper from '../ui/Stepper';
@@ -250,7 +250,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     } finally {
       setIsLoadingReviewData(false);
     }
-  }, [serviceId, artistLocation, details.location, setTravelResult]);
+  }, [serviceId, artistLocation, details.location, details.date, setTravelResult]);
 
   // Trigger the calculation when at or beyond the Guests step
   useEffect(() => {

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -24,10 +24,12 @@ function Wrapper({ serviceId }: { serviceId?: number } = {}) {
 
 function ExposeTravel() {
   const { setDetails, setTravelResult } = useBooking();
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   (window as unknown as { __setDetails: (d: any) => void }).__setDetails =
     setDetails;
   (window as unknown as { __setTravelResult: (r: any) => void }).__setTravelResult =
     setTravelResult;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   return null;
 }
 
@@ -56,11 +58,13 @@ describe("BookingWizard flow", () => {
     });
     (geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
     (getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     (calculateTravelMode as jest.Mock).mockResolvedValue({
       mode: "drive",
       totalCost: 100,
       breakdown: { drive: { estimate: 100 }, fly: {} as any },
     });
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -106,12 +110,14 @@ describe("BookingWizard flow", () => {
       root.render(React.createElement(Wrapper, { serviceId: 1 }));
     });
     await act(async () => {
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       (window as any).__setDetails({ location: "Event City" });
     });
     await flushPromises();
     expect(calculateTravelMode).not.toHaveBeenCalled();
 
     await act(async () => {
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       (window as any).__setStep(4);
     });
     await flushPromises();

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -9,11 +9,14 @@ jest.mock('@/lib/loadPlaces', () => ({
 }));
 
 jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const React = require('react');
   return () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [preds, setPreds] = React.useState<any[]>([]);
     return {
       placesService: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getDetails: (_opts: any, cb: (p: any) => void) =>
           cb({
             geometry: { location: { lat: () => 1, lng: () => 2 } },


### PR DESCRIPTION
## Summary
- handle travel date in calculateReviewData dependency
- pin TypeScript to avoid unsupported warning
- update OAuth test for new error structure
- silence eslint warnings in test utils

## Testing
- `pytest backend/tests/test_oauth.py::test_google_oauth_token_error -q`
- `npx jest src/components/booking/__tests__/BookingWizard.test.tsx src/components/booking/steps/__tests__/LocationStep.test.tsx --runInBand` *(fails: TypeError dispatchEvent)*

------
https://chatgpt.com/codex/tasks/task_e_688a03d1ae5c832e81af1366b8278df5