### PR TITLE
Fix notification link to open booking request

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" only the first time a booking is confirmed. Subsequent reminders omit the greeting. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
 * Message notifications now include the sender name in both the stored text and the API response so the drawer can display "New message from Alice" without additional lookups.
+* Clicking a new message alert opens `/booking-requests/{id}` with the full request details instead of the standalone thread page.
 * All notifications now include the sender's profile picture when available so avatars render consistently for artists and clients.
 * Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can immediately leave feedback.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read. A **Jump to unread** button quickly scrolls to the first unseen message and messages you send show a subtle *Seen* label once the recipient reads them.

--- a/backend/app/crud/crud_notification.py
+++ b/backend/app/crud/crud_notification.py
@@ -163,7 +163,7 @@ def mark_thread_read(db: Session, user_id: int, booking_request_id: int) -> None
         .filter(
             models.Notification.user_id == user_id,
             models.Notification.type == models.NotificationType.NEW_MESSAGE,
-            models.Notification.link == f"/messages/thread/{booking_request_id}",
+            models.Notification.link == f"/booking-requests/{booking_request_id}",
             models.Notification.is_read == False,
         )
         .all()

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -170,7 +170,7 @@ def notify_user_new_message(
         user.id,
         NotificationType.NEW_MESSAGE,
         message,
-        f"/messages/thread/{booking_request_id}",
+        f"/booking-requests/{booking_request_id}",
         sender_name=sender_name,
         avatar_url=avatar_url,
     )

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -106,7 +106,7 @@ def test_message_creates_notification():
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
     assert notifs[0].type.value == "new_message"
-    assert notifs[0].link == f"/messages/thread/{br.id}"
+    assert notifs[0].link == f"/booking-requests/{br.id}"
 
 
 def test_system_booking_summary_message_suppressed():
@@ -789,7 +789,7 @@ def test_new_message_notification_fallback_client_name():
         user_id=artist.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/messages/thread/{br.id}",
+        link=f"/booking-requests/{br.id}",
     )
     db.close()
 
@@ -846,7 +846,7 @@ def test_new_message_notification_fallback_business_name():
         user_id=client_user.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/messages/thread/{br.id}",
+        link=f"/booking-requests/{br.id}",
     )
     db.close()
 

--- a/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationBell.spec.tsx
@@ -63,7 +63,7 @@ describe('NotificationBell accessibility', () => {
           id: 1,
           type: 'new_message',
           message: 'New message',
-          link: '/messages/thread/1',
+          link: '/booking-requests/1',
           is_read: false,
           timestamp: new Date().toISOString(),
         },
@@ -93,7 +93,7 @@ describe('NotificationBell accessibility', () => {
     });
 
     expect(markItem).toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith('/messages/thread/1');
+    expect(push).toHaveBeenCalledWith('/booking-requests/1');
     act(() => {
       root.unmount();
     });

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -164,7 +164,7 @@ describe('NotificationDrawer component', () => {
       booking_request_id: 8,
       name: 'Tom',
       unread_count: 1,
-      link: '/messages/thread/8',
+      link: '/booking-requests/8',
     } as UnifiedNotification;
 
     const onItemClick = jest.fn();

--- a/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
+++ b/frontend/src/hooks/__tests__/getNotificationDisplayProps.test.ts
@@ -14,7 +14,7 @@ describe('getNotificationDisplayProps', () => {
       user_id: 1,
       type: 'new_message',
       message: 'New message from Bob: Hi there',
-      link: '/messages/thread/1',
+      link: '/booking-requests/1',
       is_read: false,
       timestamp: '2025-01-01T00:00:00Z',
       sender_name: 'Bob',
@@ -24,7 +24,7 @@ describe('getNotificationDisplayProps', () => {
     expect(props.from).toBe('Bob');
     expect(props.subtitle).toContain('Hi there');
     props.onClick();
-    expect(assignSpy).toHaveBeenCalledWith('/messages/thread/1');
+    expect(assignSpy).toHaveBeenCalledWith('/booking-requests/1');
   });
 
   it('maps deposit due unified notification', () => {
@@ -83,7 +83,7 @@ describe('getNotificationDisplayProps', () => {
       user_id: 1,
       type: 'new_message',
       message: 'New message from Ava: hi',
-      link: '/messages/thread/3',
+      link: '/booking-requests/3',
       is_read: false,
       timestamp: '2025-01-05T00:00:00Z',
       sender_name: 'Ava',


### PR DESCRIPTION
## Summary
- show full booking request page when opening new message notifications
- document link change
- update backend notification link logic
- update tests for new path

## Testing
- `./scripts/test-all.sh` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b196413dc832eba672f541223c566