### PR TITLE
fix: pass booking request prop correctly

### DIFF
--- a/frontend/src/app/dashboard/client/page.tsx
+++ b/frontend/src/app/dashboard/client/page.tsx
@@ -98,7 +98,7 @@ export default function ClientDashboardPage() {
               <SectionList
                 title="Booking Requests"
                 data={bookingRequests}
-                renderItem={(r) => <BookingRequestCard key={r.id} request={r} onUpdate={() => {}} />}
+                renderItem={(r) => <BookingRequestCard req={r} />}
                 emptyState={<span>No requests yet</span>}
               />
             </section>


### PR DESCRIPTION
## Summary
- fix client dashboard to pass the correct `req` prop to `BookingRequestCard`

## Testing
- `npx jest src/components/dashboard/__tests__/BookingRequestCard.test.tsx --maxWorkers=50%`
- `npm test -- src/hooks/__tests__/getNotificationDisplayProps.test.ts` *(fails: expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_688f78c0ee34832eb5d4e2f71413bf86