### PR TITLE
feat: keep search bar sticky

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -197,67 +197,7 @@
   padding-bottom: 1rem; /* py-4 */
 }
 
-/* State: Compacted */
-#app-header[data-header-state="compacted"] {
-  height: 4rem; /* h-16 */
-  padding-top: 0.5rem; /* py-2 */
-  padding-bottom: 0.5rem; /* py-2 */
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); /* shadow-md */
-}
-
-/* State: Expanded from Compact (when pill is clicked) */
-#app-header[data-header-state="expanded-from-compact"] {
-  /* Same as initial for height/padding/shadow for seamless feel */
-  padding-top: 1rem; /* py-4 */
-  padding-bottom: 1rem; /* py-4 */
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04); /* shadow-xl for prominent pop-up */
-}
-
-/* Content Visibility & Transitions within Header */
-
-/* Default for .content-area-wrapper (visible in initial & expanded-from-compact states) */
-.content-area-wrapper {
-  max-height: 100px; /* Sufficient height to show content */
-  opacity: 1;
-  pointer-events: auto;
-  overflow: hidden; /* Hide overflow during transition */
-  transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; /* Slight delay on opacity for slide effect */
-}
-
-/* When header is compacted, hide nav links and the full search bar */
-#app-header[data-header-state="compacted"] .header-nav-links,
-#app-header[data-header-state="compacted"] .header-full-search-bar {
-  max-height: 0;
-  opacity: 0;
-  pointer-events: none;
-  transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out; /* No delay when hiding */
-}
-
-/* .compact-pill-wrapper (visible only in compacted state) */
-.compact-pill-wrapper {
-  max-width: 0; /* Hidden by default */
-  opacity: 0;
-  pointer-events: none;
-  overflow: hidden;
-  /* Adjust width transition for the pill */
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; 
-}
-
-/* When header is compacted, show the pill */
-#app-header[data-header-state="compacted"] .compact-pill-wrapper {
-  max-width: 32rem; /* max-w-lg */
-  opacity: 1;
-  pointer-events: auto;
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s;
-}
-
-/* When header is expanded from compact (clicked pill), hide the pill */
-#app-header[data-header-state="expanded-from-compact"] .compact-pill-wrapper {
-  max-width: 0;
-  opacity: 0;
-  pointer-events: none;
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out;
-}
+/* Compact pill and compacted state styles removed to keep search bar always visible */
 
 /* Overlay for expanded search form */
 #expanded-search-overlay {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -157,36 +157,7 @@ export default function Header({
               </nav>
             </div>
 
-            {/* Compact Search Pill (Visible when scrolled/compacted) */}
-            {showSearchBar && (
-              <div className="compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center">
-                <div
-                  id="compact-search-trigger" // Use this ID for JS listener in MainLayout
-                  onClick={(e) => {
-                      e.stopPropagation(); // VERY IMPORTANT: Stop click from bubbling to document and closing overlay prematurely
-                      onForceHeaderState('expanded-from-compact');
-                  }}
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
-                >
-                  <span className="text-gray-500">Category, Location, When</span>
-                  <svg
-                    className="h-5 w-5 text-gray-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth="2"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            )}
+            {/* Compact search pill removed to keep search bar visible during scrolling */}
           </div>
 
           {/* Icons */}
@@ -255,9 +226,7 @@ export default function Header({
         )}
 
         {/* Extra content bar (if needed, its visibility logic might need to align with headerState) */}
-        {extraBar && (headerState === 'initial' || headerState === 'expanded-from-compact') && (
-          <div className="mt-3">{extraBar}</div>
-        )}
+        {extraBar && <div className="mt-3">{extraBar}</div>}
       </div>
 
       <MobileMenuDrawer

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -72,7 +72,7 @@ describe('MainLayout user menu', () => {
     div.remove();
   });
 
-  it('renders compact search pill on artist detail pages', async () => {
+  it('renders full search bar on artist detail pages', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({ id: '123' });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, email: 'a@test.com', user_type: 'artist' } as User, logout: jest.fn() });
@@ -86,12 +86,13 @@ describe('MainLayout user menu', () => {
     const header = div.querySelector('#app-header') as HTMLElement;
     expect(header).toBeTruthy();
     expect(header.getAttribute('data-header-state')).toBe('compacted');
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    expect(div.querySelector('#compact-search-trigger')).toBeNull();
+    expect(div.querySelector('.header-full-search-bar')).toBeTruthy();
     act(() => { root.unmount(); });
     div.remove();
   });
 
-  it('keeps search pill available on artists listing page', async () => {
+  it('keeps search bar visible on artists listing page', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({});
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 3, email: 'c@test.com', user_type: 'client' } as User, logout: jest.fn() });
@@ -108,8 +109,8 @@ describe('MainLayout user menu', () => {
       );
     });
     await flushPromises();
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
-    expect(div.querySelector('.header-full-search-bar')).toBeNull();
+    expect(div.querySelector('#compact-search-trigger')).toBeNull();
+    expect(div.textContent).toContain('addon');
     act(() => { root.unmount(); });
     div.remove();
   });

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -220,35 +220,6 @@ exports[`Header renders search bar when enabled 1`] = `
             </a>
           </nav>
         </div>
-        <div
-          class="compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center"
-        >
-          <div
-            class="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
-            id="compact-search-trigger"
-          >
-            <span
-              class="text-gray-500"
-            >
-              Category, Location, When
-            </span>
-            <svg
-              aria-hidden="true"
-              class="h-5 w-5 text-gray-500"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </div>
-        </div>
       </div>
       <div
         class="hidden sm:flex items-center gap-4"


### PR DESCRIPTION
## Summary
- remove collapsing search pill and always display search bar
- strip compact pill CSS so header stays visible while scrolling
- adjust layout tests for persistent search bar

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: router.replace is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688e81ed0a3c832ea5af6ac21d9c42a6