### PR TITLE
Switch profile image components to next/image

### DIFF
--- a/frontend/src/app/account/profile-picture/page.tsx
+++ b/frontend/src/app/account/profile-picture/page.tsx
@@ -7,6 +7,7 @@ import { uploadMyProfilePicture } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { getFullImageUrl } from '@/lib/utils';
 import dynamic from 'next/dynamic';
+import Image from 'next/image';
 import { type Crop, type PixelCrop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { centerAspectCrop, getCroppedImage } from '@/lib/imageCrop';
@@ -80,15 +81,19 @@ export default function ProfilePicturePage() {
       <div className="mx-auto max-w-sm py-10 space-y-4">
         <h1 className="text-2xl font-bold">Profile Picture</h1>
         {preview ? (
-          <img
+          <Image
             src={preview}
             alt="Preview"
+            width={128}
+            height={128}
             className="w-32 h-32 object-cover rounded-full"
           />
         ) : currentUrl ? (
-          <img
+          <Image
             src={currentUrl}
             alt="Current profile"
+            width={128}
+            height={128}
             className="w-32 h-32 object-cover rounded-full"
           />
         ) : null}
@@ -108,13 +113,14 @@ export default function ProfilePicturePage() {
                 onComplete={(c) => setCompletedCrop(c)}
                 aspect={1}
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
+                <Image
                   ref={imgRef}
                   src={originalSrc}
                   alt="Crop me"
                   onLoad={onImageLoad}
-                  style={{ maxHeight: 300, objectFit: 'contain' }}
+                  width={300}
+                  height={300}
+                  className="max-h-[300px] object-contain"
                 />
               </ReactCrop>
               <Button

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -12,6 +12,7 @@ import type { ElementType } from "react";
 import clsx from "clsx";
 import { Dialog, Transition } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion"; // Import motion and AnimatePresence
+import Image from "next/image";
 
 import type { Service } from "@/types";
 import {
@@ -491,8 +492,17 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                         <div className="flex flex-wrap gap-3 mt-4">
                           {/* Use thumbnails from useImageThumbnails hook */}
                           {thumbnails.map((src: string, i: number) => (
-                            <div key={i} className="relative w-24 h-24 border rounded overflow-hidden">
-                              <img src={src} alt={`media-${i}`} className="object-cover w-full h-full" />
+                            <div
+                              key={i}
+                              className="relative w-24 h-24 border rounded overflow-hidden"
+                            >
+                              <Image
+                                src={src}
+                                alt={`media-${i}`}
+                                width={96}
+                                height={96}
+                                className="object-cover w-full h-full"
+                              />
                               <button
                                 type="button"
                                 onClick={() => removeFile(i)}
@@ -596,7 +606,14 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                               <div className="flex flex-wrap gap-2 mt-2">
                                 {/* Use thumbnails from useImageThumbnails hook */}
                                 {thumbnails.map((src: string, i: number) => (
-                                  <img key={i} src={src} alt={`media-${i}`} className="w-20 h-20 object-cover rounded" />
+                                  <Image
+                                    key={i}
+                                    src={src}
+                                    alt={`media-${i}`}
+                                    width={80}
+                                    height={80}
+                                    className="w-20 h-20 object-cover rounded"
+                                  />
                                 ))}
                               </div>
                             </div>


### PR DESCRIPTION
## Summary
- use `next/image` for profile picture cropping and preview
- replace `<img>` tags in service media step with `<Image>`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688cd1be3434832eb01cf050d68b514c