### PR TITLE
feat: add compact search bar component

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -118,6 +118,8 @@ Now** overlay button when hovered. A sticky header hosts the search UI. On
  Filters show a tiny pink dot when active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.
 
+The collapsed pill UI is provided by `SearchBarCompact`, a reusable component that shows the current **Category**, **Location** and **Date** placeholders and calls an `onOpen` handler when clicked to reveal the full search form.
+
 ## Testing
 
 Run `npm test` when you only want to execute the frontend Jest suite. The `pretest` script defined in

--- a/frontend/src/components/search/SearchBarCompact.tsx
+++ b/frontend/src/components/search/SearchBarCompact.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { format } from 'date-fns';
+
+interface Props {
+  category?: string | null;
+  location?: string | null;
+  when?: Date | null;
+  onOpen: () => void;
+}
+
+/**
+ * Compact pill-style search bar used as a trigger for the full search form.
+ * Displays the current category, location and date placeholders and invokes
+ * `onOpen` when clicked so callers can show the expanded search UI.
+ */
+export default function SearchBarCompact({ category, location, when, onOpen }: Props) {
+  const handleClick = () => {
+    onOpen();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex items-center bg-white px-4 py-2 shadow-md rounded-full w-full transition-all duration-300 ease-out"
+    >
+      <div className="px-4 py-1 text-sm text-gray-700 flex-grow">
+        {category || 'Choose category'}
+      </div>
+      <div className="px-4 py-1 text-sm text-gray-700 whitespace-nowrap overflow-hidden text-ellipsis flex-grow">
+        {location || 'Anywhere'}
+      </div>
+      <div className="px-4 py-1 text-sm text-gray-700 flex-grow">
+        {when ? format(when, 'd\u00A0MMM\u00A0yyyy') : 'Add\u00A0date'}
+      </div>
+      <div className="p-1 bg-[var(--color-accent)] text-white rounded-full">
+        <MagnifyingGlassIcon className="h-5 w-5" />
+      </div>
+    </button>
+  );
+}
+

--- a/frontend/src/components/search/__tests__/SearchBarCompact.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarCompact.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import SearchBarCompact from '../SearchBarCompact';
+
+describe('SearchBarCompact', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders default placeholders', async () => {
+    const onOpen = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBarCompact onOpen={onOpen} />);
+    });
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.textContent).toContain('Choose category');
+    expect(button.textContent).toContain('Anywhere');
+    expect(button.textContent).toContain('Add\u00A0date');
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('updates placeholders when props change', async () => {
+    const onOpen = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const when = new Date('2025-04-01T00:00:00.000Z');
+
+    await act(async () => {
+      root.render(
+        <SearchBarCompact
+          onOpen={onOpen}
+          category="Music"
+          location="Cape Town"
+          when={when}
+        />
+      );
+    });
+
+    let button = container.querySelector('button') as HTMLButtonElement;
+    let text = button.textContent?.replace(/\u00A0/g, ' ');
+    expect(text).toContain('Music');
+    expect(text).toContain('Cape Town');
+    expect(text).toContain('1 Apr 2025');
+
+    const newWhen = new Date('2025-05-02T00:00:00.000Z');
+
+    await act(async () => {
+      root.render(
+        <SearchBarCompact
+          onOpen={onOpen}
+          category="Dance"
+          location="Johannesburg"
+          when={newWhen}
+        />
+      );
+    });
+
+    button = container.querySelector('button') as HTMLButtonElement;
+    text = button.textContent?.replace(/\u00A0/g, ' ');
+    expect(text).toContain('Dance');
+    expect(text).toContain('Johannesburg');
+    expect(text).toContain('2 May 2025');
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('fires onOpen when clicked', async () => {
+    const onOpen = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBarCompact onOpen={onOpen} />);
+    });
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onOpen).toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `SearchBarCompact` pill component for quick search entry
- document compact pill usage in frontend README
- test compact bar rendering, dynamic placeholders, and onOpen callback

## Testing
- `npx next lint --file src/components/search/SearchBarCompact.tsx --file src/components/search/__tests__/SearchBarCompact.test.tsx`
- `./scripts/test-all.sh` *(fails: BookingWizard flow – dispatchEvent undefined; API tests unauthorized; many frontend tests timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688dd71d82dc832eaea75c1cd504b638