### PR TITLE
Add quote countdown

### DIFF
--- a/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
+++ b/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import QuoteCard from '../QuoteCard';
 import { act } from 'react';
+import QuoteCard from '../QuoteCard';
 import { formatCurrency } from '@/lib/utils';
 
-const quote = {
+const baseQuote = {
   id: 1,
   booking_request_id: 1,
   artist_id: 2,
@@ -16,22 +16,91 @@ const quote = {
   subtotal: 130,
   discount: null,
   total: 130,
-  status: 'pending',
+  status: 'pending' as const,
   created_at: '',
   updated_at: '',
 };
 
 describe('QuoteCard', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it('renders service items and buttons', () => {
-    const div = document.createElement('div');
-    const root = createRoot(div);
     act(() => {
       root.render(
-        <QuoteCard quote={quote} isClient onAccept={() => {}} onDecline={() => {}} bookingConfirmed={false} />,
+        <QuoteCard
+          quote={baseQuote}
+          isClient
+          onAccept={() => {}}
+          onDecline={() => {}}
+          bookingConfirmed={false}
+        />,
       );
     });
-    expect(div.textContent).toContain('Perf');
-    expect(div.textContent).toContain(formatCurrency(100));
-    expect(div.textContent).toContain(formatCurrency(130));
+    expect(container.textContent).toContain('Perf');
+    expect(container.textContent).toContain(formatCurrency(100));
+    expect(container.textContent).toContain(formatCurrency(130));
+  });
+
+  it('shows countdown for pending quote', () => {
+    jest.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+    const quote = {
+      ...baseQuote,
+      expires_at: new Date(Date.now() + 26 * 60 * 60 * 1000).toISOString(),
+    };
+    act(() => {
+      root.render(
+        <QuoteCard
+          quote={quote}
+          isClient
+          onAccept={() => {}}
+          onDecline={() => {}}
+          bookingConfirmed={false}
+        />,
+      );
+    });
+    let span = container.querySelector('[data-testid="expires-countdown"]');
+    expect(span?.textContent).toMatch(/Expires in 1d 2h/);
+    act(() => {
+      jest.advanceTimersByTime(60 * 60 * 1000);
+    });
+    span = container.querySelector('[data-testid="expires-countdown"]');
+    expect(span?.textContent).toMatch(/Expires in 1d 1h/);
+  });
+
+  it('applies warning style when under 24h left', () => {
+    jest.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+    const quote = {
+      ...baseQuote,
+      expires_at: new Date(Date.now() + 10 * 60 * 60 * 1000).toISOString(),
+    };
+    act(() => {
+      root.render(
+        <QuoteCard
+          quote={quote}
+          isClient
+          onAccept={() => {}}
+          onDecline={() => {}}
+          bookingConfirmed={false}
+        />,
+      );
+    });
+    const span = container.querySelector('[data-testid="expires-countdown"]') as HTMLElement;
+    expect(span.className).toContain('text-orange-600');
   });
 });


### PR DESCRIPTION
## Summary
- show a live countdown for quote expiry in `QuoteCard`
- style expiry warning when <24 hours
- test countdown and warning logic

## Testing
- `npm ci` in `frontend`
- `npm test -- src/components/booking/__tests__/QuoteCard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688a1bfc4de8832e80762764b0fa3c6e