### PR TITLE
fix: truncate long search locations

### DIFF
--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -61,7 +61,10 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
         !['Add dates', 'Add artist', 'Add location'].includes(currentValue);
 
       return (
-        <div className="relative flex-1">
+        <div
+          className="relative flex-1 min-w-0"
+        >
+          {/* min-w-0 ensures flex children can shrink and truncate long values */}
           <button
             ref={buttonRef} // Attach ref to the button element
             type="button"
@@ -114,11 +117,11 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
     // Use a stable date formatter for consistent output across server/client
     const dateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 
-    return (
-      <div ref={ref} className="flex flex-1 divide-x divide-gray-200">
-        {renderField(
-          'location',
-          'Where',
+  return (
+    <div ref={ref} className="flex flex-1 divide-x divide-gray-200">
+      {renderField(
+        'location',
+        'Where',
           location || 'Add location',
           locationButtonRef,
           () => setLocation('')
@@ -142,8 +145,11 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
           category ? category.label : 'Add artist',
           categoryButtonRef,
           () => setCategory(null)
-        )}
-      </div>
-    );
-  }
+      )}
+    </div>
+  );
+}
 );
+
+// Explicitly set display name to satisfy React and ESLint rules
+SearchFields.displayName = 'SearchFields';


### PR DESCRIPTION
## Summary
- avoid search bar expansion by allowing location field to shrink and ellipsize
- name `SearchFields` component to satisfy React/ESLint

## Testing
- `npx eslint src/components/search/SearchFields.tsx`
- `npm test` *(fails: ReferenceError: getArtists is not defined, and other failures)*
- `./scripts/test-all.sh` *(fails: TypeError: router.replace is not a function, and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_688e39643950832eb7f82da482a1b235