### PR TITLE
fix: prevent LocationInput update loop

### DIFF
--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -83,10 +83,18 @@ const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
       }
     }, [placePredictions, value]);
 
+    // Keep getPlacePredictions in a ref to avoid it being a changing dependency
+    // which can cause this effect to fire continuously and exceed the update depth
+    const getPredictionsRef = useRef(getPlacePredictions);
+
+    useEffect(() => {
+      getPredictionsRef.current = getPlacePredictions;
+    }, [getPlacePredictions]);
+
     // 🎯 Trigger new predictions from user input
     useEffect(() => {
       if (value.trim().length > 0) {
-        getPlacePredictions({
+        getPredictionsRef.current({
           input: value,
           ...(userLocation && {
             location: new google.maps.LatLng(userLocation.lat, userLocation.lng),
@@ -99,7 +107,7 @@ const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
         setDropdownVisible(false);
         setHighlightedIndex(-1);
       }
-    }, [value, getPlacePredictions, userLocation]);
+    }, [value, userLocation]);
 
     // 🖱 Close dropdown on outside click
     useEffect(() => {

--- a/frontend/src/components/ui/__tests__/LocationInput.test.tsx
+++ b/frontend/src/components/ui/__tests__/LocationInput.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import LocationInput from '../LocationInput';
+
+const mockGetPlacePredictions = jest.fn();
+
+jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => ({
+  __esModule: true,
+  default: () => ({
+    placesService: null,
+    placePredictions: [],
+    getPlacePredictions: mockGetPlacePredictions,
+  }),
+}));
+
+describe('LocationInput', () => {
+  it('calls getPlacePredictions once when value changes', async () => {
+    const Wrapper = () => {
+      const [value, setValue] = React.useState('');
+      return (
+        <LocationInput
+          value={value}
+          onValueChange={setValue}
+          onPlaceSelect={jest.fn()}
+        />
+      );
+    };
+
+    const { getByRole } = render(<Wrapper />);
+    const input = getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'Cape Town' } });
+
+    await waitFor(() => {
+      expect(mockGetPlacePredictions).toHaveBeenCalledTimes(1);
+      expect(mockGetPlacePredictions).toHaveBeenCalledWith(
+        expect.objectContaining({ input: 'Cape Town' }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- prevent LocationInput from firing effects indefinitely by stabilizing prediction callback
- add unit test confirming predictions triggered once per input change

## Testing
- `./scripts/test-all.sh` *(fails: travel.calculateTravelMode › selects fly when cheaper than driving; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e1eae7298832e9125b2116d618bd8