### PR TITLE
feat(search): persist selections in inline search bar

### DIFF
--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -1,27 +1,109 @@
 // src/components/search/SearchBarInline.tsx
 'use client';
 
-import React from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
-
-// These types are no longer directly used in this simplified component,
-// but kept for context if needed elsewhere.
-// import type { Category } from '@/lib/categoryMap'; // Or from SearchFields
-// type SearchParams = { category?: string; location?: string; when?: Date | null };
+import SearchBar from './SearchBar';
+import { UI_CATEGORIES } from '@/lib/categoryMap';
+import type { Category } from './SearchFields';
 
 interface SearchBarInlineProps {
-  // No props needed here anymore, as its click handler is in Header.tsx
-  // to directly control the header state.
+  initialCategory?: string;
+  initialLocation?: string;
+  initialWhen?: Date | null;
+  onSearch: (params: { category?: string; location?: string; when?: Date | null }) => void | Promise<void>;
+  onExpandedChange?: (expanded: boolean) => void;
 }
 
-// NOTE: This component is simplified to ONLY render the pill.
-// Its behavior of expanding is handled by the Header component now.
-export default function SearchBarInline({}: SearchBarInlineProps) {
+export default function SearchBarInline({
+  initialCategory,
+  initialLocation = '',
+  initialWhen = null,
+  onSearch,
+  onExpandedChange,
+}: SearchBarInlineProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [category, setCategory] = useState<Category | null>(
+    initialCategory ? UI_CATEGORIES.find((c) => c.value === initialCategory) || null : null,
+  );
+  const [location, setLocation] = useState(initialLocation);
+  const [when, setWhen] = useState<Date | null>(initialWhen);
+
+  const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  const handleExpand = () => {
+    setExpanded(true);
+    onExpandedChange?.(true);
+  };
+
+  const collapse = useCallback(() => {
+    setExpanded(false);
+    onExpandedChange?.(false);
+  }, [onExpandedChange]);
+
+  const handleSearch = useCallback(
+    async (params: { category?: string; location?: string; when?: Date | null }) => {
+      await onSearch(params);
+      collapse();
+    },
+    [onSearch, collapse],
+  );
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        collapse();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [expanded, collapse]);
+
   return (
-    <div className="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200">
-      <span className="text-gray-500">Category, Location, When</span>
-      <MagnifyingGlassIcon className="h-5 w-5 text-gray-500" />
+    <div
+      className={clsx(
+        'mx-auto transition-all duration-300 ease-out',
+        expanded ? 'max-w-4xl' : 'max-w-2xl',
+      )}
+    >
+      {expanded ? (
+        <SearchBar
+          category={category}
+          setCategory={setCategory}
+          location={location}
+          setLocation={setLocation}
+          when={when}
+          setWhen={setWhen}
+          onSearch={handleSearch}
+          onCancel={collapse}
+          compact={false}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={handleExpand}
+          className="w-full flex items-center justify-between px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md text-sm"
+        >
+          <div className="flex flex-1 divide-x divide-gray-300">
+            <div className="flex-1 px-2 truncate">
+              {category ? category.label : 'Add artists'}
+            </div>
+            <div className="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis">
+              {location || 'Search destinations'}
+            </div>
+            <div className="flex-1 px-2 truncate">
+              {when ? dateFormatter.format(when) : 'Add dates'}
+            </div>
+          </div>
+          <MagnifyingGlassIcon className="ml-2 h-5 w-5 text-gray-500 flex-shrink-0" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -126,4 +126,31 @@ describe('SearchBarInline', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('displays initial parameters in collapsed pill', async () => {
+    const onSearch = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SearchBarInline
+          onSearch={onSearch}
+          initialCategory="dj"
+          initialLocation="Cape Town"
+          initialWhen={new Date('2025-05-01')}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const trigger = container.querySelector('button') as HTMLButtonElement;
+    expect(trigger.textContent).toContain('DJ');
+    expect(trigger.textContent).toContain('Cape Town');
+    expect(trigger.textContent).toMatch(/May\s+1,\s+2025/);
+
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- make inline search bar expand into full SearchBar and persist category/date/location selections
- collapse inline search on Escape or after search submission
- test persistence of initial search parameters

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm test` *(fails: TypeError: useRouter is not a function, and other errors)*


------
https://chatgpt.com/codex/tasks/task_e_688e19f11844832e81b591d4d75015fd