### PR TITLE
Use in-memory DB for pytest runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,8 @@ NEXT_PUBLIC_DEFAULT_CURRENCY=EUR
    ```bash
    pytest
    ```
+   Set `PYTEST_RUN=1` to run tests against an in-memory SQLite database.
+   The `scripts/test-backend.sh` helper exports this variable automatically.
 
 2. **Frontend lint**:
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,12 +1,19 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from app.core.config import settings  # import your settings
+from app.core.config import settings
+import os
 
-SQLALCHEMY_DATABASE_URL = settings.SQLALCHEMY_DATABASE_URL
+if os.getenv("PYTEST_RUN") == "1":
+    SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+else:
+    SQLALCHEMY_DATABASE_URL = settings.SQLALCHEMY_DATABASE_URL
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False}
+    if SQLALCHEMY_DATABASE_URL.startswith("sqlite")
+    else {},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -4,6 +4,7 @@ trap "echo '❌ Test run aborted'; exit 130" INT TERM
 
 export GOOGLE_CLIENT_ID=id
 export GOOGLE_CLIENT_SECRET=sec
+export PYTEST_RUN=1
 
 start_backend=$(date +%s)
 


### PR DESCRIPTION
## Summary
- avoid writing `booking.db` during tests
- run backend tests with `PYTEST_RUN=1`
- document how to use `PYTEST_RUN` for in-memory tests

## Testing
- `PYTEST_RUN=1 pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688c884ef240832ea228fbfd458cd15f