### PR TITLE
Replace search pill with inline search bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,17 +1052,17 @@ Passing a `when` date returns only artists available on that day and sets
 When filtering by a specific `category`, each profile also includes
 `service_price` showing the price of that service for the artist.
 
-The redesigned listing page features a sticky search header. On desktop this
-header collapses to a single segment that expands inline to show **Category**,
-**Location** and **Date** fields, mirroring Airbnb’s style. The search icon sits
-on the right in a pink pill. Clicking any part opens all fields together in one
-popover, which floats above the header and closes on ESC or outside clicks. The
-bar now sits directly beneath the global navigation whenever you visit
-`/artists`, providing a consistent header across the site. A
+The redesigned listing page features a sticky search header. On desktop the
+header shows **Category**, **Location** and **Date** fields inline, mirroring
+Airbnb’s style. The search icon sits on the right of these fields. The bar now
+sits directly beneath the global navigation whenever you visit `/artists`,
+providing a consistent header across the site. A
 `useMediaQuery('(min-width:768px)')` hook picks between this inline bar and the
 mobile `SearchModal`. On mobile a compact summary displays the selected values;
 tapping it opens the modal prefilled with those values. A **Filters** button
-opens `FilterSheet` for sort and price range. On desktop the filter modal uses a React portal to keep its fixed overlay centered. The button stores chosen values locally until **Apply filters** is clicked, updating the URL and results. It then
+opens `FilterSheet` for sort and price range. On desktop the filter modal uses a
+React portal to keep its fixed overlay centered. The button stores chosen values
+locally until **Apply filters** is clicked, updating the URL and results. It then
 shows a tiny pink dot when any filter is active. The page
 rests on a soft gradient background from the brand color to white. When no
 results match the current filters the page shows "No artists found" beneath the

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 ### Search Interface
 
-The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout.
+The global search bar is rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout.
 
 ### Loading Indicators
 
@@ -117,10 +117,12 @@ The artists page uses a responsive grid that shows one card per row on mobile,
 two cards on tablets and three or more on larger screens. Each artist card
 displays a skeleton placeholder until the image loads and reveals a **Book
 Now** overlay button when hovered. A sticky header hosts the search UI. On
-  desktop a segmented bar (`SearchBarInline`) collapses into three segments showing the chosen **Category**, **Location** and **Date**. Clicking anywhere on this bar smoothly expands it into the full homepage search form with identical styling. When expanded the wrapper stays centered with a fixed `md:max-w-4xl` width and a 300ms ease-out transition, while the collapsed pill uses a narrower `md:max-w-2xl` so it takes up about 25% less space. Keyboard users can press **Enter** to search or **Escape** to cancel. On mobile the compact pill opens a `SearchModal`
- bottom sheet while the filter icon opens `FilterSheet`. On larger screens this icon sits to the right of the inline search bar without shifting its centered position. The desktop filter now opens in a white rounded card with a pink range slider and clear/apply buttons, similar to Airbnb.
- Filters show a tiny pink dot when active. The filter icon now sits slightly closer to the pill and automatically hides when the inline bar expands into the full form. All search options and filters persist in the URL so pages can be shared
-or refreshed without losing state.
+desktop the `SearchBarInline` component keeps the **Category**, **Location** and
+**Date** fields visible inline at all times. The filter icon sits to the right of
+this bar and shows a pink dot when active. On mobile the search button opens a
+`SearchModal` bottom sheet while the filter icon opens `FilterSheet`. All search
+options and filters persist in the URL so pages can be shared or refreshed
+without losing state.
 
 ## Testing
 

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { format, parseISO, isValid } from 'date-fns';
-import clsx from 'clsx';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import { getArtists, type PriceBucket } from '@/lib/api';
@@ -144,63 +143,51 @@ const fetchArtists = useCallback(
     });
   };
 
-  const [searchExpanded, setSearchExpanded] = useState(false);
-
   const header = (
-    <div
-      className={clsx(
-        'relative mx-auto transition-all duration-300 ease-out',
-        searchExpanded
-          ? 'max-w-full md:max-w-5xl lg:max-w-6xl'
-          : 'max-w-2xl'
-      )}
-    >
-      <SearchBarInline
-        initialCategory={uiValue}
-        initialLocation={location}
-        initialWhen={when}
-        onSearch={handleSearchEdit}
-        onExpandedChange={setSearchExpanded}
+    <div className="relative mx-auto flex max-w-full md:max-w-5xl lg:max-w-6xl items-center gap-2">
+      <div className="flex-1">
+        <SearchBarInline
+          initialCategory={uiValue}
+          initialLocation={location}
+          initialWhen={when}
+          onSearch={handleSearchEdit}
+        />
+      </div>
+      <ArtistsPageHeader
+        iconOnly
+        categoryLabel={uiLabel}
+        categoryValue={uiValue}
+        location={location}
+        when={when}
+        onSearchEdit={handleSearchEdit}
+        initialSort={sort}
+        initialMinPrice={minPrice}
+        initialMaxPrice={maxPrice}
+        priceDistribution={priceDistribution}
+        onFilterApply={({ sort: s, minPrice: min, maxPrice: max }) => {
+          setSort(s || undefined);
+          setMinPrice(min);
+          setMaxPrice(max);
+          updateQueryParams(router, pathname, {
+            category,
+            location,
+            when,
+            sort: s,
+            minPrice: min,
+            maxPrice: max,
+          });
+        }}
+        onFilterClear={() => {
+          setSort(undefined);
+          setMinPrice(SLIDER_MIN);
+          setMaxPrice(SLIDER_MAX);
+          updateQueryParams(router, pathname, {
+            category,
+            location,
+            when,
+          });
+        }}
       />
-      {!searchExpanded && (
-        <div className="absolute left-full ml-2 top-1/2 -translate-y-1/2">
-          <ArtistsPageHeader
-            iconOnly
-            categoryLabel={uiLabel}
-            categoryValue={uiValue}
-            location={location}
-            when={when}
-            onSearchEdit={handleSearchEdit}
-            initialSort={sort}
-            initialMinPrice={minPrice}
-            initialMaxPrice={maxPrice}
-            priceDistribution={priceDistribution}
-            onFilterApply={({ sort: s, minPrice: min, maxPrice: max }) => {
-              setSort(s || undefined);
-              setMinPrice(min);
-              setMaxPrice(max);
-              updateQueryParams(router, pathname, {
-                category,
-                location,
-                when,
-                sort: s,
-                minPrice: min,
-                maxPrice: max,
-              });
-            }}
-            onFilterClear={() => {
-              setSort(undefined);
-              setMinPrice(SLIDER_MIN);
-              setMaxPrice(SLIDER_MAX);
-              updateQueryParams(router, pathname, {
-                category,
-                location,
-                when,
-              });
-            }}
-          />
-        </div>
-      )}
     </div>
   );
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -205,17 +205,9 @@
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); /* shadow-md */
 }
 
-/* State: Expanded from Compact (when pill is clicked) */
-#app-header[data-header-state="expanded-from-compact"] {
-  /* Same as initial for height/padding/shadow for seamless feel */
-  padding-top: 1rem; /* py-4 */
-  padding-bottom: 1rem; /* py-4 */
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04); /* shadow-xl for prominent pop-up */
-}
-
 /* Content Visibility & Transitions within Header */
 
-/* Default for .content-area-wrapper (visible in initial & expanded-from-compact states) */
+/* Default for .content-area-wrapper */
 .content-area-wrapper {
   max-height: 100px; /* Sufficient height to show content */
   opacity: 1;
@@ -224,53 +216,10 @@
   transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; /* Slight delay on opacity for slide effect */
 }
 
-/* When header is compacted, hide nav links and the full search bar */
-#app-header[data-header-state="compacted"] .header-nav-links,
-#app-header[data-header-state="compacted"] .header-full-search-bar {
+/* When header is compacted, hide nav links */
+#app-header[data-header-state="compacted"] .header-nav-links {
   max-height: 0;
   opacity: 0;
   pointer-events: none;
   transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out; /* No delay when hiding */
-}
-
-/* .compact-pill-wrapper (visible only in compacted state) */
-.compact-pill-wrapper {
-  max-width: 0; /* Hidden by default */
-  opacity: 0;
-  pointer-events: none;
-  overflow: hidden;
-  /* Adjust width transition for the pill */
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s; 
-}
-
-/* When header is compacted, show the pill */
-#app-header[data-header-state="compacted"] .compact-pill-wrapper {
-  max-width: 32rem; /* max-w-lg */
-  opacity: 1;
-  pointer-events: auto;
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out 0.1s;
-}
-
-/* When header is expanded from compact (clicked pill), hide the pill */
-#app-header[data-header-state="expanded-from-compact"] .compact-pill-wrapper {
-  max-width: 0;
-  opacity: 0;
-  pointer-events: none;
-  transition: max-width 0.3s ease-in-out, opacity 0.3s ease-in-out;
-}
-
-/* Overlay for expanded search form */
-#expanded-search-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
-  z-index: 39; /* Below header, above page content */
-}
-
-/* Prevent body scroll when popup is active */
-body.no-scroll {
-  overflow: hidden;
 }

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -20,7 +20,7 @@ const baseNavigation = [
 ];
 
 // Define header states (shared type)
-type HeaderState = 'initial' | 'compacted' | 'expanded-from-compact';
+type HeaderState = 'initial' | 'compacted';
 
 // --- FOOTER COMPONENT (Defined within MainLayout) ---
 const SocialIcon = ({ href, children }: { href: string; children: React.ReactNode }) => (
@@ -89,8 +89,6 @@ export default function MainLayout({ children, headerAddon, fullWidthContent = f
   const [headerState, setHeaderState] = useState<HeaderState>(
     isArtistDetail ? 'compacted' : 'initial',
   );
-  // Boolean derived from headerState to control global overlay visibility
-  const showSearchOverlay = headerState === 'expanded-from-compact';
 
   const scrollThreshold = 150; // Distance to scroll before compacting header
 
@@ -101,14 +99,9 @@ export default function MainLayout({ children, headerAddon, fullWidthContent = f
 
   // Effect for scroll-based header state changes
   useEffect(() => {
-    if (isArtistDetail) return; // Keep pill visible on artist detail pages
+    if (isArtistDetail) return;
 
     const handleScroll = () => {
-      // Only change state based on scroll if not currently in 'expanded-from-compact' state
-      if (headerState === 'expanded-from-compact') {
-        return;
-      }
-
       const scrollY = window.scrollY;
       if (scrollY > scrollThreshold) {
         setHeaderState('compacted');
@@ -117,23 +110,12 @@ export default function MainLayout({ children, headerAddon, fullWidthContent = f
       }
     };
 
-    // Attach/detach scroll listener
-    handleScroll(); // Set initial state on mount
+    handleScroll();
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [headerState, isArtistDetail]); // Re-run effect if headerState changes (to update scroll behavior)
-
-
-  // Effect to manage body scroll based on showSearchOverlay
-  useEffect(() => {
-    if (showSearchOverlay) {
-      document.body.classList.add('no-scroll');
-    } else {
-      document.body.classList.remove('no-scroll');
-    }
-  }, [showSearchOverlay]);
+  }, [isArtistDetail]);
 
   const contentWrapperClasses = fullWidthContent
     ? 'w-full'
@@ -144,24 +126,6 @@ export default function MainLayout({ children, headerAddon, fullWidthContent = f
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-50 bg-gradient-to-b from-brand-light/50 to-gray-50">
-      {/* Global Overlay for expanded search form */}
-      {showSearchOverlay && (
-        <div
-          id="expanded-search-overlay"
-          className="fixed inset-0 bg-black bg-opacity-30 z-40 animate-fadeIn"
-          onClick={() => {
-            // Revert to compacted or initial based on scroll when overlay is clicked
-            if (isArtistDetail) {
-              forceHeaderState('compacted');
-            } else if (window.scrollY > scrollThreshold) {
-              forceHeaderState('compacted');
-            } else {
-              forceHeaderState('initial');
-            }
-          }}
-        />
-      )}
-
       <div className="flex-grow">
         <Header
           headerState={headerState}

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -72,7 +72,7 @@ describe('MainLayout user menu', () => {
     div.remove();
   });
 
-  it('renders compact search pill on artist detail pages', async () => {
+  it('renders search bar on artist detail pages', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({ id: '123' });
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 2, email: 'a@test.com', user_type: 'artist' } as User, logout: jest.fn() });
@@ -86,12 +86,12 @@ describe('MainLayout user menu', () => {
     const header = div.querySelector('#app-header') as HTMLElement;
     expect(header).toBeTruthy();
     expect(header.getAttribute('data-header-state')).toBe('compacted');
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    expect(div.querySelector('.header-full-search-bar')).toBeTruthy();
     act(() => { root.unmount(); });
     div.remove();
   });
 
-  it('keeps search pill available on artists listing page', async () => {
+  it('renders search bar on artists listing page', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseParams.mockReturnValue({});
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 3, email: 'c@test.com', user_type: 'client' } as User, logout: jest.fn() });
@@ -108,8 +108,7 @@ describe('MainLayout user menu', () => {
       );
     });
     await flushPromises();
-    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
-    expect(div.querySelector('.header-full-search-bar')).toBeNull();
+    expect(div.querySelector('.header-full-search-bar')).toBeTruthy();
     act(() => { root.unmount(); });
     div.remove();
   });
@@ -125,7 +124,6 @@ describe('MainLayout user menu', () => {
       root.render(React.createElement(MainLayout, null, React.createElement('div')));
     });
     await flushPromises();
-    expect(div.querySelector('#compact-search-trigger')).toBeNull();
     expect(div.querySelector('.header-full-search-bar')).toBeNull();
     act(() => { root.unmount(); });
     div.remove();

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -160,6 +160,13 @@ exports[`Header renders extraBar when provided 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="mt-3"
+    >
+      <div>
+        bar
+      </div>
+    </div>
   </div>
 </header>
 `;
@@ -219,35 +226,6 @@ exports[`Header renders search bar when enabled 1`] = `
               Contact
             </a>
           </nav>
-        </div>
-        <div
-          class="compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex justify-center"
-        >
-          <div
-            class="flex-1 px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md cursor-pointer flex items-center justify-between text-sm transition-all duration-200"
-            id="compact-search-trigger"
-          >
-            <span
-              class="text-gray-500"
-            >
-              Category, Location, When
-            </span>
-            <svg
-              aria-hidden="true"
-              class="h-5 w-5 text-gray-500"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </div>
         </div>
       </div>
       <div

--- a/frontend/src/components/search/SearchBarInline.tsx
+++ b/frontend/src/components/search/SearchBarInline.tsx
@@ -1,9 +1,7 @@
 // src/components/search/SearchBarInline.tsx
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
-import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
-import clsx from 'clsx';
+import { useState, useCallback } from 'react';
 import SearchBar from './SearchBar';
 import { UI_CATEGORIES } from '@/lib/categoryMap';
 import type { Category } from './SearchFields';
@@ -13,7 +11,6 @@ interface SearchBarInlineProps {
   initialLocation?: string;
   initialWhen?: Date | null;
   onSearch: (params: { category?: string; location?: string; when?: Date | null }) => void | Promise<void>;
-  onExpandedChange?: (expanded: boolean) => void;
 }
 
 export default function SearchBarInline({
@@ -21,89 +18,32 @@ export default function SearchBarInline({
   initialLocation = '',
   initialWhen = null,
   onSearch,
-  onExpandedChange,
 }: SearchBarInlineProps) {
-  const [expanded, setExpanded] = useState(false);
   const [category, setCategory] = useState<Category | null>(
     initialCategory ? UI_CATEGORIES.find((c) => c.value === initialCategory) || null : null,
   );
   const [location, setLocation] = useState(initialLocation);
   const [when, setWhen] = useState<Date | null>(initialWhen);
 
-  const dateFormatter = new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-
-  const handleExpand = () => {
-    setExpanded(true);
-    onExpandedChange?.(true);
-  };
-
-  const collapse = useCallback(() => {
-    setExpanded(false);
-    onExpandedChange?.(false);
-  }, [onExpandedChange]);
-
   const handleSearch = useCallback(
     async (params: { category?: string; location?: string; when?: Date | null }) => {
       await onSearch(params);
-      collapse();
     },
-    [onSearch, collapse],
+    [onSearch],
   );
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        collapse();
-      }
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [expanded, collapse]);
-
   return (
-    <div
-      className={clsx(
-        'mx-auto transition-all duration-300 ease-out',
-        expanded ? 'max-w-4xl' : 'max-w-2xl',
-      )}
-    >
-      {expanded ? (
-        <SearchBar
-          category={category}
-          setCategory={setCategory}
-          location={location}
-          setLocation={setLocation}
-          when={when}
-          setWhen={setWhen}
-          onSearch={handleSearch}
-          onCancel={collapse}
-          compact={false}
-        />
-      ) : (
-        <button
-          type="button"
-          onClick={handleExpand}
-          className="w-full flex items-center justify-between px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md text-sm"
-        >
-          <div className="flex flex-1 divide-x divide-gray-300">
-            <div className="flex-1 px-2 truncate">
-              {category ? category.label : 'Add artist'}
-            </div>
-            <div className="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis">
-              {location || 'Add location'}
-            </div>
-            <div className="flex-1 px-2 truncate">
-              {when ? dateFormatter.format(when) : 'Add dates'}
-            </div>
-          </div>
-          <MagnifyingGlassIcon className="ml-2 h-5 w-5 text-gray-500 flex-shrink-0" />
-        </button>
-      )}
+    <div className="mx-auto max-w-4xl">
+      <SearchBar
+        category={category}
+        setCategory={setCategory}
+        location={location}
+        setLocation={setLocation}
+        when={when}
+        setWhen={setWhen}
+        onSearch={handleSearch}
+        compact={false}
+      />
     </div>
   );
 }

--- a/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBarInline.test.tsx
@@ -18,137 +18,29 @@ describe('SearchBarInline', () => {
     document.body.innerHTML = '';
   });
 
-  it('expands and triggers onSearch', async () => {
+  it('triggers onSearch when submitted', async () => {
     const onSearch = jest.fn();
-    const onChange = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
 
     await act(async () => {
-      root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
+      root.render(<SearchBarInline onSearch={onSearch} />);
       await Promise.resolve();
     });
 
-    const trigger = container.querySelector('button') as HTMLButtonElement;
-    act(() => {
-      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(onChange).toHaveBeenLastCalledWith(true);
-
-    const searchBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(searchBtn).not.toBeNull();
-
+    const submit = container.querySelector('button[type="submit"]') as HTMLButtonElement;
     await act(async () => {
-      searchBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      submit.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await Promise.resolve();
     });
-    expect(onChange).toHaveBeenLastCalledWith(false);
-
     expect(onSearch).toHaveBeenCalled();
 
     act(() => root.unmount());
     container.remove();
   });
 
-  it('closes on Escape without searching', async () => {
-    const onSearch = jest.fn();
-    const onChange = jest.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<SearchBarInline onSearch={onSearch} onExpandedChange={onChange} />);
-      await Promise.resolve();
-    });
-
-    const trigger = container.querySelector('button') as HTMLButtonElement;
-    act(() => {
-      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(onChange).toHaveBeenLastCalledWith(true);
-
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    });
-    expect(onChange).toHaveBeenLastCalledWith(false);
-
-    const searchBtn = container.querySelector('button[type="submit"]');
-    expect(searchBtn).toBeNull();
-    expect(onSearch).not.toHaveBeenCalled();
-
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('location label does not wrap and is truncated', async () => {
-    const onSearch = jest.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<SearchBarInline onSearch={onSearch} />);
-      await Promise.resolve();
-    });
-
-    const locationDiv = container.querySelector('button > div > div:nth-child(2)') as HTMLDivElement;
-    expect(locationDiv.className).toMatch(/whitespace-nowrap/);
-    expect(locationDiv.className).toMatch(/overflow-hidden/);
-    expect(locationDiv.className).toMatch(/text-ellipsis/);
-
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('uses smaller max width when collapsed and expands to full width', async () => {
-    const onSearch = jest.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<SearchBarInline onSearch={onSearch} />);
-      await Promise.resolve();
-    });
-
-    const wrapper = container.querySelector('div') as HTMLDivElement;
-    expect(wrapper.className).toMatch(/max-w-2xl/);
-    expect(wrapper.className).not.toMatch(/max-w-4xl/);
-
-    const trigger = container.querySelector('button') as HTMLButtonElement;
-    act(() => {
-      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(wrapper.className).toMatch(/max-w-4xl/);
-
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('shows placeholders when no values set', async () => {
-    const onSearch = jest.fn();
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(<SearchBarInline onSearch={onSearch} />);
-      await Promise.resolve();
-    });
-
-    const trigger = container.querySelector('button') as HTMLButtonElement;
-    expect(trigger.textContent).toContain('Add artist');
-    expect(trigger.textContent).toContain('Add location');
-    expect(trigger.textContent).toContain('Add dates');
-
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('displays initial parameters in collapsed pill', async () => {
+  it('shows initial parameters', async () => {
     const onSearch = jest.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -166,12 +58,12 @@ describe('SearchBarInline', () => {
       await Promise.resolve();
     });
 
-    const trigger = container.querySelector('button') as HTMLButtonElement;
-    expect(trigger.textContent).toContain('DJ');
-    expect(trigger.textContent).toContain('Cape Town');
-    expect(trigger.textContent).toMatch(/May\s+1,\s+2025/);
+    expect(container.textContent).toContain('DJ');
+    expect(container.textContent).toContain('Cape Town');
+    expect(container.textContent).toMatch(/May\s+1,\s+2025/);
 
     act(() => root.unmount());
     container.remove();
   });
 });
+


### PR DESCRIPTION
## Summary
- show SearchBarInline instead of collapsing to a pill
- always render search bar in header when enabled
- simplify header and layout CSS/state handling and update docs

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test` *(fails: multiple test failures)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e8b597b50832ebfc42b3d35ee7efc