### PR TITLE
Optimize booking request list query

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Status badges on booking request cards now use classes like `status-badge-quote-provided` for consistent colors.
 - Error fallback messages now detect authentication failures and prompt users to log in.
 - Booking request API responses now include `last_message_content` and `last_message_timestamp` so inbox conversations sort by recent chats.
+- Backend now fetches these fields using a single optimized query for improved performance.
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -121,29 +121,15 @@ def read_my_client_booking_requests(
     """
     Retrieve booking requests made by the current client.
     """
-    requests = crud.crud_booking_request.get_booking_requests_by_client(
-        db=db, client_id=current_user.id, skip=skip, limit=limit
+    requests = crud.crud_booking_request.get_booking_requests_with_last_message(
+        db=db,
+        client_id=current_user.id,
+        skip=skip,
+        limit=limit,
     )
     for req in requests:
         for q in req.quotes:
             q.booking_request = None
-        accepted = next(
-            (
-                q
-                for q in req.quotes
-                if q.status in [
-                    models.QuoteStatus.ACCEPTED_BY_CLIENT,
-                    models.QuoteStatus.CONFIRMED_BY_ARTIST,
-                ]
-            ),
-            None,
-        )
-        if accepted:
-            setattr(req, "accepted_quote_id", accepted.id)
-        last_msg = crud.crud_message.get_last_message_for_request(db, req.id)
-        if last_msg:
-            setattr(req, "last_message_content", last_msg.content)
-            setattr(req, "last_message_timestamp", last_msg.timestamp)
     return requests
 
 @router.get("/me/artist", response_model=List[schemas.BookingRequestResponse])
@@ -156,29 +142,15 @@ def read_my_artist_booking_requests(
     """
     Retrieve booking requests made to the current artist.
     """
-    requests = crud.crud_booking_request.get_booking_requests_by_artist(
-        db=db, artist_id=current_artist.id, skip=skip, limit=limit
+    requests = crud.crud_booking_request.get_booking_requests_with_last_message(
+        db=db,
+        artist_id=current_artist.id,
+        skip=skip,
+        limit=limit,
     )
     for req in requests:
         for q in req.quotes:
             q.booking_request = None
-        accepted = next(
-            (
-                q
-                for q in req.quotes
-                if q.status in [
-                    models.QuoteStatus.ACCEPTED_BY_CLIENT,
-                    models.QuoteStatus.CONFIRMED_BY_ARTIST,
-                ]
-            ),
-            None,
-        )
-        if accepted:
-            setattr(req, "accepted_quote_id", accepted.id)
-        last_msg = crud.crud_message.get_last_message_for_request(db, req.id)
-        if last_msg:
-            setattr(req, "last_message_content", last_msg.content)
-            setattr(req, "last_message_timestamp", last_msg.timestamp)
     return requests
 
 @router.get("/{request_id:int}", response_model=schemas.BookingRequestResponse)


### PR DESCRIPTION
## Summary
- add `get_booking_requests_with_last_message` helper
- use helper in booking-request endpoints
- document optimized query

## Testing
- `SKIP_FRONTEND=1 ./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c983dc038832eaf761ba0635f4ac5