### PR TITLE
Update test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,16 @@ NEXT_PUBLIC_DEFAULT_CURRENCY=EUR
    Set `PYTEST_RUN=1` to run tests against an in-memory SQLite database.
    The `scripts/test-backend.sh` helper exports this variable automatically.
 
+### Test environment variables
+
+Backend tests load `.env.test` from the project root automatically. This file
+defines dummy values so no real credentials are ever used during testing:
+
+```env
+GOOGLE_CLIENT_ID=id
+GOOGLE_CLIENT_SECRET=sec
+```
+
 2. **Frontend lint**:
 
    ```bash


### PR DESCRIPTION
## Summary
- document `.env.test` usage so backend tests don't rely on real credentials

## Testing
- `SKIP_TESTS=1` (docs-only)

------
https://chatgpt.com/codex/tasks/task_e_688c8bfaf784832eabe1a8d5d6d348a6