### PR TITLE
Fix conversation list typing and adjust wrapper props

### DIFF
--- a/frontend/src/components/inbox/ConversationList.tsx
+++ b/frontend/src/components/inbox/ConversationList.tsx
@@ -32,16 +32,7 @@ export default function ConversationList({
           }
           const artist = req.artist;
           if (!artist) return 'Artist';
-          if ('business_name' in artist && artist.business_name) {
-            return artist.business_name;
-          }
-          if ('user' in artist && artist.user?.first_name) {
-            return artist.user.first_name;
-          }
-          if ('first_name' in artist) {
-            return (artist as User).first_name;
-          }
-          return 'Artist';
+          return artist.business_name || artist.user?.first_name || 'Artist';
         })();
         // Use getFullImageUrl for avatarUrl to ensure correct paths and handling
         const fullAvatarUrl =

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -283,8 +283,6 @@ export default function MessageThreadWrapper({
               setReceiptUrl(url);
             }}
             onShowReviewModal={setShowReviewModal}
-            showSidePanel={showSidePanel}
-            setShowSidePanel={setShowSidePanel}
             showQuoteModal={showQuoteModal}
             setShowQuoteModal={setShowQuoteModal}
           />
@@ -304,8 +302,6 @@ export default function MessageThreadWrapper({
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}
             paymentModal={paymentModal}
-            showSidePanel={showSidePanel}
-            setShowSidePanel={setShowSidePanel}
           />
         </section>
 
@@ -323,8 +319,6 @@ export default function MessageThreadWrapper({
             confirmedBookingDetails={confirmedBookingDetails}
             setShowReviewModal={setShowReviewModal}
             paymentModal={paymentModal}
-            showSidePanel={showSidePanel}
-            setShowSidePanel={setShowSidePanel}
           />
         </section>
       </div>


### PR DESCRIPTION
## Summary
- clean up artist name selection logic in `ConversationList`
- remove unused side panel props in `MessageThreadWrapper`
- run `./scripts/test-all.sh` (tests fail in several places)

## Testing
- `./scripts/test-all.sh` *(fails: InboxPage tests timeout, API tests missing functions)*

------
https://chatgpt.com/codex/tasks/task_e_688cf78c617c832e8161b741d250760e