### PR TITLE
feat: keep search pill visible on artist pages

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -69,9 +69,16 @@ interface HeaderProps {
   headerState: HeaderState; // New prop for header state
   onForceHeaderState: (state: HeaderState) => void; // New callback for state control
   showSearchBar?: boolean; // Controls visibility of built-in search bar
+  alwaysCompact?: boolean; // Keeps pill visible regardless of scroll
 }
 
-export default function Header({ extraBar, headerState, onForceHeaderState, showSearchBar = true }: HeaderProps) {
+export default function Header({
+  extraBar,
+  headerState,
+  onForceHeaderState,
+  showSearchBar = true,
+  alwaysCompact = false,
+}: HeaderProps) {
   const { user, logout, artistViewActive, toggleArtistView } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
@@ -91,25 +98,29 @@ export default function Header({ extraBar, headerState, onForceHeaderState, show
       if (when) params.set('when', when.toISOString());
       router.push(`/artists?${params.toString()}`);
       // After search submission, revert header to compacted or initial based on scroll
-      if (window.scrollY > 150) { // Using the same scrollThreshold as MainLayout
+      if (alwaysCompact) {
+        onForceHeaderState('compacted');
+      } else if (window.scrollY > 150) {
         onForceHeaderState('compacted');
       } else {
         onForceHeaderState('initial');
       }
     },
-    [router, onForceHeaderState]
+    [router, onForceHeaderState, alwaysCompact]
   );
 
   // This is crucial: Called by SearchBar when its *internal popups* are closed (e.g., clicking outside calendar)
   const handleSearchBarCancel = useCallback(() => {
     // Determine the state to revert to: compacted if scrolled, initial if at top
     // This allows the full search bar to "collapse" back into the header's normal flow.
-    if (window.scrollY > 150) { // Using the same scrollThreshold as MainLayout
+    if (alwaysCompact) {
+      onForceHeaderState('compacted');
+    } else if (window.scrollY > 150) {
       onForceHeaderState('compacted');
     } else {
       onForceHeaderState('initial');
     }
-  }, [onForceHeaderState]);
+  }, [onForceHeaderState, alwaysCompact]);
 
   // Main header classes reacting to headerState
   const headerClasses = clsx(

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -8,22 +8,22 @@ import type { User } from '@/types';
 
 jest.mock('@/contexts/AuthContext');
 jest.mock('next/link', () => ({ __esModule: true, default: (props: Record<string, unknown>) => <a {...props} /> }));
-const usePathnameMock = jest.fn(() => '/');
-const useParamsMock = jest.fn(() => ({}));
+const mockUsePathname = jest.fn(() => '/');
+const mockUseParams = jest.fn(() => ({}));
 
 jest.mock('next/navigation', () => ({
-  usePathname: () => usePathnameMock(),
+  usePathname: () => mockUsePathname(),
   useRouter: () => ({}),
   useSearchParams: () => new URLSearchParams(),
-  useParams: () => useParamsMock(),
+  useParams: () => mockUseParams(),
 }));
 
 
 describe('MainLayout user menu', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    usePathnameMock.mockReturnValue('/');
-    useParamsMock.mockReturnValue({});
+    mockUsePathname.mockReturnValue('/');
+    mockUseParams.mockReturnValue({});
   });
 
   it('shows artist links for artist users', async () => {
@@ -73,8 +73,8 @@ describe('MainLayout user menu', () => {
   });
 
   it('renders compact search pill on artist detail pages', async () => {
-    usePathnameMock.mockReturnValue('/artists');
-    useParamsMock.mockReturnValue({ id: '123' });
+    mockUsePathname.mockReturnValue('/artists');
+    mockUseParams.mockReturnValue({ id: '123' });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, email: 'a@test.com', user_type: 'artist' } as User, logout: jest.fn() });
     const div = document.createElement('div');
     document.body.appendChild(div);
@@ -83,6 +83,9 @@ describe('MainLayout user menu', () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
     await flushPromises();
+    const header = div.querySelector('#app-header') as HTMLElement;
+    expect(header).toBeTruthy();
+    expect(header.getAttribute('data-header-state')).toBe('compacted');
     expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
     act(() => { root.unmount(); });
     div.remove();


### PR DESCRIPTION
## Summary
- keep search bar pill visible on artist profile pages regardless of scroll
- pass alwaysCompact flag to header to avoid hiding compact pill
- verify artist pages start with compact header state

## Testing
- `npm test src/components/layout/__tests__/MainLayout.test.tsx` *(fails: expect text to contain 'Sound Providers'; menu button undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688e5b625364832ea712be1d2286c399