### PR TITLE
Prefill SendQuoteModal travel and sound

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/lib/utils';
 import AlertBanner from '../ui/AlertBanner';
 import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
+import {
+  ParsedBookingDetails,
+  parseBookingDetailsFromMessage,
+} from '@/lib/bookingDetails';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
 import { Booking, Review, Message, MessageCreate, QuoteV2, QuoteV2Create } from '@/types';
 import {
@@ -151,29 +155,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     (msg) => setPaymentError(msg),
   );
 
-  // Helper to parse booking details from system message content
-  const parseBookingDetailsFromMessage = useCallback((content: string): ParsedBookingDetails => {
-    const details: ParsedBookingDetails = {};
-    const lines = content.replace(BOOKING_DETAILS_PREFIX, '').trim().split('\n');
-    lines.forEach(line => {
-      const parts = line.split(':');
-      if (parts.length >= 2) {
-        const key = parts[0].trim();
-        const value = parts.slice(1).join(':').trim();
-        switch (key) {
-          case 'Event Type': details.eventType = value; break;
-          case 'Description': details.description = value; break;
-          case 'Date': details.date = value; break;
-          case 'Location': details.location = value; break;
-          case 'Guests': details.guests = value; break;
-          case 'Venue': details.venueType = value; break;
-          case 'Sound': details.soundNeeded = value; break;
-          case 'Notes': details.notes = value; break;
-        }
-      }
-    });
-    return details;
-  }, []);
+
 
   // Moved ensureQuoteLoaded declaration here to fix hoisting issue
   const ensureQuoteLoaded = useCallback(

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -1,8 +1,46 @@
-import { flushPromises } from "@/test/utils/flush";
 import { createRoot } from 'react-dom/client';
 import React from 'react';
-import { act } from 'react';
+import { act } from 'react-dom/test-utils';
 import SendQuoteModal from '../SendQuoteModal';
 import * as api from '@/lib/api';
-import { formatCurrency } from '@/lib/utils';
+import { flushPromises } from '@/test/utils/flush';
 
+jest.mock('@/lib/api');
+
+describe('SendQuoteModal', () => {
+  beforeEach(() => {
+    (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
+  });
+
+  it('prefills travel and sound fees', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+
+    await act(async () => {
+      root.render(
+        <SendQuoteModal
+          open
+          onClose={() => {}}
+          onSubmit={async () => {}}
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          initialBaseFee={500}
+          initialTravelCost={150}
+          initialSoundNeeded
+        />,
+      );
+      await flushPromises();
+    });
+
+    const travelInput = div.querySelector('#travel-fee') as HTMLInputElement;
+    const soundInput = div.querySelector('#sound-fee') as HTMLInputElement;
+    expect(travelInput.value).toBe('150');
+    expect(soundInput.value).toBe('250');
+
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
+});

--- a/frontend/src/lib/bookingDetails.ts
+++ b/frontend/src/lib/bookingDetails.ts
@@ -1,0 +1,53 @@
+export interface ParsedBookingDetails {
+  eventType?: string;
+  description?: string;
+  date?: string;
+  location?: string;
+  guests?: string;
+  venueType?: string;
+  soundNeeded?: string;
+  notes?: string;
+}
+
+import { BOOKING_DETAILS_PREFIX } from './constants';
+
+export function parseBookingDetailsFromMessage(content: string): ParsedBookingDetails {
+  const details: ParsedBookingDetails = {};
+  const lines = content.replace(BOOKING_DETAILS_PREFIX, '').trim().split('\n');
+  lines.forEach((line) => {
+    const parts = line.split(':');
+    if (parts.length >= 2) {
+      const key = parts[0].trim();
+      const value = parts.slice(1).join(':').trim();
+      switch (key) {
+        case 'Event Type':
+          details.eventType = value;
+          break;
+        case 'Description':
+          details.description = value;
+          break;
+        case 'Date':
+          details.date = value;
+          break;
+        case 'Location':
+          details.location = value;
+          break;
+        case 'Guests':
+          details.guests = value;
+          break;
+        case 'Venue':
+          details.venueType = value;
+          break;
+        case 'Sound':
+          details.soundNeeded = value;
+          break;
+        case 'Notes':
+          details.notes = value;
+          break;
+        default:
+          break;
+      }
+    }
+  });
+  return details;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -124,7 +124,7 @@ export interface BookingRequestCreate {
 
 // This is what the backend returns when you GET a booking request:
 export interface BookingRequest {
-  sound_required: undefined;
+  sound_required?: boolean | null;
   id: number;
   client_id: number;
   artist_id: number;


### PR DESCRIPTION
## Summary
- share booking detail parsing in new helper
- use parsed travel/sound info in booking request page
- prefill SendQuoteModal with computed travel and sound costs
- update types and unit tests

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_688a580d3a9c832eb230966898ceeed8