### PR TITLE
Improve inbox layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - A **Leave Review** button now appears in chat when a completed booking has no review.
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Inbox conversations feature a **Show Details** button that opens a slide-out booking details panel. On mobile the panel overlays the chat, while on desktop it appears side-by-side with smooth Tailwind transitions.
+- The chat thread now expands or contracts horizontally as the side panel is toggled, keeping date divider lines perfectly aligned across both sections.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 - Artists can also drag and drop service cards on the dashboard to set their display order.
 - Quote modal items can now be removed even when only one item is present.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -608,10 +608,7 @@ useEffect(() => {
 
 
     return (
-      <div className="max-w-xl mx-auto px-4 sm:px-6 py-6">
-        {/* --- MAIN CONTAINER WITH FIXED HEIGHT (or max-height) --- */}
-        {/* Increased max-h to 75vh for a bit more vertical space, adjusted from 70vh */}
-        <div className="bg-white shadow-xl rounded-2xl overflow-hidden border border-gray-100 flex flex-col max-h-[75vh]">
+      <div className="bg-white shadow-xl rounded-2xl overflow-hidden border border-gray-100 flex flex-col p-6">
           {/* Chat Header - Reduced py-3 to py-2 */}
           <header className="sticky top-0 z-10 bg-gradient-to-r from-red-600 to-indigo-700 text-white px-4 py-2 flex items-center justify-between shadow-md">
             <span className="font-semibold text-base sm:text-lg">
@@ -674,7 +671,7 @@ useEffect(() => {
           <div
             ref={messagesContainerRef}
             onScroll={handleScroll}
-            className="flex-1 overflow-y-auto flex flex-col gap-3 px-4 py-4 bg-gray-50"
+            className="flex-1 overflow-y-auto flex flex-col gap-3 bg-gray-50"
           >
             {loading ? (
               <div className="flex justify-center py-6" aria-label="Loading messages">
@@ -1041,10 +1038,10 @@ useEffect(() => {
 
           {/* Error and WebSocket Connection Lost Messages */}
           {threadError && (
-            <p className="text-xs text-red-600 mx-4 mt-1.5" role="alert">{threadError}</p>
+            <p className="text-xs text-red-600 mt-1.5" role="alert">{threadError}</p>
           )}
           {wsFailed && (
-            <p className="text-xs text-red-600 mx-4 mt-1.5" role="alert">
+            <p className="text-xs text-red-600 mt-1.5" role="alert">
               Connection lost. Please refresh the page or sign in again.
             </p>
           )}

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -44,7 +44,10 @@ export default function MessageThreadWrapper({
   const [parsedDetails, setParsedDetails] = useState<ParsedBookingDetails | null>(null);
 
   // Default to false. This controls if the RIGHTMOST panel is open.
-  const [showSidePanel, setShowSidePanel] = useState(false); 
+  const [showSidePanel, setShowSidePanel] = useState(false);
+
+  const sidePanelWidthDesktop = showSidePanel ? 'md:w-[300px]' : 'md:w-0';
+  const sidePanelWidthLgDesktop = showSidePanel ? 'lg:w-[360px]' : 'lg:w-0';
 
   const { openPaymentModal, paymentModal } = usePaymentModal(
     useCallback(({ status, amount, receiptUrl: url }) => {
@@ -149,8 +152,9 @@ export default function MessageThreadWrapper({
       <div className="flex flex-1 min-h-0 py-4"> {/* flex-1 ensures it takes remaining vertical space */}
         {/* Chat Messages */}
         {/* Chat should take full width on mobile, and reduce width on desktop when panel is open */}
-        <div className={`flex-1 min-w-0 px-4 sm:px-6 transition-[margin-right] duration-300 ease-in-out
-                      ${showSidePanel ? 'md:mr-[300px] lg:mr-[360px]' : ''}`}> {/* Dynamic right margin to create space for panel */}
+        <div
+          className={`flex-1 min-w-0 px-4 sm:px-6 transition-[margin-right] duration-300 ease-in-out ${showSidePanel ? 'md:mr-[300px] lg:mr-[360px]' : ''}`}
+        >
           <MessageThread
             bookingRequestId={bookingRequestId}
             serviceId={bookingRequest.service_id ?? undefined}
@@ -194,17 +198,16 @@ export default function MessageThreadWrapper({
           id="reservation-panel"
           role="complementary"
           className={`
-            fixed inset-y-0 right-0 z-10 /* Fixed positioning relative to viewport */
-            w-full md:w-[300px] lg:w-[360px] /* Defined width for desktop */
+            fixed inset-y-0 right-0 z-10
+            w-full ${sidePanelWidthDesktop} ${sidePanelWidthLgDesktop}
             bg-white border-l border-gray-200 p-4
-            transform transition-transform duration-300 ease-in-out /* Smooth transition */
-            ${showSidePanel ? 'translate-x-0' : 'translate-x-full'} /* Slide in/out */
-            /* Add shadow to make it pop over the content */
+            transform transition-transform duration-300 ease-in-out
+            ${showSidePanel ? 'translate-x-0' : 'translate-x-full'}
             shadow-lg
           `}
         >
-          {/* Close button for side panel (always visible on the panel itself) */}
-          <div className="flex justify-end mb-2">
+          {/* Close button for side panel (visible on mobile where it overlays) */}
+          <div className="flex justify-end mb-2 md:hidden">
             <button
               type="button"
               onClick={() => setShowSidePanel(false)}


### PR DESCRIPTION
## Summary
- adjust MessageThread layout to flexibly fill width
- slide out side panel with dynamic width in MessageThreadWrapper
- mention new responsive chat behaviour in README

## Testing
- `SKIP_BACKEND=1 ./scripts/test-frontend.sh` *(fails: Test Suites: 35 failed, 1 skipped, 66 passed, 101 of 102 total)*

------
https://chatgpt.com/codex/tasks/task_e_688ba4308008832e91db81d9508db74a