### PR TITLE
feat: show location input in search bar

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,8 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.
 
+Focusing the location input now opens a popup of suggested destinations while the cursor remains in the search bar. As soon as the user types, the popup closes and Google Places autocomplete suggestions appear directly beneath the input.
+
 ### Loading Indicators
 
 `Spinner` and `SkeletonList` components in `src/components/ui` provide

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -6,11 +6,10 @@ import ReactDatePicker from 'react-datepicker';
 import { Listbox } from '@headlessui/react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
-import LocationInput, { PlaceResult } from '../ui/LocationInput';
 import { UI_CATEGORIES } from '@/lib/categoryMap';
 
 import type { ActivePopup } from './SearchBar';
-import type { Category, SearchFieldId } from './SearchFields';
+import type { Category } from './SearchFields';
 
 interface SearchPopupContentProps {
   activeField: ActivePopup;
@@ -76,11 +75,14 @@ export default function SearchPopupContent({
     return () => clearTimeout(timer);
   }, [activeField, locationInputRef, categoryListboxOptionsRef]);
 
-  const handleLocationSelect = useCallback((place: PlaceResult) => {
-    const displayName = place.formatted_address || place.name || '';
-    setLocation(displayName);
-    closeAllPopups(); // Close popup after selection
-  }, [setLocation, closeAllPopups]);
+  const handleLocationSelect = useCallback(
+    (place: { name: string; formatted_address?: string }) => {
+      const displayName = place.formatted_address || place.name || '';
+      setLocation(displayName);
+      closeAllPopups(); // Close popup after selection
+    },
+    [setLocation, closeAllPopups],
+  );
 
   const handleCategorySelect = useCallback((c: Category | null) => {
     setCategory(c);
@@ -101,24 +103,13 @@ export default function SearchPopupContent({
   const renderLocation = () => (
     <div>
       <h3 className="text-sm font-semibold text-gray-800 mb-4" id="search-popup-label-location">Suggested destinations</h3>
-      <LocationInput
-        ref={locationInputRef}
-        value={location}
-        onValueChange={setLocation}
-        onPlaceSelect={handleLocationSelect}
-        placeholder="Search destinations"
-        inputClassName="w-full text-base border border-gray-300 rounded-lg p-3 mb-4 focus:outline-none transition-all"
-      />
-      {/* Display mock suggestions if LocationInput doesn't handle its own visual suggestions */}
-      {/* Remove `location.length === 0` if you want mock suggestions always */}
-      {/* Check if images exist in public/images or remove image paths from MOCK_LOCATION_SUGGESTIONS */}
       <ul className="grid grid-cols-2 gap-4 max-h-[300px] overflow-y-hidden scrollbar-thin">
-        {MOCK_LOCATION_SUGGESTIONS.map((s) => (
+        {filteredSuggestions.map((s) => (
           <li
             key={s.name}
             role="option"
             aria-label={`${s.name}${s.description ? `, ${s.description}` : ''}`}
-            onClick={() => handleLocationSelect({ name: s.name, formatted_address: s.description || '' })}
+            onClick={() => handleLocationSelect({ name: s.name, formatted_address: s.description })}
             className="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-100 cursor-pointer transition"
             tabIndex={0}
           >


### PR DESCRIPTION
## Summary
- render the location input directly in the SearchBar and close internal popup when typing
- show destination suggestions in popup until input changes
- document search popup behavior and update unit test expectations

## Testing
- `npx jest src/components/search/__tests__/SearchBar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689066f35d3c832e82103f8b544bf58b