### PR TITLE
Add git remote validation to test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,10 @@ NEXT_PUBLIC_DEFAULT_CURRENCY=EUR
    ```
    Set `PYTEST_RUN=1` to run tests against an in-memory SQLite database.
    The `scripts/test-backend.sh` helper exports this variable automatically.
+   Ensure your Git remote `origin` points to
+   `git@github.com:Charelk2/booking-app.git`.
+   Both `scripts/test-backend.sh` and `scripts/test-all.sh` verify this and exit
+   if the remote is misconfigured.
 
 ### Test environment variables
 

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -28,6 +28,27 @@ if ! command -v npm >/dev/null; then
 fi
 echo "npm $(npm --version)"
 
+# Verify that the Git remote 'origin' is configured correctly before fetching
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EXPECTED_REMOTE="git@github.com:Charelk2/booking-app.git"
+if origin_url=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null); then
+  if [ "$origin_url" != "$EXPECTED_REMOTE" ]; then
+    cat >&2 <<EOF
+❌ Git remote 'origin' is '$origin_url' but should be '$EXPECTED_REMOTE'.
+Update the remote with:
+  git remote set-url origin $EXPECTED_REMOTE
+EOF
+    exit 1
+  fi
+else
+  cat >&2 <<EOF
+❌ Git remote 'origin' not found.
+Add the remote with:
+  git remote add origin $EXPECTED_REMOTE
+EOF
+  exit 1
+fi
+
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 git fetch origin main >/dev/null 2>&1
 if base_ref=$(git merge-base origin/main HEAD 2>/dev/null); then

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -18,6 +18,26 @@ VENV_DIR="$ROOT_DIR/backend/venv"
 REQ_FILE="$ROOT_DIR/backend/requirements.txt"
 DEV_REQ_FILE="$ROOT_DIR/requirements-dev.txt"
 
+# Verify the Git remote before running any tests
+EXPECTED_REMOTE="git@github.com:Charelk2/booking-app.git"
+if origin_url=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null); then
+  if [ "$origin_url" != "$EXPECTED_REMOTE" ]; then
+    cat >&2 <<EOF
+❌ Git remote 'origin' is '$origin_url' but should be '$EXPECTED_REMOTE'.
+Update the remote with:
+  git remote set-url origin $EXPECTED_REMOTE
+EOF
+    exit 1
+  fi
+else
+  cat >&2 <<EOF
+❌ Git remote 'origin' not found.
+Add the remote with:
+  git remote add origin $EXPECTED_REMOTE
+EOF
+  exit 1
+fi
+
 if [ ! -d "$VENV_DIR" ]; then
   if [ "${FAST:-}" = 1 ]; then
     echo "❌ FAST=1 but $VENV_DIR missing." >&2


### PR DESCRIPTION
## Summary
- verify `origin` remote before creating venv or fetching code
- enforce the same check at the start of `test-all.sh`
- document remote requirement in README

## Testing
- `bash -x ./scripts/test-all.sh` *(fails: ssh connect to github.com port 22: Network is unreachable)*
- `./scripts/test-backend.sh` *(fails: test failure in `test_notifications_ws_broadcasts`)*

------
https://chatgpt.com/codex/tasks/task_e_688c8d764994832eae734f892bb241ec