### PR TITLE
fix: allow multiple refs in SearchBar click outside

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -91,7 +91,11 @@ export default function SearchBar({
     }, 200);
   }, []);
 
-  const clickOutsideRefs = useMemo(() => [formRef, popupContainerRef], []);
+  // Cast refs to a generic HTMLElement array so useClickOutside accepts them
+  const clickOutsideRefs = useMemo(
+    () => [formRef, popupContainerRef] as React.RefObject<HTMLElement | null>[],
+    [],
+  );
 
   useClickOutside(clickOutsideRefs, () => {
     if (showInternalPopup) {


### PR DESCRIPTION
## Summary
- fix SearchBar to cast multiple refs for useClickOutside

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd backend && pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `cd frontend && npm test` *(fails: ReferenceError: getArtists is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e7972bd14832e9d435ba55615c27e