### PR TITLE
Fix ARIA attribute typos

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -907,7 +907,7 @@ useEffect(() => {
                   role="progressbar"
                   aria-label="Upload progress"
                   aria-valuemin={0}
-                  aria-amax={100}
+                  aria-valuemax={100}
                   aria-valuenow={uploadingProgress}
                   aria-valuetext={`${uploadingProgress}%`}
                 >

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -154,7 +154,6 @@ export default function Stepper({
             key={label}
             role="listitem"
             aria-current={isActive ? 'step' : undefined}
-            aria-disabled="true"
             className={clsx(
               'cursor-default',
               // Same flex behavior as buttons for non-clickable items


### PR DESCRIPTION
## Summary
- correct `aria-amax` typo in `MessageThread`
- remove unsupported `aria-disabled` from non-interactive `Stepper` div

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test -- --maxWorkers=50% --passWithNoTests` *(fails: Network access is disabled in unit tests, plus various React testing errors)*
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce2aed298832e8339a047f829eb13