### PR TITLE
feat: compact artist page search

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 ### Search Interface
 
-The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. The compact pill now mirrors the collapsed SearchBar, displaying any selected category, location, and dates when the full bar is hidden.
+The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. The compact pill mirrors the collapsed SearchBar, displaying any selected category, location, and dates when the full bar is hidden.
 
 ### Loading Indicators
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -210,7 +210,9 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
     if (isArtistDetail) return; // No scroll listener on artist detail pages
 
     window.addEventListener('scroll', optimizedScrollHandler);
-    handleScroll();
+    if (window.scrollY > 0) {
+      handleScroll();
+    }
 
     return () => {
       window.removeEventListener('scroll', optimizedScrollHandler);

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -152,6 +152,34 @@ describe('MainLayout user menu', () => {
     div.remove();
   });
 
+  it('displays search values and filter control in compact pill on artists page', async () => {
+    mockUsePathname.mockReturnValue('/artists');
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams('category=Live%20Performance&location=Cape%20Town&when=2025-07-01'),
+    );
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 8, email: 't@test.com', user_type: 'client' } as User, logout: jest.fn() });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        React.createElement(
+          MainLayout,
+          { headerFilter: React.createElement('button', { 'aria-label': 'Filters' }) },
+          React.createElement('div'),
+        ),
+      );
+    });
+    await flushPromises();
+    const trigger = div.querySelector('#compact-search-trigger') as HTMLButtonElement;
+    expect(trigger.textContent).toContain('Musician / Band');
+    expect(trigger.textContent).toContain('Cape Town');
+    expect(trigger.textContent).toContain('Jul 1, 2025');
+    expect(div.querySelector('[aria-label="Filters"]')).toBeTruthy();
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+
   it('hides search bar outside home and artists pages', async () => {
     mockUsePathname.mockReturnValue('/contact');
     mockUseParams.mockReturnValue({});


### PR DESCRIPTION
## Summary
- ensure artists page starts in compact search mode without scroll
- test search state and filter icon rendering in compact pill
- document compact default behavior for artists search

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd backend && pytest` *(fails: 50 errors in 1.79s)*
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688f60d67c44832ebc975ec6d7f6ae08