### PR TITLE
fix: correct location input ref type

### DIFF
--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -26,7 +26,7 @@ export interface SearchFieldsProps {
   compact?: boolean;
   // Ref forwarded to the internal location input so parent components can focus it
   // The ref's `current` will be `null` initially but will point to the input element once mounted
-  locationInputRef: React.RefObject<HTMLInputElement>;
+  locationInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(


### PR DESCRIPTION
## Summary
- fix SearchFields to accept a mutable location input ref

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test` *(fails: ReferenceError: getArtists is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689070db14e0832eb7a3f55ce0a2184a