### PR TITLE
fix: handle missing dashboard tabs

### DIFF
--- a/frontend/src/components/dashboard/DashboardTabs.tsx
+++ b/frontend/src/components/dashboard/DashboardTabs.tsx
@@ -11,12 +11,18 @@ interface Tab {
 }
 
 interface DashboardTabsProps {
-  tabs: Tab[];
+  tabs?: Tab[]; // Tabs are optional to allow rendering without data
   active: "bookings" | "services" | "requests"; // Make active specific to allowed tab types
   onChange: (id: "bookings" | "services" | "requests") => void; // Make onChange id specific
 }
 
-export default function DashboardTabs({ tabs, active, onChange }: DashboardTabsProps) {
+export default function DashboardTabs({
+  tabs = [],
+  active,
+  onChange,
+}: DashboardTabsProps) {
+  if (tabs.length === 0) return null;
+
   return (
     <div className="sticky top-0 z-30 bg-gray-50 border-b">
       <div className="flex text-sm">

--- a/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardTabs.test.tsx
@@ -40,4 +40,16 @@ describe('DashboardTabs', () => {
     });
     expect(onChange).toHaveBeenCalledWith('b');
   });
+
+  it('renders no buttons when tabs are omitted', () => {
+    act(() => {
+      root.render(
+        React.createElement(DashboardTabs, {
+          active: 'bookings',
+          onChange: jest.fn(),
+        })
+      );
+    });
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid crashing when DashboardTabs receives no tab data
- cover no-tab case with new unit test

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found / numerous frontend tests failing)*
- `npm test -- src/components/dashboard/__tests__/DashboardTabs.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f3a903fc0832eb9237879a4680c1e