### PR TITLE
Fix search pill visibility on compact artist header

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -224,8 +224,9 @@
   transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; /* Slight delay on opacity for slide effect */
 }
 
-/* When header is compacted, hide these */
-#app-header[data-header-state="compacted"] .content-area-wrapper {
+/* When header is compacted, hide nav links and the full search bar */
+#app-header[data-header-state="compacted"] .header-nav-links,
+#app-header[data-header-state="compacted"] .header-full-search-bar {
   max-height: 0;
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- ensure header only hides nav links on scroll so the search pill stays visible

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688e58eab48c832e80b917e84c928f24