### PR TITLE
Replace header pill with compact search bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,9 +1053,9 @@ When filtering by a specific `category`, each profile also includes
 `service_price` showing the price of that service for the artist.
 
 The redesigned listing page features a sticky search header. On desktop this
-header collapses to a single segment that expands inline to show **Category**,
+header collapses to a compact search bar that expands inline to show **Category**,
 **Location** and **Date** fields, mirroring Airbnb’s style. The search icon sits
-on the right in a pink pill. Clicking any part opens all fields together in one
+on the right inside the bar. Clicking any field opens all inputs together in one
 popover, which floats above the header and closes on ESC or outside clicks. The
 bar now sits directly beneath the global navigation whenever you visit
 `/artists`, providing a consistent header across the site. A

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 ### Search Interface
 
-The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout.
+The global search bar and its compact inline version are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout.
 
 ### Loading Indicators
 
@@ -117,9 +117,9 @@ The artists page uses a responsive grid that shows one card per row on mobile,
 two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
-  desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition, while the collapsed pill uses a narrower `md:max-w-2xl` so it takes up about 25% less space. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
+  desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition, while the collapsed bar uses a narrower `md:max-w-2xl` so it takes up about 25% less space. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact bar opens a `SearchModal`
  bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. The desktop filter now opens in a white rounded card with a pink range slider and clear/apply buttons, similar to Airbnb.
- Filters show a tiny pink dot when active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
+ Filters show a tiny pink dot when active. The filter icon now sits slightly closer to the bar and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
 or refreshed without losing state.
 
 ## Testing

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -233,26 +233,26 @@
   transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out; /* No delay when hiding */
 }
 
-/* .compact-pill-wrapper (visible only in compacted state) */
-.compact-pill-wrapper {
+/* Compact search bar (visible only in compacted state) */
+.compact-searchbar-wrapper {
   max-width: 0; /* Hidden by default */
   opacity: 0;
   pointer-events: none;
   overflow: hidden;
-  /* Adjust width transition for the pill */
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; 
+  /* Adjust width transition for the bar */
+  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s;
 }
 
-/* When header is compacted, show the pill */
-#app-header[data-header-state="compacted"] .compact-pill-wrapper {
+/* When header is compacted, show the compact search bar */
+#app-header[data-header-state="compacted"] .compact-searchbar-wrapper {
   max-width: 32rem; /* max-w-lg */
   opacity: 1;
   pointer-events: auto;
   transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s;
 }
 
-/* When header is expanded from compact (clicked pill), hide the pill */
-#app-header[data-header-state="expanded-from-compact"] .compact-pill-wrapper {
+/* When header is expanded from compact, hide the compact search bar */
+#app-header[data-header-state="expanded-from-compact"] .compact-searchbar-wrapper {
   max-width: 0;
   opacity: 0;
   pointer-events: none;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -157,33 +157,20 @@ export default function Header({
               </nav>
             </div>
 
-            {/* Compact Search Pill (Visible when scrolled/compacted) */}
+            {/* Compact Search Bar (Visible when scrolled/compacted) */}
             {showSearchBar && (
-              <div className="compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center">
-                <div
-                  id="compact-search-trigger" // Use this ID for JS listener in MainLayout
-                  onClick={(e) => {
-                      e.stopPropagation(); // VERY IMPORTANT: Stop click from bubbling to document and closing overlay prematurely
-                      onForceHeaderState('expanded-from-compact');
-                  }}
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
-                >
-                  <span className="text-gray-500">Category, Location, When</span>
-                  <svg
-                    className="h-5 w-5 text-gray-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth="2"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                    />
-                  </svg>
+              <div className="compact-searchbar-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center">
+                <div id="compact-search-bar" className="flex-1">
+                  <SearchBar
+                    category={category}
+                    setCategory={setCategory}
+                    location={location}
+                    setLocation={setLocation}
+                    when={when}
+                    setWhen={setWhen}
+                    onSearch={handleSearch}
+                    compact
+                  />
                 </div>
               </div>
             )}

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -72,7 +72,7 @@ describe('MainLayout user menu', () => {
     div.remove();
   });
 
-  it('renders compact search pill on artist detail pages', async () => {
+  it('renders compact search bar on artist detail pages', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({ id: '123' });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, email: 'a@test.com', user_type: 'artist' } as User, logout: jest.fn() });
@@ -86,12 +86,12 @@ describe('MainLayout user menu', () => {
     const header = div.querySelector('#app-header') as HTMLElement;
     expect(header).toBeTruthy();
     expect(header.getAttribute('data-header-state')).toBe('compacted');
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    expect(div.querySelector('#compact-search-bar')).toBeTruthy();
     act(() => { root.unmount(); });
     div.remove();
   });
 
-  it('keeps search pill available on artists listing page', async () => {
+  it('keeps compact search bar available on artists listing page', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({});
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 3, email: 'c@test.com', user_type: 'client' } as User, logout: jest.fn() });
@@ -108,7 +108,7 @@ describe('MainLayout user menu', () => {
       );
     });
     await flushPromises();
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    expect(div.querySelector('#compact-search-bar')).toBeTruthy();
     expect(div.querySelector('.header-full-search-bar')).toBeNull();
     act(() => { root.unmount(); });
     div.remove();
@@ -125,7 +125,7 @@ describe('MainLayout user menu', () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
     await flushPromises();
-    expect(div.querySelector('#compact-search-trigger')).toBeNull();
+    expect(div.querySelector('#compact-search-bar')).toBeNull();
     expect(div.querySelector('.header-full-search-bar')).toBeNull();
     act(() => { root.unmount(); });
     div.remove();

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -221,32 +221,122 @@ exports[`Header renders search bar when enabled 1`] = `
           </nav>
         </div>
         <div
-          class="compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center"
+          class="compact-searchbar-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center"
         >
           <div
-            class="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
-            id="compact-search-trigger"
+            class="flex-1"
+            id="compact-search-bar"
           >
-            <span
-              class="text-gray-500"
+            <form
+              aria-label="Artist booking search"
+              autocomplete="off"
+              class="relative z-45 flex items-stretch bg-white rounded-r-full shadow-lg transition-all duration-200 ease-out text-sm shadow-md hover:shadow-lg"
+              role="search"
             >
-              Category, Location, When
-            </span>
-            <svg
-              aria-hidden="true"
-              class="h-5 w-5 text-gray-500"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+              <div
+                class="flex flex-1 divide-x divide-gray-200"
+              >
+                <div
+                  class="relative flex-1 min-w-0"
+                >
+                  <button
+                    aria-controls="category-popup"
+                    aria-expanded="false"
+                    class="group relative z-10 w-full flex flex-col justify-center text-left transition-all duration-200 ease-out outline-none px-4 py-2 hover:bg-gray-50 focus:bg-gray-50"
+                    id="category-search-button"
+                    type="button"
+                  >
+                    <span
+                      class="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none"
+                    >
+                      Category
+                    </span>
+                    <span
+                      class="block truncate pointer-events-none select-none text-gray-400 italic text-sm"
+                    >
+                      Add artist
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="border-l border-gray-200"
+                />
+                <div
+                  class="relative flex-1 min-w-0"
+                >
+                  <button
+                    aria-controls="location-popup"
+                    aria-expanded="false"
+                    class="group relative z-10 w-full flex flex-col justify-center text-left transition-all duration-200 ease-out outline-none px-4 py-2 hover:bg-gray-50 focus:bg-gray-50"
+                    id="location-search-button"
+                    type="button"
+                  >
+                    <span
+                      class="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none"
+                    >
+                      Where
+                    </span>
+                    <span
+                      class="block truncate pointer-events-none select-none text-gray-400 italic text-sm"
+                    >
+                      Add location
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="border-l border-gray-200"
+                />
+                <div
+                  class="relative flex-1 min-w-0"
+                >
+                  <button
+                    aria-controls="when-popup"
+                    aria-expanded="false"
+                    class="group relative z-10 w-full flex flex-col justify-center text-left transition-all duration-200 ease-out outline-none px-4 py-2 hover:bg-gray-50 focus:bg-gray-50"
+                    id="when-search-button"
+                    type="button"
+                  >
+                    <span
+                      class="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none"
+                    >
+                      When
+                    </span>
+                    <span
+                      class="block truncate pointer-events-none select-none text-gray-400 italic text-sm"
+                    >
+                      Add dates
+                    </span>
+                  </button>
+                </div>
+              </div>
+              <button
+                aria-label="Search now"
+                class="bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/90 px-5 py-3 flex items-center justify-center text-white rounded-r-full transition-all duration-200 ease-out active:scale-95"
+                type="submit"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="h-5 w-5"
+                  data-slot="icon"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+                <span
+                  class="sr-only"
+                >
+                  Search
+                </span>
+              </button>
+            </form>
           </div>
         </div>
       </div>
@@ -283,6 +373,31 @@ exports[`Header renders search bar when enabled 1`] = `
         <div
           class="flex flex-1 divide-x divide-gray-200"
         >
+          <div
+            class="relative flex-1 min-w-0"
+          >
+            <button
+              aria-controls="category-popup"
+              aria-expanded="false"
+              class="group relative z-10 w-full flex flex-col justify-center text-left transition-all duration-200 ease-out outline-none px-6 py-3 hover:bg-gray-50 focus:bg-gray-50"
+              id="category-search-button"
+              type="button"
+            >
+              <span
+                class="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none"
+              >
+                Category
+              </span>
+              <span
+                class="block truncate pointer-events-none select-none text-gray-400 italic text-base"
+              >
+                Add artist
+              </span>
+            </button>
+          </div>
+          <div
+            class="border-l border-gray-200"
+          />
           <div
             class="relative flex-1 min-w-0"
           >
@@ -327,31 +442,6 @@ exports[`Header renders search bar when enabled 1`] = `
                 class="block truncate pointer-events-none select-none text-gray-400 italic text-base"
               >
                 Add dates
-              </span>
-            </button>
-          </div>
-          <div
-            class="border-l border-gray-200"
-          />
-          <div
-            class="relative flex-1 min-w-0"
-          >
-            <button
-              aria-controls="category-popup"
-              aria-expanded="false"
-              class="group relative z-10 w-full flex flex-col justify-center text-left transition-all duration-200 ease-out outline-none px-6 py-3 hover:bg-gray-50 focus:bg-gray-50"
-              id="category-search-button"
-              type="button"
-            >
-              <span
-                class="text-xs text-gray-500 font-semibold mb-1 pointer-events-none select-none"
-              >
-                Category
-              </span>
-              <span
-                class="block truncate pointer-events-none select-none text-gray-400 italic text-base"
-              >
-                Add artist
               </span>
             </button>
           </div>

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -118,31 +118,31 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
   return (
     <div ref={ref} className="flex flex-1 divide-x divide-gray-200">
       {renderField(
+        'category',
+        'Category',
+        category ? category.label : 'Add artist',
+        categoryButtonRef,
+        () => setCategory(null)
+      )}
+
+      <div className="border-l border-gray-200" />
+
+      {renderField(
         'location',
         'Where',
-          location || 'Add location',
-          locationButtonRef,
-          () => setLocation('')
-        )}
+        location || 'Add location',
+        locationButtonRef,
+        () => setLocation('')
+      )}
 
-        <div className="border-l border-gray-200" />
+      <div className="border-l border-gray-200" />
 
-        {renderField(
-          'when',
-          'When',
-          when ? dateFormatter.format(when) : 'Add dates',
-          whenButtonRef,
-          () => setWhen(null)
-        )}
-
-        <div className="border-l border-gray-200" />
-
-        {renderField(
-          'category',
-          'Category',
-          category ? category.label : 'Add artist',
-          categoryButtonRef,
-          () => setCategory(null)
+      {renderField(
+        'when',
+        'When',
+        when ? dateFormatter.format(when) : 'Add dates',
+        whenButtonRef,
+        () => setWhen(null)
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show a compact search bar instead of the pill when the header is collapsed
- reorder search fields to show Add artist, Add location, Add dates
- update docs and styles for the compact search bar

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 33 failed, 1 skipped, 69 passed; Tests: 72 failed, 1 skipped, 245 passed; Snapshots: 1 failed, 1 obsolete, 1 file obsolete)*


------
https://chatgpt.com/codex/tasks/task_e_688e86711888832ead5ac5d0ac86735d