### PR TITLE
fix: address SearchBar type errors

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -82,6 +82,21 @@ export default function SearchBar({
     }
   }, [showInternalPopup, activeField]); // Recalculate if popup state or active field changes
 
+  const closeThisSearchBarsInternalPopups = useCallback(() => {
+    setShowInternalPopup(false);
+    setTimeout(() => {
+      setActiveField(null);
+      if (lastActiveButtonRef.current) {
+        if (activeField === 'location' && locationInputRef.current) {
+          locationInputRef.current.focus();
+        } else {
+          lastActiveButtonRef.current.focus();
+        }
+        lastActiveButtonRef.current = null;
+      }
+    }, 200);
+  }, [activeField]);
+
   const handleLocationChange = useCallback(
     (value: string) => {
       setLocation(value);
@@ -97,29 +112,11 @@ export default function SearchBar({
     setShowInternalPopup(true);
     lastActiveButtonRef.current = buttonElement;
     // Position calculated in useLayoutEffect
-  }, [activeField]);
-
-  const closeThisSearchBarsInternalPopups = useCallback(() => {
-    setShowInternalPopup(false);
-    setTimeout(() => {
-        setActiveField(null);
-        if (lastActiveButtonRef.current) {
-            if (activeField === 'location' && locationInputRef.current) {
-                locationInputRef.current.focus();
-            } else {
-                lastActiveButtonRef.current.focus();
-            }
-            lastActiveButtonRef.current = null;
-        }
-    }, 200);
-  }, [activeField]);
+  }, []);
 
   // Close popups when clicking outside the search form or its floating content
   useClickOutside(
-    [
-      formRef as RefObject<HTMLElement | null>,
-      popupContainerRef as RefObject<HTMLElement | null>,
-    ],
+    [formRef, popupContainerRef] as Array<RefObject<HTMLElement | null>>,
     () => {
       if (showInternalPopup) {
         closeThisSearchBarsInternalPopups();

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -24,7 +24,8 @@ export interface SearchFieldsProps {
   activeField: ActivePopup;
   onFieldClick: (fieldId: SearchFieldId, element: HTMLElement) => void;
   compact?: boolean;
-  locationInputRef: React.RefObject<HTMLInputElement>;
+  // Ref forwarded to the internal location input so parent components can focus it
+  locationInputRef: React.RefObject<HTMLInputElement | null>;
 }
 
 export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(


### PR DESCRIPTION
## Summary
- define `closeThisSearchBarsInternalPopups` before use and tidy field click handler
- cast multiple refs for `useClickOutside`
- type `locationInputRef` to accept nullable HTMLInputElement

## Testing
- `./scripts/test-all.sh` (skipped tests)
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` (fails: TypeError: (0 , _navigation.useRouter) is not a function)


------
https://chatgpt.com/codex/tasks/task_e_689069cc9340832e8e4bf2c66dc930d1