### PR TITLE
Fix missing is_read column on messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The SQLite database path is automatically resolved to the project root, so you c
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
+Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read`, and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
 
 ### Service type enum
 

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -48,6 +48,17 @@ def ensure_attachment_url_column(engine: Engine) -> None:
     )
 
 
+def ensure_message_is_read_column(engine: Engine) -> None:
+    """Add the ``is_read`` column to ``messages`` if missing."""
+
+    add_column_if_missing(
+        engine,
+        "messages",
+        "is_read",
+        "is_read BOOLEAN NOT NULL DEFAULT FALSE",
+    )
+
+
 def ensure_request_attachment_column(engine: Engine) -> None:
     """Add the ``attachment_url`` column to ``booking_requests`` if missing."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from .database import SessionLocal
 from .db_utils import (
     ensure_message_type_column,
     ensure_attachment_url_column,
+    ensure_message_is_read_column,
     ensure_service_type_column,
     ensure_display_order_column,
     ensure_notification_link_column,
@@ -83,6 +84,7 @@ logger = logging.getLogger(__name__)
 # ─── Ensure database schema is up-to-date ──────────────────────────────────
 ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
+ensure_message_is_read_column(engine)
 ensure_request_attachment_column(engine)
 ensure_service_type_column(engine)
 ensure_display_order_column(engine)

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -11,6 +11,7 @@ from app.db_utils import (
     ensure_mfa_columns,
     ensure_calendar_account_email_column,
     ensure_booking_request_travel_columns,
+    ensure_message_is_read_column,
 )
 
 
@@ -146,6 +147,21 @@ def setup_booking_request_engine() -> Engine:
     return engine
 
 
+def setup_message_engine() -> Engine:
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE messages (
+                    id INTEGER PRIMARY KEY
+                )
+                """
+            )
+        )
+    return engine
+
+
 def test_add_price_visible_column():
     engine = setup_artist_engine()
     ensure_price_visible_column(engine)
@@ -210,4 +226,12 @@ def test_booking_request_travel_columns():
     assert "travel_mode" in cols
     assert "travel_cost" in cols
     assert "travel_breakdown" in cols
+
+
+def test_message_is_read_column():
+    engine = setup_message_engine()
+    ensure_message_is_read_column(engine)
+    inspector = inspect(engine)
+    cols = [c["name"] for c in inspector.get_columns("messages")]
+    assert "is_read" in cols
 


### PR DESCRIPTION
## Summary
- automatically add `is_read` column to messages table
- call the new helper during app startup
- document auto-added column in README
- test `ensure_message_is_read_column`

## Testing
- `pytest backend/tests/test_db_utils.py::test_message_is_read_column -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688a838c6994832e9fcd180e786622fa