### PR TITLE
fix: ensure search popup overlays header

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -189,7 +189,8 @@ export default function SearchBar({
         <>
           {/* Overlay for SearchBar's internal popups (dims the page area around the popup) */}
           <div
-            className="fixed inset-0 bg-black bg-opacity-30 z-[46] cursor-pointer animate-fadeIn"
+            // z-[51] so overlay also covers the header (z-50)
+            className="fixed inset-0 bg-black bg-opacity-30 z-[51] cursor-pointer animate-fadeIn"
             aria-hidden="true"
             onClick={closeThisSearchBarsInternalPopups}
           />
@@ -208,7 +209,8 @@ export default function SearchBar({
             <div
               ref={popupContainerRef}
               className={clsx(
-                "absolute rounded-xl bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 z-[47]",
+                // z-[52] so popup appears above header (z-50) and overlay (z-[51])
+                "absolute rounded-xl bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 z-[52]",
                 "origin-top-left"
               )}
               role="dialog"


### PR DESCRIPTION
## Summary
- ensure SearchBar popup and overlay render above the header

## Testing
- `FAST=1 ./scripts/test-all.sh`
- `npm test src/components/booking/steps/__tests__/ReviewStep.test.tsx -- --runTestsByPath` *(fails: h3 count)*

------
https://chatgpt.com/codex/tasks/task_e_689061aa6424832e9bb8b848baac6771