### PR TITLE
refactor: load google maps once

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,14 +317,12 @@ The `next.config.js` file now explicitly includes `/static/cover_photos/**` and
 `/static/portfolio_images/**` alongside `/static/profile_pics/**` in its
 `remotePatterns` list.
 
-The location input now reuses the `LocationInput` component powered by the
-`react-google-autocomplete` package. It matches the styling and behaviour of the
-homepage and artist page search bars. The Google Maps script still loads lazily
-via the `loadPlaces()` helper so it is only injected once and avoids the "API
-included multiple times" warning.
-`LocationInput` waits for this helper to resolve before creating the
-autocomplete service. When the API key is missing the field degrades to a plain
-text input instead of throwing a runtime error.
+The location input now reuses the `LocationInput` component which directly
+invokes the Google Places API via the shared `loadPlaces()` helper. This keeps
+styling and behaviour consistent with the homepage and artist page search bars
+while ensuring the Maps script is injected only once, avoiding the
+"API included multiple times" warning. When the API key is missing the field
+degrades to a plain text input instead of throwing a runtime error.
 
 The **Edit Profile** page now uses this same component and requires a location
 to be entered so travel fees can be estimated correctly.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -75,22 +75,36 @@ jest.mock('@react-google-maps/api', () => {
 });
 
 
-// Stub Places Autocomplete used by LocationStep
+// Stub Google Maps objects used across tests
 const mockAutocomplete = jest.fn(function Autocomplete(this: any) {
   this.getPlace = jest.fn();
   this.addListener = jest.fn((evt: string, cb: () => void) => {
     if (evt === 'place_changed') this._cb = cb;
   });
 });
+const mockAutocompleteService = jest.fn(function AutocompleteService(this: any) {
+  this.getPlacePredictions = jest.fn();
+});
+const mockPlacesService = jest.fn(function PlacesService(this: any) {
+  this.getDetails = jest.fn();
+});
 (globalThis as any).google = {
   maps: {
+    LatLng: function LatLng(lat: number, lng: number) {
+      return { lat: () => lat, lng: () => lng } as any;
+    },
     places: {
       Autocomplete: mockAutocomplete,
+      AutocompleteService: mockAutocompleteService,
+      PlacesService: mockPlacesService,
+      PlacesServiceStatus: { OK: 'OK' },
       AutocompleteSessionToken: jest.fn(),
     },
   },
 };
 (globalThis as any).mockAutocomplete = mockAutocomplete;
+(globalThis as any).mockAutocompleteService = mockAutocompleteService;
+(globalThis as any).mockPlacesService = mockPlacesService;
 
 // Stub gmpx-place-autocomplete web component used in LocationMapModal
 class GmpxPlaceAutocomplete extends HTMLElement {

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -17,12 +17,15 @@ jest.mock('next/dynamic', () => () => {
   return Stub;
 });
 
-jest.mock('@/lib/loadPlaces', () => ({ loadPlaces: () => Promise.resolve({}) }));
-
-jest.mock('react-google-autocomplete/lib/usePlacesAutocompleteService', () => () => ({
-  placesService: null,
-  placePredictions: [],
-  getPlacePredictions: jest.fn(),
+jest.mock('@/lib/loadPlaces', () => ({
+  loadPlaces: () =>
+    Promise.resolve({
+      AutocompleteService: function () {
+        this.getPlacePredictions = jest.fn();
+      },
+      PlacesService: function () {},
+      AutocompleteSessionToken: function () {},
+    }),
 }));
 
 describe('SearchBar', () => {

--- a/frontend/src/types/modules.d.ts
+++ b/frontend/src/types/modules.d.ts
@@ -1,3 +1,2 @@
 declare module 'react-datepicker';
-declare module 'react-google-autocomplete/lib/usePlacesAutocompleteService';
 declare module 'react-window';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,6 @@
   "packages": {
     "": {
       "name": "booking-app-root",
-      "dependencies": {
-        "react-google-autocomplete": "^2.7.5"
-      },
       "devDependencies": {
         "@types/react-datepicker": "^7.0.0",
         "autoprefixer": "^10.4.21",
@@ -214,27 +211,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -264,14 +240,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -316,20 +284,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -362,23 +321,6 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
-    },
-    "node_modules/react-google-autocomplete": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/react-google-autocomplete/-/react-google-autocomplete-2.7.5.tgz",
-      "integrity": "sha512-CPHMFBCgaJER19iA/y9Isjxh5au8mRxkt6przu9miOHLqrno+ifwJGXQOzMvtwdqNPXhb5Z6jpTtiJrbFeUvHg==",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "prop-types": "^15.5.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/scheduler": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11"
-  },
-  "dependencies": {
-    "react-google-autocomplete": "^2.7.5"
   }
 }


### PR DESCRIPTION
## Summary
- replace third-party autocomplete hook with direct Google Places API loading
- mock Google Maps objects in test setup and tests
- document new loader-based approach

## Testing
- `./scripts/test-all.sh` *(no tests executed)*
- `npm test -- src/components/ui/__tests__/LocationInput.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688f982acb08832eb022e528a7e56655