### PR TITLE
feat: add expanded search bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   global rule in `globals.css`.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
+- Added a full-screen `SearchBarExpanded` component that surfaces location, date, and guest inputs in a modal on mobile and desktop.
 - Fixed an initial load bug where a selected date sent an invalid `when` value and caused a 422 error.
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map **Musician / Band** to the `Live Performance` service

--- a/frontend/src/components/search/SearchBarExpanded.tsx
+++ b/frontend/src/components/search/SearchBarExpanded.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback, FormEvent, Fragment } from 'react';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import clsx from 'clsx';
+import { Transition } from '@headlessui/react';
+import dynamic from 'next/dynamic';
+import { SearchFields, type SearchFieldId } from './SearchFields';
+import type { ActivePopup } from './SearchBar';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  initialLocation?: string;
+  initialWhen?: Date | null;
+  initialGuests?: number | null;
+  onSearch: (params: { location?: string; when?: Date | null; guests?: number | null }) => void | Promise<void>;
+}
+
+const DynamicSearchPopupContent = dynamic(() => import('./SearchPopupContent'), {
+  ssr: false,
+  loading: () => <div className="p-4 text-center text-gray-500">Loading search options...</div>,
+});
+
+export default function SearchBarExpanded({
+  open,
+  onClose,
+  initialLocation,
+  initialWhen,
+  initialGuests,
+  onSearch,
+}: Props) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+  const [activeField, setActiveField] = useState<ActivePopup>(null);
+  const [showPopup, setShowPopup] = useState(false);
+
+  const [location, setLocation] = useState(initialLocation || '');
+  const [when, setWhen] = useState<Date | null>(initialWhen || null);
+  const [guests, setGuests] = useState<number | null>(initialGuests || null);
+
+  const lastActiveButtonRef = useRef<HTMLButtonElement | null>(null);
+  const locationInputRef = useRef<HTMLInputElement>(null);
+  const guestsInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setLocation(initialLocation || '');
+      setWhen(initialWhen || null);
+      setGuests(initialGuests || null);
+      setActiveField('location');
+      setShowPopup(true);
+    } else {
+      setShowPopup(false);
+    }
+  }, [open, initialLocation, initialWhen, initialGuests]);
+
+  const handleFieldClick = useCallback((fieldId: SearchFieldId, buttonElement: HTMLButtonElement) => {
+    setActiveField(fieldId);
+    setShowPopup(true);
+    lastActiveButtonRef.current = buttonElement;
+  }, []);
+
+  const closeAllPopups = useCallback(() => {
+    setShowPopup(false);
+    setTimeout(() => {
+      setActiveField(null);
+      if (lastActiveButtonRef.current) {
+        lastActiveButtonRef.current.focus();
+        lastActiveButtonRef.current = null;
+      }
+    }, 200);
+  }, []);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitting(true);
+    closeAllPopups();
+    try {
+      await onSearch({ location: location || undefined, when, guests });
+    } finally {
+      setSubmitting(false);
+      onClose();
+    }
+  };
+
+  const popupPositionAndSizeClasses = clsx(
+    { 'min-w-[300px]': true },
+    { 'left-0 right-auto': activeField === 'location', 'w-full sm:w-[480px]': activeField === 'location' },
+    { 'left-1/2 -translate-x-1/2 right-auto': activeField === 'when', 'w-fit min-w-[400px] max-w-[600px]': activeField === 'when' },
+    { 'right-1 left-auto': activeField === 'guests', 'w-[260px] max-h-[200px] overflow-hidden': activeField === 'guests' }
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        data-testid="search-expanded-overlay"
+        className="absolute inset-0 bg-black/30"
+        onClick={onClose}
+      />
+      <div className="relative bg-white w-full h-full p-4 sm:h-auto sm:max-w-xl sm:rounded-xl overflow-auto">
+        <button
+          type="button"
+          aria-label="Close search"
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
+          onClick={onClose}
+        >
+          <XMarkIcon className="h-6 w-6" />
+        </button>
+
+        {showPopup && (
+          <div
+            className="absolute inset-0 bg-black/20 z-10" // overlay within modal for popups
+            aria-hidden="true"
+            onClick={closeAllPopups}
+          />
+        )}
+
+        <form
+          ref={formRef}
+          onSubmit={handleSubmit}
+          autoComplete="off"
+          className="relative z-20 flex items-stretch bg-white rounded-full shadow-md"
+        >
+          <SearchFields
+            mode="guests"
+            location={location}
+            setLocation={setLocation}
+            when={when}
+            setWhen={setWhen}
+            guests={guests}
+            setGuests={setGuests}
+            activeField={activeField}
+            onFieldClick={handleFieldClick}
+          />
+          <button
+            type="submit"
+            className={clsx(
+              'bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/90 px-5 py-3 flex items-center justify-center text-white rounded-r-full transition-all duration-200 ease-out',
+              isSubmitting && 'opacity-70 cursor-not-allowed',
+              !isSubmitting && 'active:scale-95'
+            )}
+            aria-label="Search now"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+            ) : (
+              <MagnifyingGlassIcon className="h-5 w-5" />
+            )}
+            <span className="sr-only">Search</span>
+          </button>
+
+          <Transition
+            show={showPopup}
+            as={Fragment}
+            key={activeField ?? 'none'}
+            enter="transition ease-out duration-100"
+            enterFrom="opacity-0 -translate-y-2"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-75"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 -translate-y-2"
+          >
+            <div
+              className={clsx(
+                'absolute top-full mt-2 rounded-xl bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 z-30',
+                popupPositionAndSizeClasses
+              )}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={activeField ? `search-popup-label-${activeField}` : undefined}
+            >
+              {showPopup && (
+                <DynamicSearchPopupContent
+                  activeField={activeField}
+                  location={location}
+                  setLocation={setLocation}
+                  when={when}
+                  setWhen={setWhen}
+                  guests={guests}
+                  setGuests={setGuests}
+                  closeAllPopups={closeAllPopups}
+                  locationInputRef={locationInputRef}
+                  guestsInputRef={guestsInputRef}
+                />
+              )}
+            </div>
+          </Transition>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -8,15 +8,18 @@ import type { ActivePopup } from './SearchBar';
 
 
 export interface SearchFieldsProps {
-  category: Category | null;
-  setCategory: (c: Category | null) => void;
+  category?: Category | null;
+  setCategory?: (c: Category | null) => void;
+  guests?: number | null;
+  setGuests?: (n: number | null) => void;
   location: string;
   setLocation: (l: string) => void;
   when: Date | null;
   setWhen: (d: Date | null) => void;
-  activeField: ActivePopup;
-  onFieldClick: (fieldId: SearchFieldId, buttonElement: HTMLButtonElement) => void;
+  activeField?: ActivePopup;
+  onFieldClick?: (fieldId: SearchFieldId, buttonElement: HTMLButtonElement) => void;
   compact?: boolean;
+  mode?: 'category' | 'guests';
 }
 
 export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
@@ -24,6 +27,8 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
     {
       category,
       setCategory,
+      guests,
+      setGuests,
       location,
       setLocation,
       when,
@@ -31,11 +36,13 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
       activeField,
       onFieldClick,
       compact = false,
+      mode = 'category',
     },
     ref
   ) => {
     // Individual refs for each field's button element to store and return focus
     const categoryButtonRef = useRef<HTMLButtonElement>(null);
+    const guestsButtonRef = useRef<HTMLButtonElement>(null);
     const locationButtonRef = useRef<HTMLButtonElement>(null);
     const whenButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -43,50 +50,53 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
     const renderField = (
       id: SearchFieldId,
       label: string,
-      currentValue: string | JSX.Element, // Can be string or JSX element for placeholder
+      currentValue: string | JSX.Element,
       buttonRef: React.RefObject<HTMLButtonElement>,
-      onClear: () => void // Function to clear the specific field
+      onClear: () => void
     ) => {
       const isActive = activeField === id;
-      const isValuePresent = typeof currentValue === 'string' && currentValue !== '' && currentValue !== 'Add dates' && currentValue !== 'Add artists' && currentValue !== 'Search destinations';
+      const isValuePresent =
+        typeof currentValue === 'string' &&
+        currentValue !== '' &&
+        currentValue !== 'Add dates' &&
+        currentValue !== 'Add artists' &&
+        currentValue !== 'Search destinations' &&
+        currentValue !== 'Add guests';
 
       return (
         <div className="relative flex-1">
           <button
-            ref={buttonRef} // Attach ref to the button element
+            ref={buttonRef}
             type="button"
-            onClick={() => onFieldClick(id, buttonRef.current!)} // Pass the ID and the button element
+            onClick={() => onFieldClick?.(id, buttonRef.current!)}
             className={clsx(
               'group relative z-10 w-full flex flex-col justify-center text-left  transition-all duration-200 ease-out outline-none',
               compact ? 'px-4 py-2' : 'px-6 py-3',
-              isActive
-                ? 'bg-gray-100  shadow-md'
-                : 'hover:bg-gray-50 focus:bg-gray-50' // Added focus state for keyboard users
+              isActive ? 'bg-gray-100  shadow-md' : 'hover:bg-gray-50 focus:bg-gray-50'
             )}
             aria-expanded={isActive}
             aria-controls={`${id}-popup`}
-            id={`${id}-search-button`} // Provide a unique ID for aria-controls
+            id={`${id}-search-button`}
           >
             <span className="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none">{label}</span>
             <span
               className={clsx(
                 'block truncate pointer-events-none select-none',
-                isValuePresent ? 'text-gray-800' : 'text-gray-400 italic', // Adjusted for hydration
+                isValuePresent ? 'text-gray-800' : 'text-gray-400 italic',
                 compact ? 'text-sm' : 'text-base'
               )}
             >
               {currentValue}
             </span>
 
-            {/* Clear button - only visible when a value is present AND the field is NOT active */}
             {isValuePresent && !isActive && (
               <button
                 type="button"
                 onClick={(e) => {
-                  e.stopPropagation(); // Prevent opening the popup
-                  onClear(); // Clear the specific field
+                  e.stopPropagation();
+                  onClear();
                   if (buttonRef.current) {
-                      buttonRef.current.focus(); // Return focus to the button
+                    buttonRef.current.focus();
                   }
                 }}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none  rounded-full p-1 z-20 transition-transform active:scale-90"
@@ -123,13 +133,21 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
 
         <div className="border-l border-gray-200" />
 
-        {renderField(
-          'category',
-          'Category',
-          category ? category.label : 'Add artists', // Ensure consistent placeholder for hydration
-          categoryButtonRef,
-          () => setCategory(null)
-        )}
+        {mode === 'category'
+          ? renderField(
+              'category',
+              'Category',
+              category ? category.label : 'Add artists',
+              categoryButtonRef,
+              () => setCategory?.(null)
+            )
+          : renderField(
+              'guests',
+              'Guests',
+              guests != null ? String(guests) : 'Add guests',
+              guestsButtonRef,
+              () => setGuests?.(null)
+            )}
       </div>
     );
   }
@@ -140,4 +158,4 @@ export type Category = {
   value: string;
 };
 
-export type SearchFieldId = 'location' | 'when' | 'category';
+export type SearchFieldId = 'location' | 'when' | 'category' | 'guests';

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -11,7 +11,7 @@ import { UI_CATEGORIES } from '@/lib/categoryMap';
 // CORRECTED IMPORT: Import ActivePopup from SearchBar, but Category and SearchFieldId from SearchFields
 // because SearchFields is where these types are originally defined and exported.
 import type { ActivePopup } from './SearchBar';
-import type { Category, SearchFieldId } from './SearchFields'; // <-- CORRECTED IMPORT
+import type { Category } from './SearchFields'; // <-- CORRECTED IMPORT
 
 // IMPORTANT: Ensure 'react-datepicker/dist/react-datepicker.css' is imported GLOBALLY.
 // (e.g., in your globals.css or _app.tsx / root layout.tsx)
@@ -25,15 +25,18 @@ import type { Category, SearchFieldId } from './SearchFields'; // <-- CORRECTED 
 
 interface SearchPopupContentProps {
   activeField: ActivePopup;
-  category: Category | null;
-  setCategory: (c: Category | null) => void;
+  category?: Category | null;
+  setCategory?: (c: Category | null) => void;
+  guests?: number | null;
+  setGuests?: (n: number | null) => void;
   location: string;
   setLocation: (l: string) => void;
   when: Date | null;
   setWhen: (d: Date | null) => void;
   closeAllPopups: () => void;
   locationInputRef: RefObject<HTMLInputElement>;
-  categoryListboxOptionsRef: RefObject<HTMLUListElement>;
+  categoryListboxOptionsRef?: RefObject<HTMLUListElement>;
+  guestsInputRef?: RefObject<HTMLInputElement>;
 }
 
 type CustomHeaderProps = {
@@ -66,6 +69,8 @@ export default function SearchPopupContent({
   activeField,
   category,
   setCategory,
+  guests,
+  setGuests,
   location,
   setLocation,
   when,
@@ -73,6 +78,7 @@ export default function SearchPopupContent({
   closeAllPopups,
   locationInputRef,
   categoryListboxOptionsRef,
+  guestsInputRef,
 }: SearchPopupContentProps) {
   const [isClient, setIsClient] = useState(false);
 
@@ -82,16 +88,18 @@ export default function SearchPopupContent({
     const timer = setTimeout(() => {
       if (activeField === 'location' && locationInputRef.current) {
         locationInputRef.current.focus();
-      } else if (activeField === 'category' && categoryListboxOptionsRef.current) {
+      } else if (activeField === 'category' && categoryListboxOptionsRef?.current) {
         const target =
           categoryListboxOptionsRef.current.querySelector('[aria-selected="true"]') ??
           categoryListboxOptionsRef.current.querySelector('[role="option"]');
         (target as HTMLElement | null)?.focus();
+      } else if (activeField === 'guests' && guestsInputRef?.current) {
+        guestsInputRef.current.focus();
       }
     }, 50);
 
     return () => clearTimeout(timer);
-  }, [activeField, locationInputRef, categoryListboxOptionsRef]); // Ref dependencies added
+  }, [activeField, locationInputRef, categoryListboxOptionsRef, guestsInputRef]);
 
   const handleLocationSelect = useCallback((place: PlaceResult) => {
     if (place.name) {
@@ -102,15 +110,29 @@ export default function SearchPopupContent({
     closeAllPopups();
   }, [setLocation, closeAllPopups]);
 
-  const handleCategorySelect = useCallback((c: Category | null) => {
-    setCategory(c);
-    closeAllPopups();
-  }, [setCategory, closeAllPopups]);
+  const handleCategorySelect = useCallback(
+    (c: Category | null) => {
+      setCategory?.(c);
+      closeAllPopups();
+    },
+    [setCategory, closeAllPopups]
+  );
 
-  const handleDateSelect = useCallback((date: Date | null) => {
-    setWhen(date);
-    closeAllPopups();
-  }, [setWhen, closeAllPopups]);
+  const handleDateSelect = useCallback(
+    (date: Date | null) => {
+      setWhen(date);
+      closeAllPopups();
+    },
+    [setWhen, closeAllPopups]
+  );
+
+  const handleGuestsChange = useCallback(
+    (value: string) => {
+      const parsed = value ? parseInt(value, 10) : null;
+      setGuests?.(parsed);
+    },
+    [setGuests]
+  );
 
   // Ensure 'item' is typed by MOCK_LOCATION_SUGGESTIONS's structure
   const filteredSuggestions = MOCK_LOCATION_SUGGESTIONS.filter((item) =>
@@ -245,7 +267,7 @@ export default function SearchPopupContent({
   const renderDefault = () => (
     <div className="text-center text-gray-500 py-8">
       <h3 className="text-lg font-semibold mb-2" id="search-popup-label-default">Find artists for your event!</h3>
-      <p className="text-sm">Click 'Where', 'When', or 'Category' to start.</p>
+      <p className="text-sm">Click 'Where', 'When', or {category !== undefined ? "'Category'" : "'Guests'"} to start.</p>
       <div className="mt-6">
         <h4 className="text-md font-semibold text-gray-700 mb-3">Popular Artist Locations</h4>
         <ul className="grid grid-cols-2 gap-4">
@@ -268,6 +290,21 @@ export default function SearchPopupContent({
     </div>
   );
 
+  const renderGuests = () => (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-800 mb-2" id="search-popup-label-guests">Guests</h3>
+      <input
+        ref={guestsInputRef}
+        type="number"
+        min={1}
+        value={guests != null ? guests : ''}
+        onChange={(e) => handleGuestsChange(e.target.value)}
+        onBlur={closeAllPopups}
+        className="w-full border border-gray-300 rounded-lg p-3 focus:outline-none"
+      />
+    </div>
+  );
+
   switch (activeField) {
     case 'location':
       return renderLocation();
@@ -275,6 +312,8 @@ export default function SearchPopupContent({
       return renderDate();
     case 'category':
       return renderCategory();
+    case 'guests':
+      return renderGuests();
     default:
       return renderDefault();
   }

--- a/frontend/src/components/search/__tests__/SearchBarExpanded.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarExpanded.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import SearchBarExpanded from '../SearchBarExpanded';
+
+jest.mock('@/lib/loadPlaces', () => ({
+  loadPlaces: () => Promise.resolve({}),
+}));
+
+jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => () => ({
+  placesService: null,
+  placePredictions: [],
+  getPlacePredictions: jest.fn(),
+}));
+
+describe('SearchBarExpanded', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('focuses location input on open', async () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    const onClose = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBarExpanded open onClose={onClose} onSearch={onSearch} />);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const input = container.querySelector('input');
+    expect(document.activeElement).toBe(input);
+
+    jest.useRealTimers();
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('calls onSearch with values on submit', async () => {
+    const onSearch = jest.fn();
+    const onClose = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SearchBarExpanded
+          open
+          onClose={onClose}
+          onSearch={onSearch}
+          initialLocation="Cape Town"
+          initialGuests={2}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(onSearch).toHaveBeenCalledWith({ location: 'Cape Town', when: null, guests: 2 });
+    expect(onClose).toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('closes when clicking overlay and close button', async () => {
+    const onSearch = jest.fn();
+    const onClose = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBarExpanded open onClose={onClose} onSearch={onSearch} />);
+      await Promise.resolve();
+    });
+
+    const overlay = container.querySelector('[data-testid="search-expanded-overlay"]') as HTMLDivElement;
+    act(() => {
+      overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.render(<SearchBarExpanded open onClose={onClose} onSearch={onSearch} />);
+      await Promise.resolve();
+    });
+
+    const closeBtn = container.querySelector('button[aria-label="Close search"]') as HTMLButtonElement;
+    act(() => {
+      closeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(2);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add `SearchBarExpanded` modal with location, date, and guest inputs
- extend `SearchFields` and popup content to support guests
- document new expanded search bar and add unit tests

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test` *(fails: ReferenceError and router undefined errors)*

------
https://chatgpt.com/codex/tasks/task_e_688dde7be100832ebc42411a9de660b7