### PR TITLE
feat: keep artist search compact

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -90,6 +90,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isArtistsPage = pathname.startsWith('/artists');
   const [menuOpen, setMenuOpen] = useState(false); // Mobile menu drawer state
 
   // Search parameters for the search bars (managed locally by Header and passed to SearchBar)
@@ -136,16 +137,30 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
       // After search submission, revert header.
       // Let MainLayout's scroll logic handle the final state based on current scroll.
       // We explicitly close the expanded state here.
-      onForceHeaderState(window.scrollY > 0 ? 'compacted' : 'initial', window.scrollY > 0 ? undefined : 0);
+      if (isArtistsPage) {
+        onForceHeaderState('compacted');
+      } else {
+        onForceHeaderState(
+          window.scrollY > 0 ? 'compacted' : 'initial',
+          window.scrollY > 0 ? undefined : 0,
+        );
+      }
     },
-    [router, onForceHeaderState] // Removed alwaysCompact as it's handled by MainLayout
+    [router, onForceHeaderState, isArtistsPage] // Include isArtistsPage for conditional compacting
   );
 
   // This is crucial: Called by SearchBar when its *internal popups* are closed (e.g., clicking outside calendar)
   const handleSearchBarCancel = useCallback(() => {
     // Let MainLayout's scroll logic determine the final state based on current scroll.
-    onForceHeaderState(window.scrollY > 0 ? 'compacted' : 'initial', window.scrollY > 0 ? undefined : 0);
-  }, [onForceHeaderState]);
+    if (isArtistsPage) {
+      onForceHeaderState('compacted');
+    } else {
+      onForceHeaderState(
+        window.scrollY > 0 ? 'compacted' : 'initial',
+        window.scrollY > 0 ? undefined : 0,
+      );
+    }
+  }, [onForceHeaderState, isArtistsPage]);
 
   // Main header classes reacting to headerState
   const headerClasses = clsx(
@@ -298,11 +313,6 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
               onCancel={handleSearchBarCancel} // Pass handler for closing from SearchBar's internal popups
               compact={false} // This SearchBar is always the "full" one for visuals
             />
-            {filterControl && headerState !== 'compacted' && (
-              <div className="absolute top-1/2 right-0 -translate-y-1/2 pr-2">
-                {filterControl}
-              </div>
-            )}
           </div>
         )}
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -180,22 +180,25 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
           }, TRANSITION_DURATION + 150); // Wait for scroll to complete
         }
       }
-    } else { // scrollDirection === 'up'
-      if (currentScrollY < SCROLL_THRESHOLD_UP) {
-        setHeaderState('initial');
-      } else if (currentScrollY >= SCROLL_THRESHOLD_UP && currentScrollY <= SCROLL_THRESHOLD_DOWN) {
-        // User is in the dead zone, scrolling up, and header is compacted: snap to initial
-        if (headerState === 'compacted') {
-          isAdjustingScroll.current = true; // Block further scroll handling
-          setHeaderState('initial'); // Immediately set the state visually
-          window.scrollTo({ top: 0, behavior: 'smooth' }); // Programmatically scroll to top
-          setTimeout(() => {
-            isAdjustingScroll.current = false; // Allow scroll handling again
-          }, TRANSITION_DURATION + 150); // Wait for scroll to complete
+    } else {
+      // scrollDirection === 'up'
+      if (!isArtistsPage) {
+        if (currentScrollY < SCROLL_THRESHOLD_UP) {
+          setHeaderState('initial');
+        } else if (currentScrollY >= SCROLL_THRESHOLD_UP && currentScrollY <= SCROLL_THRESHOLD_DOWN) {
+          // User is in the dead zone, scrolling up, and header is compacted: snap to initial
+          if (headerState === 'compacted') {
+            isAdjustingScroll.current = true; // Block further scroll handling
+            setHeaderState('initial'); // Immediately set the state visually
+            window.scrollTo({ top: 0, behavior: 'smooth' }); // Programmatically scroll to top
+            setTimeout(() => {
+              isAdjustingScroll.current = false; // Allow scroll handling again
+            }, TRANSITION_DURATION + 150); // Wait for scroll to complete
+          }
         }
       }
     }
-  }, [headerState]); // Depend on headerState to get its latest value
+  }, [headerState, isArtistsPage]); // Depend on headerState to get its latest value
 
   // Optimized scroll handler with requestAnimationFrame
   const optimizedScrollHandler = useCallback(() => {
@@ -272,7 +275,9 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
           onClick={() => {
             // This click dismisses the overlay and sets header state.
             // MainLayout's handleScroll logic will then re-evaluate the scroll position.
-            forceHeaderState(window.scrollY > SCROLL_THRESHOLD_DOWN ? 'compacted' : 'initial', window.scrollY > 0 ? undefined : 0);
+            const targetState = isArtistsPage || window.scrollY > SCROLL_THRESHOLD_DOWN ? 'compacted' : 'initial';
+            const scrollTarget = !isArtistsPage && window.scrollY === 0 ? 0 : undefined;
+            forceHeaderState(targetState, scrollTarget);
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- keep header in compact mode on artist pages unless user expands search
- hide filter button when artist page search bar is expanded

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: NotificationDrawer.test.tsx due to unexpected token and multiple other failures)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f330aa4832e89a4fb06cf817645