### PR TITLE
fix: use camelCase SVG props

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -157,7 +157,21 @@ export default function Header({ extraBar, headerState, onForceHeaderState }: He
                 className="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
               >
                 <span className="text-gray-500">Category, Location, When</span>
-                <svg className="h-5 w-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"></path></svg>
+                <svg
+                  className="h-5 w-5 text-gray-500"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="2"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                  />
+                </svg>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- fix React warning in header by using camelCase SVG attributes

## Testing
- `./scripts/test-all.sh` *(fails: getArtists is not defined, router.replace is not a function, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e1d1f7770832eb065bd31dfc25e28