### PR TITLE
Fix date picker filter

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -4,7 +4,7 @@ import { Controller, Control } from 'react-hook-form'; // REMOVED FieldValues
 import ReactDatePicker from 'react-datepicker';
 import '../../../styles/datepicker.css';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
-import { format, parseISO } from 'date-fns';
+import { format, parseISO, isBefore, startOfDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import useIsMobile from '@/hooks/useIsMobile';
 import { DateInput } from '../../ui'; // Assuming DateInput is imported
@@ -28,7 +28,8 @@ export default function DateTimeStep({
   const isMobile = useIsMobile();
   const filterDate = (date: Date) => {
     const day = format(date, 'yyyy-MM-dd');
-    return !unavailable.includes(day) && date >= new Date();
+    const today = startOfDay(new Date());
+    return !unavailable.includes(day) && !isBefore(date, today);
   };
   return (
     <div className="wizard-step-container">
@@ -64,6 +65,7 @@ export default function DateTimeStep({
                   inline
                   locale={enUS}
                   filterDate={filterDate}
+                  minDate={startOfDay(new Date())}
                   onChange={(date: Date | null) => field.onChange(date)}
                   renderCustomHeader={({
                     date,


### PR DESCRIPTION
## Summary
- ensure future dates are enabled in booking DateTimeStep

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: git fetch origin main)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: numerous failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b1cecf6f0832e9d41ff3c65e23a1c