### PR TITLE
Fix payment status callback in MessageThread

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -137,6 +137,9 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       initialBaseFee,
       initialTravelCost,
       initialSoundNeeded,
+      onBookingConfirmedChange,
+      onPaymentStatusChange,
+      onShowReviewModal,
     }: MessageThreadProps,
     ref,
   ) {


### PR DESCRIPTION
## Summary
- include `onPaymentConfirmedChange`, `onPaymentStatusChange`, and `onShowReviewModal` props when destructuring in `MessageThread`

## Testing
- `./scripts/test-all.sh` *(fails: OperationalError table users already exists)*
- `SKIP_BACKEND=1 npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 35 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b78e309c4832ea9bdfa9bea2206ee