### PR TITLE
Fix messages table schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The SQLite database path is automatically resolved to the project root, so you c
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read`, and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
+Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read` (added in revision `1e5c92e1a7de`), and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
 
 ### Service type enum
 

--- a/backend/alembic/versions/1e5c92e1a7de_add_is_read_to_messages.py
+++ b/backend/alembic/versions/1e5c92e1a7de_add_is_read_to_messages.py
@@ -1,0 +1,22 @@
+"""add is_read column to messages
+
+Revision ID: 1e5c92e1a7de
+Revises: 8ab844044580
+Create Date: 2025-09-02 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '1e5c92e1a7de'
+down_revision: Union[str, None] = '8ab844044580'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('messages', sa.Column('is_read', sa.Boolean(), nullable=False, server_default=sa.text('FALSE')))
+
+
+def downgrade() -> None:
+    op.drop_column('messages', 'is_read')


### PR DESCRIPTION
## Summary
- add Alembic migration for `messages.is_read`
- document the new migration in README

## Testing
- `./scripts/test-all.sh` *(fails: `/workspace/booking-app/backend/venv/bin/activate: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_688b0e82407c832eb59171fd06c6f347