### PR TITLE
feat: unify search date param

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
 - Fixed an initial load bug where a selected date sent an invalid `when` value and caused a 422 error.
+- Homepage and artist searches now share the `when` query parameter so date selections persist between pages.
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map **Musician / Band** to the `Live Performance` service
   type so searching musicians shows available artists.

--- a/frontend/src/components/landing/HomeSearchForm.tsx
+++ b/frontend/src/components/landing/HomeSearchForm.tsx
@@ -1,18 +1,19 @@
 'use client';
 import { useState, FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Button from '@/components/ui/Button';
 
 export default function HomeSearchForm() {
   const router = useRouter();
-  const [destination, setDestination] = useState('');
-  const [date, setDate] = useState('');
+  const params = useSearchParams();
+  const [destination, setDestination] = useState(params.get('location') || '');
+  const [when, setWhen] = useState(params.get('when') || '');
 
   const onSearch = (e: FormEvent) => {
     e.preventDefault();
     const params = new URLSearchParams();
     if (destination) params.set('location', destination);
-    if (date) params.set('date', date);
+    if (when) params.set('when', when);
     router.push(`/artists?${params.toString()}`);
   };
 
@@ -30,8 +31,8 @@ export default function HomeSearchForm() {
       />
       <input
         type="date"
-        value={date}
-        onChange={(e) => setDate(e.target.value)}
+        value={when}
+        onChange={(e) => setWhen(e.target.value)}
         className="min-h-[44px] w-56 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand"
       />
       <Button

--- a/frontend/src/components/landing/__tests__/HomeSearchForm.test.tsx
+++ b/frontend/src/components/landing/__tests__/HomeSearchForm.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import HomeSearchForm from '../HomeSearchForm';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+describe('HomeSearchForm', () => {
+  it('submits search with location and when params', () => {
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams());
+
+    const { container } = render(<HomeSearchForm />);
+    fireEvent.change(screen.getByPlaceholderText('Destination'), {
+      target: { value: 'Cape Town' },
+    });
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    fireEvent.change(dateInput, { target: { value: '2025-07-20' } });
+    fireEvent.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(push).toHaveBeenCalledWith('/artists?location=Cape+Town&when=2025-07-20');
+  });
+
+  it('initializes fields from search params', () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useSearchParams as jest.Mock).mockReturnValue(
+      new URLSearchParams('location=Joburg&when=2025-08-01'),
+    );
+
+    const { container } = render(<HomeSearchForm />);
+    const destInput = screen.getByPlaceholderText('Destination') as HTMLInputElement;
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+
+    expect(destInput.value).toBe('Joburg');
+    expect(dateInput.value).toBe('2025-08-01');
+  });
+});
+


### PR DESCRIPTION
## Summary
- standardize home search date parameter to `when` and restore previous search state
- document shared `when` query param for home and artist searches
- add unit test for HomeSearchForm behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688f603c0bec832ea2fb8d6093d24196