### PR TITLE
Trim location details in compact search

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 ### Search Interface
 
-The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden.
+The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.
 
 ### Loading Indicators
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -17,6 +17,7 @@ import { Avatar } from '../ui'; // Assuming Avatar is set up
 import clsx from 'clsx';
 import { type Category } from '../search/SearchFields'; // Import Category type from SearchFields
 import { parseISO, isValid } from 'date-fns';
+import { getStreetFromAddress } from '@/lib/utils';
 
 
 // Define header states (must match MainLayout)
@@ -226,7 +227,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                       {category ? category.label : 'Add artist'}
                     </div>
                     <div className="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis">
-                      {location || 'Add location'}
+                      {location ? getStreetFromAddress(location) : 'Add location'}
                     </div>
                     <div className="flex-1 px-2 truncate">
                       {when ? dateFormatter.format(when) : 'Add dates'}

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -115,4 +115,23 @@ describe('Header', () => {
     act(() => root.unmount());
     div.remove();
   });
+
+  it('shows only street name in compact pill when location contains commas', async () => {
+    mockUseSearchParams.mockReturnValue(
+      new URLSearchParams('location=123%20Main%20St%2C%20Cape%20Town%2C%20South%20Africa'),
+    );
+    const { div, root } = render();
+    await act(async () => {
+      root.render(
+        <Header headerState="compacted" onForceHeaderState={jest.fn()} />,
+      );
+    });
+    await flushPromises();
+    const trigger = div.querySelector('#compact-search-trigger') as HTMLButtonElement;
+    expect(trigger.textContent).toContain('123 Main St');
+    expect(trigger.textContent).not.toContain('Cape Town');
+    act(() => root.unmount());
+    div.remove();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  });
 });

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -3,6 +3,7 @@
 
 import { forwardRef, useRef } from 'react';
 import clsx from 'clsx';
+import { getStreetFromAddress } from '@/lib/utils';
 
 // Import types for consistency
 import type { ActivePopup } from './SearchBar'; // Assuming SearchBar defines ActivePopup
@@ -120,7 +121,7 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
       {renderField(
         'location',
         'Where',
-          location || 'Add location',
+          (compact && location ? getStreetFromAddress(location) : location) || 'Add location',
           locationButtonRef,
           () => setLocation('')
         )}

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ import {
   formatStatus,
   generateQuoteNumber,
   applyDisplayOrder,
+  getStreetFromAddress,
 } from '../utils';
 import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
@@ -163,6 +164,16 @@ describe('formatStatus', () => {
 
   it('humanises unknown values', () => {
     expect(formatStatus('foo_bar')).toBe('Foo Bar');
+  });
+});
+
+describe('getStreetFromAddress', () => {
+  it('returns text before the first comma', () => {
+    expect(getStreetFromAddress('123 Main St, Cape Town, South Africa')).toBe('123 Main St');
+  });
+
+  it('returns original when no comma is present', () => {
+    expect(getStreetFromAddress('Cape Town')).toBe('Cape Town');
   });
 });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -94,6 +94,16 @@ export const authAwareMessage = (
   return fallback;
 };
 
+/**
+ * Return only the street portion of a full address string.
+ * Useful for compact UI where space is limited.
+ */
+export const getStreetFromAddress = (address: string): string => {
+  if (!address) return '';
+  const [street] = address.split(',');
+  return street.trim();
+};
+
 export const normalizeQuoteTemplate = (
   tmpl: QuoteTemplate,
 ): QuoteTemplate => ({


### PR DESCRIPTION
## Summary
- show only the street portion of an address when search bar is compact
- provide helper to extract street name from full address
- test that compact header pill trims location values

## Testing
- `./scripts/test-all.sh`
- `cd frontend && npm test src/components/layout/__tests__/Header.test.tsx src/lib/__tests__/utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689064d76008832ead80f4afd484186b