### PR TITLE
Fix message links

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
 * Message notifications now include the sender name in both the stored text and the API response so the drawer can display "New message from Alice" without additional lookups.
 * Clicking a new message alert opens `/inbox?requestId={id}` with the conversation active.
+* Legacy `/messages/{id}` and `/messages/thread/{id}` URLs now redirect to the Inbox so older links remain valid.
 * All notifications now include the sender's profile picture when available so avatars render consistently for artists and clients.
 * Artists marking a booking **completed** now trigger a **REVIEW_REQUEST** notification. The alert links to `/dashboard/client/bookings/{booking_id}?review=1` so clients can immediately leave feedback.
 * Chat message groups display a small unread badge on the right side when new messages arrive, clearing automatically once read. A **Jump to unread** button quickly scrolls to the first unseen message and messages you send show a subtle *Seen* label once the recipient reads them.

--- a/frontend/src/app/messages/[id]/page.tsx
+++ b/frontend/src/app/messages/[id]/page.tsx
@@ -6,11 +6,11 @@ import MainLayout from '@/components/layout/MainLayout';
 import { Spinner } from '@/components/ui';
 import { useAuth } from '@/contexts/AuthContext';
 
-export default function ThreadPageRedirect() {
+export default function MessagesRedirectPage() {
   const params = useParams();
   const router = useRouter();
   const { user, loading } = useAuth();
-  const id = Number((params as { threadId?: string }).threadId);
+  const id = Number((params as { id?: string }).id);
 
   useEffect(() => {
     if (!loading) {
@@ -21,7 +21,7 @@ export default function ThreadPageRedirect() {
           router.replace('/inbox');
         }
       } else {
-        router.replace(`/login?redirect=/messages/thread/${id}`);
+        router.replace(`/login?redirect=/messages/${id}`);
       }
     }
   }, [id, router, user, loading]);


### PR DESCRIPTION
## Summary
- add redirect page for `/messages/[id]`
- redirect `/messages/thread/[threadId]` to new inbox page
- document new redirect behavior

## Testing
- `./scripts/test-backend.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688c4bfd2d40832e8adc0964cdad7464