### PR TITLE
Add quote PDF download feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,10 +781,11 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `POST /api/v1/quotes` returns **404 Not Found** when the
   `booking_request_id` does not match an existing request.
 * Accepting a Quote V2 now also creates a formal booking visible on the artist dashboard.
-* Accepted quotes now include a `booking_id` referencing the formal booking when
-  retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
-* `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
-  parameter when the related booking request was created without one.
+  * Accepted quotes now include a `booking_id` referencing the formal booking when
+    retrieved via `GET /api/v1/quotes/{id}` so clients can load booking details.
+  * `GET /api/v1/quotes/{id}/pdf` downloads a PDF version of the quote.
+  * `POST /api/v1/quotes/{id}/accept` accepts an optional `service_id` query
+    parameter when the related booking request was created without one.
   The response now returns the newly created `BookingSimple` so the frontend
   can immediately fetch full booking details using the returned `id`.
 * If the booking request is for a **Live Performance** and lacks a

--- a/backend/app/services/quote_pdf.py
+++ b/backend/app/services/quote_pdf.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+from .. import models
+
+
+def generate_pdf(quote: models.QuoteV2) -> bytes:
+    """Return PDF bytes for the given quote."""
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=A4)
+    c.setFont("Helvetica", 14)
+    c.drawString(50, 800, f"Quote #{quote.id}")
+    c.setFont("Helvetica", 10)
+    c.drawString(50, 780, f"Created: {quote.created_at:%Y-%m-%d}")
+    c.drawString(50, 760, f"Artist ID: {quote.artist_id}")
+    c.drawString(50, 740, f"Client ID: {quote.client_id}")
+    c.drawString(50, 720, "Services")
+    y = 700
+    for item in quote.services:
+        c.drawString(60, y, f"- {item['description']}")
+        c.drawRightString(550, y, f"R{item['price']}")
+        y -= 20
+    c.line(50, y + 5, 550, y + 5)
+    c.setFont("Helvetica-Bold", 12)
+    c.drawRightString(550, y - 20, f"Total: R{quote.total}")
+    c.showPage()
+    c.save()
+    buffer.seek(0)
+    return buffer.read()

--- a/backend/tests/test_quote_pdf.py
+++ b/backend/tests/test_quote_pdf.py
@@ -1,0 +1,118 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from decimal import Decimal
+import datetime
+
+from app.main import app
+from app.models import User, UserType, BookingRequest, Service, QuoteV2, QuoteStatusV2
+from app.models.base import BaseModel
+from app.api.dependencies import get_db, get_current_user
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_quote(Session):
+    db = Session()
+    client = User(email="c@test.com", password="x", first_name="C", last_name="L", user_type=UserType.CLIENT)
+    artist = User(email="a@test.com", password="x", first_name="A", last_name="R", user_type=UserType.ARTIST)
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title="Show",
+        price=Decimal("100"),
+        duration_minutes=60,
+        service_type="Live Performance",
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    br = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        service_id=service.id,
+        proposed_datetime_1=datetime.datetime.utcnow(),
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    quote = QuoteV2(
+        booking_request_id=br.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[{"description": "Show", "price": 100}],
+        sound_fee=0,
+        travel_fee=0,
+        subtotal=Decimal("100"),
+        total=Decimal("100"),
+        status=QuoteStatusV2.PENDING,
+    )
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+
+    return db, client, artist, quote
+
+
+def override_user(user):
+    def _override():
+        return user
+
+    return _override
+
+
+def test_quote_pdf_endpoint():
+    Session = setup_app()
+    db, client_user, artist_user, quote = create_quote(Session)
+
+    prev_db = app.dependency_overrides.get(get_db)
+    prev_user = app.dependency_overrides.get(get_current_user)
+
+    def _db_override():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_current_user] = override_user(client_user)
+    client = TestClient(app)
+
+    res = client.get(f"/api/v1/quotes/{quote.id}/pdf")
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+
+    if prev_db is not None:
+        app.dependency_overrides[get_db] = prev_db
+    else:
+        app.dependency_overrides.pop(get_db, None)
+    if prev_user is not None:
+        app.dependency_overrides[get_current_user] = prev_user
+    else:
+        app.dependency_overrides.pop(get_current_user, None)
+    db.close()

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2660,6 +2660,52 @@
         }
       }
     },
+    "/api/v1/quotes/{quote_id}/pdf": {
+      "get": {
+        "tags": [
+          "quotes",
+          "Quotes"
+        ],
+        "summary": "Get Quote Pdf",
+        "operationId": "get_quote_pdf_api_v1_quotes__quote_id__pdf_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "quote_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Quote Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/quotes/calculate": {
       "post": {
         "tags": [

--- a/frontend/src/components/booking/QuoteCard.tsx
+++ b/frontend/src/components/booking/QuoteCard.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import Button from '../ui/Button';
 import { QuoteV2 } from '@/types';
 import { formatCurrency } from '@/lib/utils';
+import { downloadQuotePdf } from '@/lib/api';
 
 interface Props {
   quote: QuoteV2;
@@ -21,6 +22,23 @@ const QuoteCard: React.FC<Props> = ({ quote, isClient, onAccept, onDecline, book
   };
   const [remaining, setRemaining] = useState('');
   const [warning, setWarning] = useState(false);
+
+  const handleDownloadPdf = async () => {
+    try {
+      const res = await downloadQuotePdf(quote.id);
+      const blob = new Blob([res.data], { type: 'application/pdf' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `quote-${quote.id}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Quote PDF download error', err);
+    }
+  };
 
   useEffect(() => {
     if (!quote.expires_at || quote.status !== 'pending') {
@@ -93,6 +111,16 @@ const QuoteCard: React.FC<Props> = ({ quote, isClient, onAccept, onDecline, book
           </>
         )}
         {bookingConfirmed && <span className="ml-2 text-green-600">🎉 Booking Confirmed</span>}
+        <Button
+          type="button"
+          onClick={handleDownloadPdf}
+          variant="secondary"
+          size="sm"
+          data-testid="download-quote-pdf"
+          className="ml-2"
+        >
+          Download PDF
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
+++ b/frontend/src/components/booking/__tests__/QuoteCard.test.tsx
@@ -55,6 +55,8 @@ describe('QuoteCard', () => {
     expect(container.textContent).toContain('Perf');
     expect(container.textContent).toContain(formatCurrency(100));
     expect(container.textContent).toContain(formatCurrency(130));
+    const btn = container.querySelector('[data-testid="download-quote-pdf"]');
+    expect(btn).not.toBeNull();
   });
 
   it('shows countdown for pending quote', () => {

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -3,6 +3,7 @@ import api, {
   createPayment,
   updateBookingStatus,
   downloadBookingIcs,
+  downloadQuotePdf,
   getMyArtistQuotes,
   getMyClientQuotes,
   updateQuoteAsArtist,
@@ -91,6 +92,19 @@ describe('downloadBookingIcs', () => {
       .mockResolvedValue({ data: new Blob() } as unknown as { data: Blob });
     await downloadBookingIcs(2);
     expect(spy).toHaveBeenCalledWith('/api/v1/bookings/2/calendar.ics', {
+      responseType: 'blob',
+    });
+    spy.mockRestore();
+  });
+});
+
+describe('downloadQuotePdf', () => {
+  it('requests the quote PDF as a blob', async () => {
+    const spy = jest
+      .spyOn(api, 'get')
+      .mockResolvedValue({ data: new Blob() } as unknown as { data: Blob });
+    await downloadQuotePdf(5);
+    expect(spy).toHaveBeenCalledWith('/api/v1/quotes/5/pdf', {
       responseType: 'blob',
     });
     spy.mockRestore();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -287,6 +287,11 @@ export const downloadBookingIcs = (id: number) =>
     responseType: 'blob',
   });
 
+export const downloadQuotePdf = (id: number) =>
+  api.get<Blob>(`${API_V1}/quotes/${id}/pdf`, {
+    responseType: 'blob',
+  });
+
 // ─── REVIEWS ───────────────────────────────────────────────────────────────────
 
 // create review for a booking: POST /api/v1/reviews/bookings/{booking_id}/reviews


### PR DESCRIPTION
## Summary
- generate quote PDFs
- add quote PDF endpoint
- expose quote PDF on client via download button
- document new endpoint
- test coverage for quote PDF route and API helpers

## Testing
- `SKIP_TESTS=1 ./scripts/test-all.sh` *(fails: tests require long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_688a2988d324832ebc4e29c115544a2a