### PR TITLE
Fix notification broadcast mocks in tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,18 @@
 from pathlib import Path
 from dotenv import load_dotenv
+from unittest.mock import AsyncMock
+import pytest
+
+# Patch notifications broadcast for all tests
+@pytest.fixture(autouse=True)
+def patch_notifications_broadcast(monkeypatch):
+    """Replace NotificationManager.broadcast with an AsyncMock."""
+    mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.utils.notifications.notifications_manager.broadcast",
+        mock,
+    )
+    return mock
 
 # Load environment variables for tests
 load_dotenv(Path(__file__).resolve().parents[1] / '.env.test')


### PR DESCRIPTION
## Summary
- patch NotificationManager.broadcast with AsyncMock for all tests
- update websocket notification test to check mocked broadcast

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c9176b354832e81654b3ed38c399d