### PR TITLE
Fix search pill visibility on artist listing page

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -238,7 +238,7 @@ export default function Header({
         </div>
 
         {/* Full Search Bar (Visible initially, and when expanded from compact) */}
-        {showSearchBar && (
+        {showSearchBar && !extraBar && (
           <div className="content-area-wrapper header-full-search-bar mt-3 max-w-4xl mx-auto">
             <SearchBar
               category={category}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -169,7 +169,6 @@ export default function MainLayout({ children, headerAddon, fullWidthContent = f
           extraBar={
             isArtistsRoot ? <div className="mx-auto w-full px-4">{headerAddon}</div> : undefined
           }
-          showSearchBar={!isArtistsRoot}
           alwaysCompact={isArtistDetail}
         />
 

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -90,4 +90,27 @@ describe('MainLayout user menu', () => {
     act(() => { root.unmount(); });
     div.remove();
   });
+
+  it('keeps search pill available on artists listing page', async () => {
+    mockUsePathname.mockReturnValue('/artists');
+    mockUseParams.mockReturnValue({});
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 3, email: 'c@test.com', user_type: 'client' } as User, logout: jest.fn() });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        React.createElement(
+          MainLayout,
+          { headerAddon: React.createElement('div', null, 'addon') },
+          React.createElement('div')
+        )
+      );
+    });
+    await flushPromises();
+    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    expect(div.querySelector('.header-full-search-bar')).toBeNull();
+    act(() => { root.unmount(); });
+    div.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- avoid rendering full search bar when extra header content is present
- always render compact search pill and test visibility on artists listing page

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: router.replace is not a function, ReferenceError: getArtists is not defined, many Jest failures)*

------
https://chatgpt.com/codex/tasks/task_e_688e76135060832e97d17966e9693022