### PR TITLE
Link notifications to inbox thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" only the first time a booking is confirmed. Subsequent reminders omit the greeting. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
 * Message notifications now include the sender name in both the stored text and the API response so the drawer can display "New message from Alice" without additional lookups.
-* Clicking a new message alert opens `/booking-requests/{id}` with the full request details instead of the standalone thread page.
+* Clicking a new message alert opens `/inbox?requestId={id}` with the conversation active.
 * All notifications now include the sender's profile picture when available so avatars render consistently for artists and clients.
 * Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can immediately leave feedback.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read. A **Jump to unread** button quickly scrolls to the first unseen message and messages you send show a subtle *Seen* label once the recipient reads them.
@@ -1074,7 +1074,7 @@ keeps the current view, e.g.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Chat attachment button stays inline with the message input and send button on all screens.
 * Tap feedback on icons via `active:bg-gray-100`.
-* **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details.
+* **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details. Message notifications open directly to this page so clients can read and respond without hunting for the correct thread.
 * `/booking-requests` lists all requests with search and filters. Search and filter inputs now include hidden labels for screen readers.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.
 * Tap a booking request card to open `/booking-requests/[id]`.

--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -28,6 +28,9 @@ def _build_response(
                 sender = match.group(1).strip()
 
             br_match = re.search(r"/(?:booking-requests|messages/thread)/(\d+)", n.link)
+            if not br_match:
+                q_match = re.search(r"/inbox\?requestId=(\d+)", n.link)
+                br_match = q_match
             if br_match:
                 br_id = int(br_match.group(1))
                 br = (
@@ -65,7 +68,10 @@ def _build_response(
             )
     elif n.type == models.NotificationType.NEW_BOOKING_REQUEST:
         try:
-            request_id = int(n.link.split("/")[-1])
+            match = re.search(r"(?:/booking-requests/|/inbox\?requestId=)(\d+)", n.link)
+            if not match:
+                raise ValueError("invalid link")
+            request_id = int(match.group(1))
             br = (
                 db.query(models.BookingRequest)
                 .filter(models.BookingRequest.id == request_id)
@@ -134,6 +140,10 @@ def _build_response(
     elif n.type == models.NotificationType.QUOTE_ACCEPTED:
         try:
             match = re.search(r"/booking-requests/(\d+)", n.link)
+            if not match:
+                match = re.search(r"/inbox\?requestId=(\d+)", n.link)
+            if not match:
+                match = re.search(r"/inbox\?requestId=(\d+)", n.link)
             if match:
                 request_id = int(match.group(1))
                 br = (

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -170,7 +170,7 @@ def notify_user_new_message(
         user.id,
         NotificationType.NEW_MESSAGE,
         message,
-        f"/booking-requests/{booking_request_id}",
+        f"/inbox?requestId={booking_request_id}",
         sender_name=sender_name,
         avatar_url=avatar_url,
     )

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -106,7 +106,7 @@ def test_message_creates_notification():
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
     assert len(notifs) == 1
     assert notifs[0].type.value == "new_message"
-    assert notifs[0].link == f"/booking-requests/{br.id}"
+    assert notifs[0].link == f"/inbox?requestId={br.id}"
 
 
 def test_system_booking_summary_message_suppressed():
@@ -789,7 +789,7 @@ def test_new_message_notification_fallback_client_name():
         user_id=artist.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/booking-requests/{br.id}",
+        link=f"/inbox?requestId={br.id}",
     )
     db.close()
 
@@ -846,7 +846,7 @@ def test_new_message_notification_fallback_business_name():
         user_id=client_user.id,
         type=NotificationType.NEW_MESSAGE,
         message="New message: hi",
-        link=f"/booking-requests/{br.id}",
+        link=f"/inbox?requestId={br.id}",
     )
     db.close()
 
@@ -1016,7 +1016,7 @@ def test_booking_request_api_parses_sender_and_type():
         user_id=artist.id,
         type=NotificationType.NEW_BOOKING_REQUEST,
         message="New booking request",
-        link=f"/booking-requests/{br.id}",
+        link=f"/inbox?requestId={br.id}",
     )
     db.close()
 

--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -1,0 +1,9 @@
+# Inbox Page Overview
+
+Clients and artists communicate through the dedicated **Inbox** page. The layout is split into three sections:
+
+1. **Conversation list** on the left displays all booking requests sorted by the most recent update. Unread threads show a red dot indicator.
+2. **Chat area** in the center shows all messages for the selected request. Quotes appear as special bubbles with **Accept** and **Decline** buttons for clients.
+3. **Booking details panel** on the right summarises key information from the request and, when a quote is accepted, provides quick links to pay the deposit and add the event to a calendar.
+
+Notifications for new messages link directly to the relevant conversation in the Inbox. When the artist sends a final quote the client can open it here, accept it and proceed with payment without leaving the page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,8 +1,11 @@
 # Notifications API and Card Usage
 
-`NotificationCard` displays a single alert in the drawer or full screen modal. The
-frontend converts API responses using `getNotificationDisplayProps` which maps
-each notification to `NotificationCard` props.
+`NotificationCard` displays a single alert in the drawer or full screen modal.
+The frontend converts API responses using `getNotificationDisplayProps` which
+maps each notification to `NotificationCard` props. Message notifications are
+created whenever a new chat message is sent. The card subtitle includes a short
+snippet of the latest message so clients can quickly decide whether they need to
+open the conversation.
 
 Important fields returned by `/api/v1/notifications`:
 
@@ -16,3 +19,8 @@ Important fields returned by `/api/v1/notifications`:
 Clicking a card marks the notification read then navigates to `link`. The card
 shows a coloured icon based on the status, the sender name as the title and a
 short subtitle derived from the notification type.
+
+For message notifications the `link` points directly to
+`/inbox?requestId={id}`, opening the Inbox with that conversation active.
+This lets users jump from the notification drawer straight to the chat thread
+without any intermediate redirect.


### PR DESCRIPTION
## Summary
- link message notifications to `/inbox?requestId=ID`
- parse inbox links in notification API helpers
- document new inbox links
- update tests for link path

## Testing
- `./scripts/test-all.sh` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688bec3f4730832eab174c0b86e9b104