### PR TITLE
Update booking context and unify notifications

### DIFF
--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -219,7 +219,7 @@ const fetchArtists = useCallback(
             return (
               <ArtistCard
                 key={a.id}
-                id={a.id}
+                artistId={a.id}
                 priority={i === 0}
                 name={name}
                 subtitle={a.custom_subtitle || undefined}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -11,8 +11,6 @@ export default function NavBar() {
     unreadCount,
     markItem,
     markAll,
-    loadMore,
-    hasMore,
     error,
   } = useNotifications();
   const handleItemClick = async (itemId: number) => {
@@ -47,8 +45,6 @@ export default function NavBar() {
         items={items}
         onItemClick={handleItemClick}
         markAllRead={markAllRead}
-        loadMore={loadMore}
-        hasMore={hasMore}
         error={error}
       />
     </nav>

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -10,9 +10,10 @@ import {
   CheckBadgeIcon,
 } from '@heroicons/react/24/solid';
 import { Tag } from '@/components/ui';
+import { getFullImageUrl } from '@/lib/utils';
 
 export interface ArtistCardProps extends HTMLAttributes<HTMLDivElement> {
-  id: number;
+  artistId: number;
   imageUrl?: string | null;
   name: string;
   subtitle?: string | null;
@@ -39,7 +40,7 @@ export interface ArtistCardProps extends HTMLAttributes<HTMLDivElement> {
 // ratingCount and isAvailable are currently unused but may be utilized in the future.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function ArtistCard({
-  id,
+  artistId,
   imageUrl,
   name,
   subtitle,
@@ -128,7 +129,7 @@ export default function ArtistCard({
         {limitedTags.length > 0 && (
           <div className="flex flex-nowrap overflow-hidden gap-1 mt-2 whitespace-nowrap">
             {limitedTags.map((s) => (
-              <Tag key={`${id}-${s}`} className="text-[10px]">
+              <Tag key={`${artistId}-${s}`} className="text-[10px]">
                 {s}
               </Tag>
             ))}

--- a/frontend/src/components/artist/ArtistCardCompact.tsx
+++ b/frontend/src/components/artist/ArtistCardCompact.tsx
@@ -7,8 +7,10 @@ import {
   StarIcon,
 } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
+import { getFullImageUrl } from '@/lib/utils';
 
 export interface ArtistCardCompactProps extends HTMLAttributes<HTMLDivElement> {
+  artistId: number;
   name: string;
   subtitle?: string;
   imageUrl?: string;
@@ -20,6 +22,7 @@ export interface ArtistCardCompactProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export default function ArtistCardCompact({
+  artistId,
   name,
   subtitle,
   imageUrl,

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -41,6 +41,7 @@ type EventDetails = {
   eventType?: string;
   eventDescription?: string;
   date?: Date;
+  time?: string;
   location?: string;
   guests?: string;
   venueType?: 'indoor' | 'outdoor' | 'hybrid';
@@ -53,6 +54,7 @@ const schema = yup.object<EventDetails>().shape({
   eventType: yup.string().required('Event type is required.'),
   eventDescription: yup.string().required('Event description is required.').min(5, 'Description must be at least 5 characters.'),
   date: yup.date().required('Date is required.').min(new Date(), 'Date cannot be in the past.'),
+  time: yup.string().optional(),
   location: yup.string().required('Location is required.'),
   guests: yup.string().required('Number of guests is required.').matches(/^\d+$/, 'Guests must be a number.'),
   venueType: yup

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Controller, Control } from 'react-hook-form'; // REMOVED FieldValues
 // WizardNav is REMOVED from here, as navigation is global now.
-import ReactDatePicker from 'react-datepicker';
+import ReactDatePicker, { type ReactDatePickerCustomHeaderProps } from 'react-datepicker';
 import '../../../styles/datepicker.css';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { format, parseISO, isBefore, startOfDay } from 'date-fns';
@@ -67,13 +67,15 @@ export default function DateTimeStep({
                   filterDate={filterDate}
                   minDate={startOfDay(new Date())}
                   onChange={(date: Date | null) => field.onChange(date)}
-                  renderCustomHeader={({
-                    date,
-                    decreaseMonth,
-                    increaseMonth,
-                    prevMonthButtonDisabled,
-                    nextMonthButtonDisabled,
-                  }) => (
+                  renderCustomHeader={(
+                    {
+                      date,
+                      decreaseMonth,
+                      increaseMonth,
+                      prevMonthButtonDisabled,
+                      nextMonthButtonDisabled,
+                    }: ReactDatePickerCustomHeaderProps,
+                  ) => (
                     <div className="flex justify-between items-center px-3 pt-2 pb-2">
                       <button
                         onClick={(e) => {

--- a/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
@@ -1,16 +1,17 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
-import { useForm, Control, FieldValues } from 'react-hook-form';
+import { useForm, Control } from 'react-hook-form';
+import type { EventDetails } from '@/contexts/BookingContext';
 import DateTimeStep from '../DateTimeStep';
 
 function Wrapper() {
-  const { control } = useForm({
+  const { control } = useForm<EventDetails>({
     defaultValues: { date: new Date('2025-06-20') },
   });
   return (
     <DateTimeStep
-      control={control as unknown as Control<FieldValues>}
+      control={control as Control<EventDetails>}
       unavailable={[]}
       step={0}
       steps={['one']}
@@ -22,10 +23,10 @@ function Wrapper() {
 }
 
 function LoadingWrapper() {
-  const { control } = useForm();
+  const { control } = useForm<EventDetails>();
   return (
     <DateTimeStep
-      control={control as unknown as Control<FieldValues>}
+      control={control as Control<EventDetails>}
       unavailable={[]}
       loading
       step={0}

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -91,7 +91,7 @@ export default function ArtistsSection({
             return (
               <ArtistCardCompact
                 key={a.id}
-                id={a.id}
+                artistId={a.id}
                 name={name}
                 subtitle={a.custom_subtitle || undefined}
                 imageUrl={

--- a/frontend/src/components/inbox/ConversationList.tsx
+++ b/frontend/src/components/inbox/ConversationList.tsx
@@ -29,8 +29,7 @@ export default function ConversationList({
         const otherName =
           currentUser.user_type === 'artist'
             ? req.client?.first_name || 'Client'
-            : req.artist?.business_name || req.artist?.first_name ||
-              (req.artist as any)?.user?.first_name || 'Artist';
+            : req.artist?.business_name || req.artist?.user?.first_name || 'Artist';
         // Use getFullImageUrl for avatarUrl to ensure correct paths and handling
         const fullAvatarUrl =
           (currentUser.user_type === 'artist'

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -87,7 +87,7 @@ export default function MessageThreadWrapper({
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
-    } catch (err: any) {
+    } catch (err) {
       console.error('Calendar download error:', err);
     }
   }, [confirmedBookingDetails]);
@@ -137,7 +137,7 @@ export default function MessageThreadWrapper({
             <div className="h-10 w-10 rounded-full bg-red-400 flex items-center justify-center text-base font-medium border-2 border-white shadow-sm flex-shrink-0">
               {(
                 bookingRequest.artist?.business_name ||
-                bookingRequest.artist?.first_name ||
+                bookingRequest.artist?.user?.first_name ||
                 bookingRequest.client?.first_name
               )?.charAt(0) || 'U'}
             </div>
@@ -145,7 +145,7 @@ export default function MessageThreadWrapper({
 
           {/* Name next to avatar */}
           <span className="font-semibold text-base sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis ml-2">
-            Chat with {bookingRequest.client?.first_name || bookingRequest.artist?.business_name || bookingRequest.artist?.first_name || 'User'}
+            Chat with {bookingRequest.client?.first_name || bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'User'}
           </span>
 
           {/* Send Quote button next */}
@@ -214,7 +214,7 @@ export default function MessageThreadWrapper({
       {/* Alert Banners */}
       {bookingConfirmed && confirmedBookingDetails && (
         <AlertBanner variant="success" className="mx-4 mt-4 rounded-lg z-10">
-          🎉 Booking confirmed for {bookingRequest.artist?.business_name || bookingRequest.artist?.first_name || 'Artist'}! {confirmedBookingDetails.service?.title} on {new Date(confirmedBookingDetails.start_time).toLocaleString()}. {formatDepositReminder(confirmedBookingDetails.deposit_amount ?? 0, confirmedBookingDetails.deposit_due_by ?? undefined)}.
+          🎉 Booking confirmed for {bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'Artist'}! {confirmedBookingDetails.service?.title} on {new Date(confirmedBookingDetails.start_time).toLocaleString()}. {formatDepositReminder(confirmedBookingDetails.deposit_amount ?? 0, confirmedBookingDetails.deposit_due_by ?? undefined)}.
           <div className="flex flex-wrap gap-3 mt-2">
             <Link href={`/dashboard/client/bookings/${confirmedBookingDetails.id}`} className="inline-block text-indigo-600 hover:underline text-sm font-medium">
               View booking
@@ -261,7 +261,7 @@ export default function MessageThreadWrapper({
             bookingRequestId={bookingRequestId}
             serviceId={bookingRequest.service_id ?? undefined}
             clientName={bookingRequest.client?.first_name}
-            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.first_name}
+            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name}
             artistAvatarUrl={bookingRequest.artist?.profile_picture_url ?? null}
             serviceName={bookingRequest.service?.title}
             initialNotes={bookingRequest.message ?? null}
@@ -300,7 +300,7 @@ export default function MessageThreadWrapper({
           <BookingDetailsPanel
             bookingRequest={bookingRequest}
             parsedBookingDetails={parsedDetails}
-            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.first_name || 'Artist'}
+            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'Artist'}
             bookingConfirmed={bookingConfirmed}
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}
@@ -320,7 +320,7 @@ export default function MessageThreadWrapper({
           <BookingDetailsPanel
             bookingRequest={bookingRequest}
             parsedBookingDetails={parsedDetails}
-            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.first_name || 'Artist'}
+            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'Artist'}
             bookingConfirmed={bookingConfirmed}
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}

--- a/frontend/src/components/layout/BookingRequestIcon.tsx
+++ b/frontend/src/components/layout/BookingRequestIcon.tsx
@@ -3,11 +3,12 @@
 import Link from 'next/link';
 import { ClipboardIcon } from '@heroicons/react/24/outline';
 import useNotifications from '@/hooks/useNotifications';
+import type { UnifiedNotification } from '@/types';
 
 export default function BookingRequestIcon() {
   const { items } = useNotifications();
   const unreadIds = new Set<number>();
-  items.forEach((n) => {
+  items.forEach((n: UnifiedNotification) => {
     if (n.type === 'message' && n.booking_request_id && (n.unread_count ?? 0) > 0) {
       unreadIds.add(n.booking_request_id);
     }

--- a/frontend/src/components/layout/FullScreenNotificationModal.tsx
+++ b/frontend/src/components/layout/FullScreenNotificationModal.tsx
@@ -9,6 +9,7 @@ import {
   FixedSizeList,
   type ListChildComponentProps,
 } from 'react-window';
+import type { FixedSizeList as FixedSizeListType } from 'react-window';
 import NotificationCard from '../ui/NotificationCard';
 import getNotificationDisplayProps from '@/hooks/getNotificationDisplayProps';
 import type { UnifiedNotification } from '@/types';
@@ -42,7 +43,7 @@ export default function FullScreenNotificationModal({
   const [showUnread, setShowUnread] = useState(false);
   // how many loaded into the list
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  const listRef = useRef<FixedSizeList>(null);
+  const listRef = useRef<FixedSizeListType>(null);
   const prevCountRef = useRef(visibleCount);
 
   // auto-scroll when loading more

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -11,6 +11,7 @@ import {
 import type { User } from '@/types';
 import useNotifications from '@/hooks/useNotifications';
 import { toUnifiedFromNotification } from '@/hooks/notificationUtils';
+import type { UnifiedNotification } from '@/types';
 import useScrollDirection from '@/hooks/useScrollDirection';
 
 interface MobileBottomNavProps {
@@ -38,7 +39,7 @@ function classNames(...classes: (string | false | undefined)[]) {
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   const router = useRouter();
   const { items } = useNotifications();
-  const notificationItems = items.map((n) => toUnifiedFromNotification(n));
+  const notificationItems = items;
   const scrollDir = useScrollDirection();
   if (!user) {
     return null;
@@ -46,8 +47,8 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   // Next.js App Router doesn’t expose pathname in its types, so we use a type assertion
   const pathname = (router as unknown as { pathname?: string }).pathname || '';
   const unreadMessages = notificationItems
-    .filter((i) => i.type === 'message')
-    .reduce((sum, t) => sum + (t.unread_count || 0), 0);
+    .filter((i: UnifiedNotification) => i.type === 'message')
+    .reduce((sum, t: UnifiedNotification) => sum + (t.unread_count || 0), 0);
   const badgeCount = unreadMessages > 99 ? '99+' : String(unreadMessages);
 
   return (

--- a/frontend/src/components/layout/NotificationBell.tsx
+++ b/frontend/src/components/layout/NotificationBell.tsx
@@ -24,8 +24,7 @@ function prefetchNotifications() {
 }
 import useIsMobile from '@/hooks/useIsMobile';
 import useNotifications from '@/hooks/useNotifications';
-import type { UnifiedNotification, Notification as AppNotification } from '@/types';
-import { toUnifiedFromNotification } from '@/hooks/notificationUtils';
+import type { UnifiedNotification } from '@/types';
 
 // Displays a dropdown of recent notifications. Unread counts update via the
 // `useNotifications` hook. Notifications are loaded incrementally for better
@@ -44,7 +43,6 @@ export default function NotificationBell(): JSX.Element {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const isMobile = useIsMobile();
-  const unifiedItems = items.map((n) => toUnifiedFromNotification(n));
 
   /**
    * Mark a notification as read and navigate to its link.
@@ -53,7 +51,7 @@ export default function NotificationBell(): JSX.Element {
    * lookup the full object here before acting.
    */
   const handleItemClick = async (itemId: number) => {
-    const item = unifiedItems.find(
+    const item = items.find(
       (i: UnifiedNotification) => (i.id || i.booking_request_id) === itemId,
     );
     if (!item) {
@@ -61,7 +59,7 @@ export default function NotificationBell(): JSX.Element {
       return;
     }
     if (!item.is_read) {
-      await markItem(item as unknown as AppNotification);
+      await markItem(item);
     }
     setOpen(false);
     if (item.link) {
@@ -98,7 +96,7 @@ export default function NotificationBell(): JSX.Element {
         <FullScreenNotificationModal
           open={open}
           onClose={() => setOpen(false)}
-          items={unifiedItems}
+          items={items}
           onItemClick={handleItemClick}
           markAllRead={markAllRead}
           loadMore={loadMore}
@@ -109,7 +107,7 @@ export default function NotificationBell(): JSX.Element {
         <NotificationDrawer
           open={open}
           onClose={() => setOpen(false)}
-          items={unifiedItems}
+          items={items}
           onItemClick={handleItemClick}
           markAllRead={markAllRead}
           error={error}

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -9,6 +9,7 @@ import {
   FixedSizeList,
   type ListChildComponentProps,
 } from 'react-window';
+import type { FixedSizeList as FixedSizeListType } from 'react-window';
 import NotificationCard from '../ui/NotificationCard';
 import getNotificationDisplayProps from '@/hooks/getNotificationDisplayProps';
 import { ToggleSwitch, IconButton } from '../ui';
@@ -52,7 +53,7 @@ export default function NotificationDrawer({
 
   const [showUnread, setShowUnread] = useState(false);
   const [visibleCount, setVisibleCount] = useState(pageSize);
-  const listRef = useRef<FixedSizeList>(null);
+  const listRef = useRef<FixedSizeListType>(null);
   const prevCountRef = useRef(visibleCount);
 
   // clamp visibleCount when pageSize changes

--- a/frontend/src/components/ui/__tests__/PriceFilter.test.tsx
+++ b/frontend/src/components/ui/__tests__/PriceFilter.test.tsx
@@ -13,7 +13,12 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('rheostat', () => {
   // simple mock slider with two inputs
-  return function MockSlider({ values, onValuesUpdated, onChange }: any) {
+  interface MockSliderProps {
+    values: number[];
+    onValuesUpdated: (state: { values: number[] }) => void;
+    onChange: (state: { values: number[] }) => void;
+  }
+  return function MockSlider({ values, onValuesUpdated, onChange }: MockSliderProps) {
     return (
       <div>
         <input

--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -5,6 +5,8 @@ export interface EventDetails {
   eventType: string;
   eventDescription: string;
   date: Date;
+  /** Optional time string in HH:mm format */
+  time?: string;
   location: string;
   guests: string;
   venueType: 'indoor' | 'outdoor' | 'hybrid';
@@ -36,6 +38,7 @@ const initialDetails: EventDetails = {
   eventType: '',
   eventDescription: '',
   date: new Date(),
+  time: '',
   location: '',
   guests: '',
   venueType: 'indoor',
@@ -72,7 +75,7 @@ export const BookingProvider = ({ children }: { children: ReactNode }) => {
     try {
       const parsed = JSON.parse(stored) as {
         step?: number;
-        details?: Partial<EventDetails> & { date?: string };
+        details?: Partial<EventDetails> & { date?: string; time?: string };
         serviceId?: number;
         requestId?: number;
         travelResult?: TravelResult | null;
@@ -112,7 +115,10 @@ export const BookingProvider = ({ children }: { children: ReactNode }) => {
     if (typeof window === 'undefined') return;
     const data = {
       step,
-      details: { ...details, date: new Date(details.date).toISOString() },
+      details: {
+        ...details,
+        date: new Date(details.date).toISOString(),
+      },
       serviceId,
       requestId,
       travelResult,

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,2 +1,1 @@
-export { default, default as useNotifications } from './useNotifications.tsx';
-export * from './useNotifications.tsx';
+export { default, NotificationsProvider } from './useNotifications.tsx';

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -13,7 +13,8 @@ import axios, { type AxiosRequestHeaders } from 'axios';
 import toast from 'react-hot-toast';
 import useWebSocket from './useWebSocket';
 import { useAuth } from '@/contexts/AuthContext';
-import type { Notification } from '@/types';
+import type { Notification, UnifiedNotification } from '@/types';
+import { toUnifiedFromNotification } from './notificationUtils';
 import { authAwareMessage } from '@/lib/utils';
 
 // Use the root API URL and include the /api prefix on each request so
@@ -47,8 +48,8 @@ interface NotificationsContextValue {
   markAllAsRead: () => Promise<void>;
   deleteNotification: (id: number) => Promise<void>;
   /** compatibility with legacy hooks */
-  items: Notification[];
-  markItem: (notification: Notification) => Promise<void>;
+  items: UnifiedNotification[];
+  markItem: (notification: UnifiedNotification) => Promise<void>;
   markAll: () => Promise<void>;
   loadMore: () => Promise<void>;
   hasMore: boolean;
@@ -210,6 +211,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     }
   }, [notifications.length]);
 
+  const unifiedItems = notifications.map(toUnifiedFromNotification);
+
   const value: NotificationsContextValue = {
     notifications,
     unreadCount,
@@ -219,8 +222,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     markAllAsRead,
     deleteNotification,
     // legacy compatibility
-    items: notifications,
-    markItem: (n: Notification) => markAsRead(n.id),
+    items: unifiedItems,
+    markItem: (n: UnifiedNotification) => (n.id ? markAsRead(n.id) : Promise.resolve()),
     markAll: markAllAsRead,
     loadMore,
     hasMore,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -125,7 +125,7 @@ export interface BookingRequestCreate {
 // This is what the backend returns when you GET a booking request:
 export interface BookingRequest {
   last_message_timestamp: string;
-  is_unread_by_current_user: any;
+  is_unread_by_current_user: boolean;
   last_message_content: string | undefined;
   sound_required: undefined;
   id: number;
@@ -144,7 +144,7 @@ export interface BookingRequest {
   updated_at: string;
   // Optional expanded relations returned by the API
   client?: User;
-  artist?: User;
+  artist?: ArtistProfile;
   service?: Service;
   quotes?: Quote[];
   accepted_quote_id?: number | null;


### PR DESCRIPTION
## Summary
- add time property to booking context details
- use artist profile for booking requests
- update notification context and components for UnifiedNotification
- import image URL helper in artist cards
- add explicit types in tests

## Testing
- `npm --prefix frontend run type-check` *(fails: TS errors)*
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce6874af0832e9c5cd4c4d1030b48