### PR TITLE
Fix lint errors in notifications and tests

### DIFF
--- a/frontend/src/__tests__/artistViewToggle.test.tsx
+++ b/frontend/src/__tests__/artistViewToggle.test.tsx
@@ -5,16 +5,12 @@ import Header from '../components/layout/Header';
 import { useAuth } from '@/contexts/AuthContext';
 
 jest.mock('../components/layout/NotificationBell', () => {
-  function MockNotificationBell() {
-    return <div />;
-  }
+  const MockNotificationBell: React.FC = () => <div />;
   MockNotificationBell.displayName = 'MockNotificationBell';
   return MockNotificationBell;
 });
 jest.mock('../components/layout/BookingRequestIcon', () => {
-  function MockBookingRequestIcon() {
-    return <div />;
-  }
+  const MockBookingRequestIcon: React.FC = () => <div />;
   MockBookingRequestIcon.displayName = 'MockBookingRequestIcon';
   return MockBookingRequestIcon;
 });

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -10,6 +10,7 @@ import {
 } from '@heroicons/react/24/outline';
 import type { User, UnifiedNotification } from '@/types';
 import useNotifications from '@/hooks/useNotifications';
+import { toUnifiedFromNotification } from '@/hooks/notificationUtils';
 import useScrollDirection from '@/hooks/useScrollDirection';
 
 interface MobileBottomNavProps {
@@ -36,7 +37,8 @@ function classNames(...classes: (string | false | undefined)[]) {
 
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   const router = useRouter();
-  const { items: notificationItems } = useNotifications();
+  const { items } = useNotifications();
+  const notificationItems = items.map((n) => toUnifiedFromNotification(n));
   const scrollDir = useScrollDirection();
   if (!user) {
     return null;
@@ -44,11 +46,8 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   // Next.js App Router doesn’t expose pathname in its types, so we use a type assertion
   const pathname = (router as unknown as { pathname?: string }).pathname || '';
   const unreadMessages = notificationItems
-    .filter((i: UnifiedNotification) => i.type === 'message')
-    .reduce(
-      (sum: number, t: UnifiedNotification) => sum + (t.unread_count || 0),
-      0,
-    );
+    .filter((i) => i.type === 'message')
+    .reduce((sum, t) => sum + (t.unread_count || 0), 0);
   const badgeCount = unreadMessages > 99 ? '99+' : String(unreadMessages);
 
   return (


### PR DESCRIPTION
## Summary
- add display names in `artistViewToggle` mocks
- convert notifications to unified type in `MobileBottomNav`
- restore proper re-export path for `useNotifications`

## Testing
- `./scripts/test-all.sh` *(fails: TypeError and other Jest errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ca2a6f9b4832eb7af3fd799bc4507