### PR TITLE
Update search bar placeholders on selection

### DIFF
--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -92,10 +92,10 @@ export default function SearchBarInline({
         >
           <div className="flex flex-1 divide-x divide-gray-300">
             <div className="flex-1 px-2 truncate">
-              {category ? category.label : 'Add artists'}
+              {category ? category.label : 'Add artist'}
             </div>
             <div className="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis">
-              {location || 'Search destinations'}
+              {location || 'Add location'}
             </div>
             <div className="flex-1 px-2 truncate">
               {when ? dateFormatter.format(when) : 'Add dates'}

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -55,9 +55,10 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
     ) => {
       const isActive = activeField === id;
       // Adjusted isValuePresent logic for clarity and consistency across all placeholders
-      const isValuePresent = typeof currentValue === 'string' && 
-                             currentValue !== '' && 
-                             !['Add dates', 'Add artists', 'Search destinations'].includes(currentValue);
+      const isValuePresent =
+        typeof currentValue === 'string' &&
+        currentValue !== '' &&
+        !['Add dates', 'Add artist', 'Add location'].includes(currentValue);
 
       return (
         <div className="relative flex-1">
@@ -118,7 +119,7 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
         {renderField(
           'location',
           'Where',
-          location || 'Search destinations',
+          location || 'Add location',
           locationButtonRef,
           () => setLocation('')
         )}
@@ -138,7 +139,7 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
         {renderField(
           'category',
           'Category',
-          category ? category.label : 'Add artists',
+          category ? category.label : 'Add artist',
           categoryButtonRef,
           () => setCategory(null)
         )}

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -39,8 +39,9 @@ describe('SearchBarInline', () => {
     const searchBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
     expect(searchBtn).not.toBeNull();
 
-    act(() => {
+    await act(async () => {
       searchBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
     });
     expect(onChange).toHaveBeenLastCalledWith(false);
 
@@ -92,7 +93,7 @@ describe('SearchBarInline', () => {
       await Promise.resolve();
     });
 
-    const locationDiv = container.querySelector('button > div:nth-child(2)') as HTMLDivElement;
+    const locationDiv = container.querySelector('button > div > div:nth-child(2)') as HTMLDivElement;
     expect(locationDiv.className).toMatch(/whitespace-nowrap/);
     expect(locationDiv.className).toMatch(/overflow-hidden/);
     expect(locationDiv.className).toMatch(/text-ellipsis/);
@@ -122,6 +123,26 @@ describe('SearchBarInline', () => {
     });
 
     expect(wrapper.className).toMatch(/max-w-4xl/);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows placeholders when no values set', async () => {
+    const onSearch = jest.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<SearchBarInline onSearch={onSearch} />);
+      await Promise.resolve();
+    });
+
+    const trigger = container.querySelector('button') as HTMLButtonElement;
+    expect(trigger.textContent).toContain('Add artist');
+    expect(trigger.textContent).toContain('Add location');
+    expect(trigger.textContent).toContain('Add dates');
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- refine placeholder texts in search fields and inline search bar
- add regression test for empty search placeholders

## Testing
- `./scripts/test-all.sh` *(fails: repository 'https://example.com/placeholder.git/' not found)*
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: multiple failing tests such as api.test.ts and dashboard page errors)*
- `cd frontend && npx jest src/components/search/__tests__/SearchBarInline.test.tsx --runTestsByPath --maxWorkers=50%`

------
https://chatgpt.com/codex/tasks/task_e_688e20b52dd4832e95209842451293c3