### PR TITLE
Fix header nav toggle and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,8 +1372,10 @@ For the booking wizard HTML structure reference, see [docs/booking_wizard_layout
 Artists can switch between managing their profile and acting as a client.
 When logged in as an artist, the navigation bar shows **Today**, **View Profile**,
 **Services**, and **Messages**. A **Switch to Booking** button toggles to the
-client view, returning the standard navigation links. All other artist options
-are available from the mobile menu or profile dropdown.
+client view, returning the standard navigation links. The toggle appears left of
+the booking request icon for quick access. On mobile the drawer lists both sets
+of links so switching views is always possible. All other artist options are
+available from the mobile menu or profile dropdown.
 
 ## Contributing
 

--- a/frontend/src/__tests__/artistViewToggle.test.tsx
+++ b/frontend/src/__tests__/artistViewToggle.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Header from '../components/layout/Header';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -12,17 +13,21 @@ const mockUseAuth = useAuth as jest.Mock;
 
 describe('Header artist view', () => {
   it('shows artist links when artistViewActive', () => {
+    const toggleArtistView = jest.fn();
     mockUseAuth.mockReturnValue({
       user: { id: 1, user_type: 'artist', email: 'a', first_name: 'A', last_name: 'B' },
       logout: jest.fn(),
       artistViewActive: true,
-      toggleArtistView: jest.fn(),
+      toggleArtistView,
     });
     render(<Header />);
     expect(screen.getByText('Today')).toBeInTheDocument();
     expect(screen.getByText('View Profile')).toBeInTheDocument();
     expect(screen.getByText('Services')).toBeInTheDocument();
     expect(screen.getByText('Messages')).toBeInTheDocument();
+    expect(mockUseAuth).toHaveBeenCalledTimes(1);
+    userEvent.click(screen.getByText(/Switch to Booking/));
+    expect(toggleArtistView).toHaveBeenCalledTimes(1);
   });
 
   it('shows client nav when artistViewActive is false', () => {
@@ -35,5 +40,6 @@ describe('Header artist view', () => {
     render(<Header />);
     expect(screen.getByText('Artists')).toBeInTheDocument();
     expect(screen.queryByText('Today')).toBeNull();
+    expect(mockUseAuth).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -15,6 +15,7 @@ interface MobileMenuDrawerProps {
   open: boolean;
   onClose: () => void;
   navigation: NavItem[];
+  drawerNavigation: NavItem[];
   user: User | null;
   logout: () => void;
   pathname: string;
@@ -28,6 +29,7 @@ export default function MobileMenuDrawer({
   open,
   onClose,
   navigation,
+  drawerNavigation,
   user,
   logout,
   pathname,
@@ -85,6 +87,25 @@ export default function MobileMenuDrawer({
                   </Link>
                 ))}
               </div>
+              {drawerNavigation.length > 0 && (
+                <div className="mt-2 space-y-1 px-2">
+                  {drawerNavigation.map((item) => (
+                    <Link
+                      key={item.name}
+                      href={item.href}
+                      onClick={onClose}
+                      className={classNames(
+                        pathname === item.href
+                          ? "bg-brand-light border-brand text-brand-dark"
+                          : "border-transparent text-gray-700 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900",
+                        "block border-l-4 px-3 py-2 text-base font-medium no-underline hover:no-underline",
+                      )}
+                    >
+                      {item.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
               <div className="mt-4 border-t border-gray-200 pt-4 px-2">
                 {user ? (
                   <>


### PR DESCRIPTION
## Summary
- refactor `Header` navigation to use separate `artistNav` and `clientNav`
- move the artist view toggle before the booking request icon
- update mobile drawer to accept both navigation sets
- add `ArtistNav`/`ClientNav` subcomponents
- update auth toggle test for single `useAuth` call
- document navigation toggle behavior

## Testing
- `npm --prefix frontend test --silent` *(fails: useSearchParams not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688b6d7a7158832eb54aef4f9b78c1ef