### PR TITLE
Fix Google Maps autocomplete type

### DIFF
--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -43,7 +43,7 @@ function LocationInputInner({
   // Wrap getPlacePredictions so it remains stable across renders and
   // doesn't trigger effects unnecessarily.
   const stableGetPlacePredictions = useCallback(
-    (req: google.maps.places.AutocompleteRequest) => getPlacePredictions(req),
+    (req: google.maps.places.AutocompletionRequest) => getPlacePredictions(req),
     [getPlacePredictions]
   );
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -229,7 +229,7 @@ export interface BookingSimple {
 }
 
 export interface Message {
-  is_read: any;
+  is_read: boolean;
   id: number;
   booking_request_id: number;
   sender_id: number;


### PR DESCRIPTION
## Summary
- fix argument type for Google Autocomplete
- tidy types to avoid eslint errors

## Testing
- `FAST=1 ./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d05167f48832ea54883087a315293