### PR TITLE
Add timeline to booking request detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
 - Users can download all account data via `/api/v1/users/me/export` and permanently delete their account with `DELETE /api/v1/users/me`.
 - Booking cards now show deposit and payment status with a simple progress timeline.
+- Booking request detail pages now display a step-by-step timeline from submission to quote acceptance.
 - Booking wizard includes a required **Guests** step.
 - Date picker and quote calculator show skeleton loaders while data fetches.
 - Google Maps and large images load lazily once in view to reduce first paint time.

--- a/frontend/src/app/booking-requests/[id]/page.tsx
+++ b/frontend/src/app/booking-requests/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import MessageThread from '@/components/booking/MessageThread';
 import PersonalizedVideoFlow from '@/components/booking/PersonalizedVideoFlow';
+import BookingTimeline from '@/components/booking/BookingTimeline';
 import { getBookingRequestById, getArtist } from '@/lib/api';
 import { Spinner } from '@/components/ui';
 import { BookingRequest } from '@/types';
@@ -104,6 +105,7 @@ export default function BookingRequestDetailPage() {
             </p>
           )}
         </div>
+        <BookingTimeline status={request.status} />
         {request.service?.service_type === 'Personalized Video' ? (
           <PersonalizedVideoFlow
             bookingRequestId={request.id}

--- a/frontend/src/components/booking/BookingTimeline.tsx
+++ b/frontend/src/components/booking/BookingTimeline.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Stepper from '../ui/Stepper';
+
+export interface BookingTimelineProps {
+  /** Current booking request status string. */
+  status: string;
+}
+
+const steps = [
+  'Request Submitted',
+  'Artist Reviewing',
+  'Quote Sent',
+  'Quote Accepted/Rejected',
+];
+
+/**
+ * Map backend BookingRequestStatus values to stepper indices.
+ */
+const STATUS_TO_STEP: Record<string, number> = {
+  draft: 0,
+  pending_quote: 1,
+  quote_provided: 2,
+  pending_artist_confirmation: 3,
+  request_confirmed: 3,
+  request_completed: 3,
+  request_declined: 3,
+  request_withdrawn: 3,
+  quote_rejected: 3,
+};
+
+/**
+ * Display a vertical timeline showing the progress of a booking request.
+ */
+export default function BookingTimeline({ status }: BookingTimelineProps) {
+  const currentStep = STATUS_TO_STEP[status] ?? 0;
+  return (
+    <Stepper
+      steps={steps}
+      currentStep={currentStep}
+      orientation="vertical"
+      variant="neutral"
+      noCircles
+      className="space-y-2"
+    />
+  );
+}

--- a/frontend/src/components/booking/__tests__/BookingTimeline.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingTimeline.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import BookingTimeline from '../BookingTimeline';
+
+function renderTimeline(status: string) {
+  const div = document.createElement('div');
+  const root = createRoot(div);
+  act(() => {
+    root.render(<BookingTimeline status={status} />);
+  });
+  return { div, root };
+}
+
+describe('BookingTimeline component', () => {
+  it('highlights Artist Reviewing for pending_quote', () => {
+    const { div, root } = renderTimeline('pending_quote');
+    const items = div.querySelectorAll('[role="listitem"]');
+    expect(items).toHaveLength(4);
+    expect(items[1].getAttribute('aria-current')).toBe('step');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+
+  it('highlights Quote Sent for quote_provided', () => {
+    const { div, root } = renderTimeline('quote_provided');
+    const items = div.querySelectorAll('[role="listitem"]');
+    expect(items[2].getAttribute('aria-current')).toBe('step');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+
+  it('shows final step for request_confirmed', () => {
+    const { div, root } = renderTimeline('request_confirmed');
+    const items = div.querySelectorAll('[role="listitem"]');
+    expect(items[3].getAttribute('aria-current')).toBe('step');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- display booking progress timeline using new `BookingTimeline` component
- map request statuses to timeline steps
- unit test the timeline component
- document new timeline feature in README

## Testing
- `npx jest src/components/booking/__tests__/BookingTimeline.test.tsx --runInBand`
- `./scripts/test-all.sh` *(fails: `git fetch` failed because no remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_688a31e5c064832e825f259b3b5e0a8f