### PR TITLE
fix: ensure expanded search bar visible on artist pages

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -259,6 +259,14 @@
   transition: max-width 0.5s ease-in-out, opacity 0.3s ease-in-out;
 }
 
+/* Ensure full search bar and nav links are visible when expanded from compact */
+#app-header[data-header-state="expanded-from-compact"] .header-nav-links,
+#app-header[data-header-state="expanded-from-compact"] .header-full-search-bar {
+  max-height: 100px;
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* Overlay for expanded search form */
 #expanded-search-overlay {
   position: fixed;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -149,7 +149,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
 
   // Main header classes reacting to headerState
   const headerClasses = clsx(
-    "app-header sticky top-0 z-40 bg-white transition-all duration-300 ease-in-out",
+    "app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out",
     {
       "compacted": headerState === 'compacted',
       "expanded-from-compact": headerState === 'expanded-from-compact',

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -115,6 +115,8 @@ describe('MainLayout user menu', () => {
     const header = div.querySelector('#app-header') as HTMLElement;
     expect(header.getAttribute('data-header-state')).toBe('expanded-from-compact');
     expect(div.querySelector('.header-full-search-bar')).toBeTruthy();
+    expect(div.querySelector('#expanded-search-overlay')).toBeTruthy();
+    expect(header.className).toMatch('z-50');
     act(() => { root.unmount(); });
     div.remove();
   });


### PR DESCRIPTION
## Summary
- raise header stacking context so the expanded search form renders above overlays
- ensure nav links and full search bar are shown when expanding from compact mode
- cover expanded-from-compact case in MainLayout tests

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_688f633959a4832e8c8cb123e69a77da