### PR TITLE
Fix client reference in notification builder

### DIFF
--- a/backend/app/api/api_notification.py
+++ b/backend/app/api/api_notification.py
@@ -157,10 +157,10 @@ def _build_response(
                         .filter(models.User.id == br.client_id)
                         .first()
                     )
-                if client:
-                    sender = f"{client.first_name} {client.last_name}"
-                    if client.profile_picture_url:
-                        avatar_url = client.profile_picture_url
+                    if client:
+                        sender = f"{client.first_name} {client.last_name}"
+                        if client.profile_picture_url:
+                            avatar_url = client.profile_picture_url
         except (ValueError, IndexError) as exc:
             logger.warning(
                 "Failed to derive quote accepted details from link %s: %s",


### PR DESCRIPTION
## Summary
- avoid referencing `client` when quote isn't linked to a booking request

## Testing
- `flake8 backend/app/api/api_notification.py --max-line-length 88`
- `pytest -q` *(fails: 50 errors during collection)*
- `./scripts/test-all.sh` *(fails to fetch remote)*

------
https://chatgpt.com/codex/tasks/task_e_688cd20b23e8832e989b804c72625765