### PR TITLE
fix: forward header ref and satisfy click outside types

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 // src/components/layout/Header.tsx
 'use client';
 
-import { useState, useCallback, Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode, forwardRef, useCallback, useState } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { Bars3Icon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
@@ -72,13 +72,17 @@ interface HeaderProps {
   alwaysCompact?: boolean; // Keeps pill visible regardless of scroll
 }
 
-export default function Header({
-  extraBar,
-  headerState,
-  onForceHeaderState,
-  showSearchBar = true,
-  alwaysCompact = false,
-}: HeaderProps) {
+// Forward the ref so MainLayout can access the header DOM element
+const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
+  {
+    extraBar,
+    headerState,
+    onForceHeaderState,
+    showSearchBar = true,
+    alwaysCompact = false,
+  }: HeaderProps,
+  ref,
+) {
   const { user, logout, artistViewActive, toggleArtistView } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
@@ -129,7 +133,7 @@ export default function Header({
   );
 
   return (
-    <header id="app-header" className={headerClasses} data-header-state={headerState}>
+    <header ref={ref} id="app-header" className={headerClasses} data-header-state={headerState}>
       <div className="mx-auto px-4 sm:px-6 lg:px-8">
         {/* Top Row: Logo - Center - Icons */}
         <div className="grid grid-cols-[auto,1fr,auto] items-center py-2"> {/* Added py-2 back for consistency */}
@@ -273,4 +277,6 @@ export default function Header({
       />
     </header>
   );
-}
+});
+
+export default Header;

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,7 +1,16 @@
 // src/components/search/SearchBar.tsx
 'use client';
 
-import { useRef, useState, KeyboardEvent, FormEvent, useCallback, Fragment, useLayoutEffect } from 'react';
+import {
+  Fragment,
+  type RefObject,
+  FormEvent,
+  KeyboardEvent,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { SearchFields, type Category, type SearchFieldId } from './SearchFields';
@@ -92,11 +101,17 @@ export default function SearchBar({
   }, []);
 
   // Close popups when clicking outside the search form or its floating content
-  useClickOutside([formRef, popupContainerRef], () => {
-    if (showInternalPopup) {
-      closeThisSearchBarsInternalPopups();
-    }
-  });
+  useClickOutside(
+    [
+      formRef as RefObject<HTMLElement | null>,
+      popupContainerRef as RefObject<HTMLElement | null>,
+    ],
+    () => {
+      if (showInternalPopup) {
+        closeThisSearchBarsInternalPopups();
+      }
+    },
+  );
 
   const handleKeyDown = (e: KeyboardEvent<HTMLFormElement>) => {
     if (e.key === 'Escape') {


### PR DESCRIPTION
## Summary
- forward ref through Header to allow MainLayout scroll control
- cast SearchBar refs to HTMLElement for click outside hook

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd frontend && npm test` *(fails: ReferenceError: getArtists is not defined and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ea94e0208832ea89d6cefa783e821