### PR TITLE
fix: render search bar after compact mode

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 ### Search Interface
 
-The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. The compact pill mirrors the collapsed SearchBar, displaying any selected category, location, and dates when the full bar is hidden.
+The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden.
 
 ### Loading Indicators
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -275,8 +275,9 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
           </div>
         </div>
 
-        {/* Full Search Bar (Visible initially, and when expanded from compact) */}
-        {showSearchBar && !extraBar && (
+        {/* Full Search Bar (Visible initially, and when expanded from compact). */}
+        {/* Always render even when extraBar is present so compact mode can expand. */}
+        {showSearchBar && (
           <div
             className={clsx(
               "content-area-wrapper header-full-search-bar mt-3 max-w-4xl mx-auto relative",

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -137,6 +137,29 @@ describe('MainLayout user menu', () => {
     div.remove();
   });
 
+  it('expands search bar when compact pill is clicked on artists listing page', async () => {
+    mockUsePathname.mockReturnValue('/artists');
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 5, email: 'e@test.com', user_type: 'client' } as User, logout: jest.fn() });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(React.createElement(MainLayout, null, React.createElement('div')));
+    });
+    await flushPromises();
+    const trigger = div.querySelector('#compact-search-trigger') as HTMLButtonElement;
+    expect(trigger).toBeTruthy();
+    await act(async () => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushPromises();
+    const header = div.querySelector('#app-header') as HTMLElement;
+    expect(header.getAttribute('data-header-state')).toBe('expanded-from-compact');
+    expect(div.querySelector('.header-full-search-bar')).toBeTruthy();
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+
   it('initializes compact header when search params present', async () => {
     mockUsePathname.mockReturnValue('/artists');
     mockUseSearchParams.mockReturnValue(new URLSearchParams('category=Live%20Performance'));


### PR DESCRIPTION
## Summary
- ensure full search bar renders even when extra header content is present
- document search bar expansion on artists listing page
- test search bar expansion on artists listing page

## Testing
- `./scripts/test-all.sh` *(failed: TypeError: (0 , _navigation.useSearchParams) is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f663727b8832ea95629f7b68fc063