### PR TITLE
Fix conversation dates

### DIFF
--- a/frontend/src/components/inbox/ConversationList.tsx
+++ b/frontend/src/components/inbox/ConversationList.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx';
 import Image from 'next/image';
-import { format } from 'date-fns';
+import { formatRelative } from 'date-fns';
 import { BookingRequest, User } from '@/types';
 import { getFullImageUrl } from '@/lib/utils'; // Import getFullImageUrl
 
@@ -87,7 +87,7 @@ export default function ConversationList({
                   dateTime={date}
                   className="text-xs text-gray-500 flex-shrink-0 ml-2" // Added ml-2 for spacing
                 >
-                  {format(new Date(date), 'MMM d, yyyy')}
+                  {formatRelative(new Date(date), new Date())}
                 </time>
               </div>
               <div


### PR DESCRIPTION
## Summary
- show relative dates in the inbox conversation list

## Testing
- `./scripts/test-all.sh` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688c9d557c88832eb7fb698e302f95ef