### PR TITLE
Fix search popups exceeding search bar width

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,6 +41,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.
 
 Focusing the location input now opens a popup of suggested destinations while the cursor remains in the search bar. As soon as the user types, the popup closes and Google Places autocomplete suggestions appear directly beneath the input.
+All popups are constrained to the search bar's width, and the location autocomplete dropdown now uses the same styling and size as the other popups.
 
 ### Loading Indicators
 

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -74,8 +74,8 @@ export default function SearchBar({
       // Calculate position relative to the viewport
       setPopupPosition({
         top: buttonRect.bottom + window.scrollY + 8, // 8px margin below button
-        left: buttonRect.left + window.scrollX,
-        width: formRect.width // Make popup same width as the entire search bar form
+        left: formRect.left + window.scrollX, // Align popup with the SearchBar's left edge
+        width: formRect.width, // Popup matches the SearchBar width
       });
     } else {
       setPopupPosition(null); // Clear position when popup is not visible

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -248,7 +248,7 @@ const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
           <div
             id={listboxId}
             role="listbox"
-            className="pac-container absolute z-50 mt-2 w-full max-h-60 overflow-auto rounded-lg bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 scrollbar-thin"
+            className="pac-container absolute left-0 z-50 mt-2 w-full max-h-60 overflow-auto rounded-xl bg-white p-2 shadow-xl ring-1 ring-black ring-opacity-5 scrollbar-thin"
           >
             {predictions.map((prediction, index) => {
               const isActive = index === highlightedIndex;
@@ -264,7 +264,7 @@ const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
                   onMouseDown={() => handleSelect(prediction)}
                   className={clsx(
                     'flex items-center px-4 py-2 text-sm cursor-pointer',
-                    isActive ? 'bg-indigo-100' : 'hover:bg-indigo-50'
+                    isActive ? 'bg-gray-100' : 'hover:bg-gray-50'
                   )}
                   data-testid="location-option"
                 >


### PR DESCRIPTION
## Summary
- align all search popups to the search bar's width
- style LocationInput dropdown to match other popups
- document popup width behavior in frontend README

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test` *(fails: multiple test suites)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689077b66674832e94fb824e45be8ca1