### PR TITLE
Fix messaging props and TypeScript config

### DIFF
--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -142,7 +142,6 @@ export default function InboxPage() {
             <MessageThreadWrapper
               bookingRequestId={selectedBookingRequestId}
               bookingRequest={selectedRequest}
-              showReviewModal={showReviewModal}
               setShowReviewModal={setShowReviewModal}
             />
           ) : (

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -70,6 +70,7 @@ interface MessageThreadProps {
   onQuoteSent?: () => void;
   serviceId?: number;
   artistName?: string;
+  clientName?: string;
   clientId?: number;
   artistId?: number;
   artistAvatarUrl?: string | null;

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -300,7 +300,6 @@ export default function MessageThreadWrapper({
           <BookingDetailsPanel
             bookingRequest={bookingRequest}
             parsedBookingDetails={parsedDetails}
-            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'Artist'}
             bookingConfirmed={bookingConfirmed}
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}
@@ -320,7 +319,6 @@ export default function MessageThreadWrapper({
           <BookingDetailsPanel
             bookingRequest={bookingRequest}
             parsedBookingDetails={parsedDetails}
-            artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'Artist'}
             bookingConfirmed={bookingConfirmed}
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- add missing `clientName` prop to `MessageThread`
- remove unused `artistName` prop from `MessageThreadWrapper`
- fix `useNotifications` re-export
- enable importing TS extensions in the frontend TS config
- update inbox page prop usage

## Testing
- `./scripts/test-all.sh` *(fails: multiple frontend test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688cf27c8728832eb9cee304c3e2cddb