### PR TITLE
Require login before booking submission

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import * as yup from 'yup';
 
 import { useBooking } from '@/contexts/BookingContext';
+import { useAuth } from '@/contexts/AuthContext';
 import useIsMobile from '@/hooks/useIsMobile';
 import useBookingForm from '@/hooks/useBookingForm';
 import {
@@ -122,6 +123,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     setTravelResult,
     loadSavedProgress,
   } = useBooking();
+  const { user } = useAuth();
 
   // --- Component States ---
   const [unavailable, setUnavailable] = useState<string[]>([]);
@@ -337,6 +339,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
   // Handles final submission of the booking request
   const submitRequest = handleSubmit(async (vals: EventDetails) => {
+    if (!user) {
+      const wantsLogin = window.confirm(
+        'You need an account to submit a booking request. Press OK to sign in or Cancel to sign up.'
+      );
+      router.push(wantsLogin ? '/login' : '/register');
+      return;
+    }
     if (isLoadingReviewData || reviewDataError || calculatedPrice === null || travelResult === null) {
       setValidationError('Review data is not ready. Please wait or check for errors before submitting.');
       return;

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { act } from "react";
 import BookingWizard from "../BookingWizard";
 import { BookingProvider, useBooking } from "@/contexts/BookingContext";
+import { useAuth } from "@/contexts/AuthContext";
 import * as api from "@/lib/api";
 import { geocodeAddress } from "@/lib/geo";
 import { calculateTravelMode, getDrivingMetrics } from "@/lib/travel";
@@ -11,6 +12,7 @@ import { calculateTravelMode, getDrivingMetrics } from "@/lib/travel";
 jest.mock("@/lib/api");
 jest.mock("@/lib/geo");
 jest.mock("@/lib/travel");
+jest.mock("@/contexts/AuthContext");
 
 function Wrapper({ serviceId }: { serviceId?: number } = {}) {
   return (
@@ -44,8 +46,10 @@ function ExposeSetter() {
 describe("BookingWizard flow", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
+  const mockUseAuth = useAuth as jest.Mock;
 
   beforeEach(async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 1 } });
     Object.defineProperty(window, "innerWidth", { value: 500, writable: true });
     (api.getArtistAvailability as jest.Mock).mockResolvedValue({
       data: { unavailable_dates: [] },
@@ -84,6 +88,7 @@ describe("BookingWizard flow", () => {
     });
     container.remove();
     jest.clearAllMocks();
+    mockUseAuth.mockReset();
   });
 
   function getButton(label: string): HTMLButtonElement {


### PR DESCRIPTION
## Summary
- ensure booking submission requires login and redirect to sign-in/sign-up
- update BookingWizard tests to mock auth context

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688fa135aa6c832e8c1e90b76f7230bb