### PR TITLE
feat(search): unify location popup styling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,8 +40,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.
 
-Focusing the location input now opens a popup of suggested destinations while the cursor remains in the search bar. As soon as the user types, the popup closes and Google Places autocomplete suggestions appear directly beneath the input.
-All popups are constrained to the search bar's width, and the location autocomplete dropdown now uses the same styling and size as the other popups.
+Clicking the location field now opens a popup that contains the location input alongside suggested destinations. This popup shares the same styling and width as the date and category popups so the search bar feels consistent. The booking flow's Location step continues to use the original `LocationInput` styling.
 
 ### Loading Indicators
 

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -87,25 +87,11 @@ export default function SearchBar({
     setTimeout(() => {
       setActiveField(null);
       if (lastActiveButtonRef.current) {
-        if (activeField === 'location' && locationInputRef.current) {
-          locationInputRef.current.focus();
-        } else {
-          lastActiveButtonRef.current.focus();
-        }
+        lastActiveButtonRef.current.focus();
         lastActiveButtonRef.current = null;
       }
     }, 200);
-  }, [activeField]);
-
-  const handleLocationChange = useCallback(
-    (value: string) => {
-      setLocation(value);
-      if (showInternalPopup && activeField === 'location') {
-        closeThisSearchBarsInternalPopups();
-      }
-    },
-    [setLocation, showInternalPopup, activeField, closeThisSearchBarsInternalPopups],
-  );
+  }, []);
 
   const handleFieldClick = useCallback(
     (fieldId: SearchFieldId, element: HTMLElement) => {
@@ -170,12 +156,11 @@ export default function SearchBar({
           category={category}
           setCategory={setCategory}
           location={location}
-          setLocation={handleLocationChange}
+          setLocation={setLocation}
           when={when}
           setWhen={setWhen}
           activeField={activeField}
           onFieldClick={handleFieldClick}
-          locationInputRef={locationInputRef}
           compact={compact}
         />
         <button

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -3,7 +3,6 @@
 
 import { forwardRef, useRef } from 'react';
 import clsx from 'clsx';
-import LocationInput, { PlaceResult } from '../ui/LocationInput';
 
 // Import types for consistency
 import type { ActivePopup } from './SearchBar'; // Assuming SearchBar defines ActivePopup
@@ -24,9 +23,6 @@ export interface SearchFieldsProps {
   activeField: ActivePopup;
   onFieldClick: (fieldId: SearchFieldId, element: HTMLElement) => void;
   compact?: boolean;
-  // Ref forwarded to the internal location input so parent components can focus it
-  // The ref's `current` will be `null` initially but will point to the input element once mounted
-  locationInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
@@ -41,13 +37,12 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
       activeField,
       onFieldClick,
       compact = false,
-      locationInputRef,
     },
     ref
   ) => {
     // Individual refs for each field's button element to store and return focus
     const categoryButtonRef = useRef<HTMLButtonElement>(null);
-    const locationContainerRef = useRef<HTMLDivElement>(null);
+    const locationButtonRef = useRef<HTMLButtonElement>(null);
     const whenButtonRef = useRef<HTMLButtonElement>(null);
 
     // Helper to render a generic search field button
@@ -122,50 +117,13 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
 
   return (
     <div ref={ref} className="flex flex-1 divide-x divide-gray-200">
-      {/* Location field now uses a direct input instead of a button */}
-      <div
-        ref={locationContainerRef}
-        className={clsx(
-          'relative flex-1 min-w-0 transition-all duration-200 ease-out',
-          compact ? 'px-4 py-2' : 'px-6 py-3',
-          activeField === 'location'
-            ? 'bg-gray-100 shadow-md'
-            : 'hover:bg-gray-50 focus-within:bg-gray-50',
-        )}
-        onFocus={() => onFieldClick('location', locationContainerRef.current!)}
-        onClick={() => locationInputRef.current?.focus()}
-      >
-        <span className="text-sm text-gray-700 font-semibold pointer-events-none select-none">Where</span>
-        <LocationInput
-          ref={locationInputRef}
-          value={location}
-          onValueChange={setLocation}
-          onPlaceSelect={(place: PlaceResult) => setLocation(place.formatted_address || place.name || '')}
-          placeholder="Add location"
-          className="w-full"
-          inputClassName={clsx(
-            'block truncate p-0 bg-transparent',
-            location ? 'text-gray-800' : 'text-gray-500',
-            compact ? 'text-sm' : 'text-base text-xs',
-          )}
-        />
-
-        {location && activeField !== 'location' && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setLocation('');
-              locationInputRef.current?.focus();
-            }}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none rounded-full p-1 z-20 transition-transform active:scale-90"
-            aria-label="Clear location"
-            title="Clear location"
-          >
-            &times;
-          </button>
-        )}
-      </div>
+      {renderField(
+        'location',
+        'Where',
+        location ? location : 'Add location',
+        locationButtonRef,
+        () => setLocation('')
+      )}
 
       <div className="border-l border-gray-200" />
 
@@ -177,14 +135,14 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
         () => setWhen(null)
       )}
 
-        <div className="border-l border-gray-200" />
+      <div className="border-l border-gray-200" />
 
-        {renderField(
-          'category',
-          'Category',
-          category ? category.label : 'Add artist',
-          categoryButtonRef,
-          () => setCategory(null)
+      {renderField(
+        'category',
+        'Category',
+        category ? category.label : 'Add artist',
+        categoryButtonRef,
+        () => setCategory(null)
       )}
     </div>
   );

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -7,6 +7,7 @@ import { Listbox } from '@headlessui/react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { UI_CATEGORIES } from '@/lib/categoryMap';
+import LocationInput, { PlaceResult } from '../ui/LocationInput';
 
 import type { ActivePopup } from './SearchBar';
 import type { Category } from './SearchFields';
@@ -34,7 +35,7 @@ type CustomHeaderProps = {
 
 // MOCK data for location suggestions (ensure images exist or remove image paths)
 const MOCK_LOCATION_SUGGESTIONS = [
-  { name: 'Nearby', description: 'Find what\'s around you', image: '/images/location-nearby.png' },
+  { name: 'Nearby', description: "Find what's around you", image: '/images/location-nearby.png' },
   { name: 'Stellenbosch', description: 'Western Cape', image: '/images/location-stellenbosch.png' },
   { name: 'Langebaan', description: 'For nature-lovers', image: '/images/location-langebaan.png' },
   { name: 'Onrus', description: 'Popular with travelers near you', image: '/images/location-onrus.png' },
@@ -76,10 +77,10 @@ export default function SearchPopupContent({
   }, [activeField, locationInputRef, categoryListboxOptionsRef]);
 
   const handleLocationSelect = useCallback(
-    (place: { name: string; formatted_address?: string }) => {
+    (place: PlaceResult) => {
       const displayName = place.formatted_address || place.name || '';
       setLocation(displayName);
-      closeAllPopups(); // Close popup after selection
+      closeAllPopups();
     },
     [setLocation, closeAllPopups],
   );
@@ -102,12 +103,24 @@ export default function SearchPopupContent({
 
   const renderLocation = () => (
     <div>
-      <h3 className="text-sm font-semibold text-gray-800 mb-4" id="search-popup-label-location">Suggested destinations</h3>
-      <ul className="grid grid-cols-2 gap-4 max-h-[300px] overflow-y-hidden scrollbar-thin">
+      <h3 className="text-sm font-semibold text-gray-800 mb-2" id="search-popup-label-location">
+        Where
+      </h3>
+      <LocationInput
+        ref={locationInputRef}
+        value={location}
+        onValueChange={setLocation}
+        onPlaceSelect={handleLocationSelect}
+        placeholder="Search location"
+        className="mb-4"
+        inputClassName="w-full"
+      />
+      <ul className="grid grid-cols-2 gap-4 max-h-[300px] overflow-y-auto scrollbar-thin">
         {filteredSuggestions.map((s) => (
           <li
             key={s.name}
             role="option"
+            aria-selected="false"
             aria-label={`${s.name}${s.description ? `, ${s.description}` : ''}`}
             onClick={() => handleLocationSelect({ name: s.name, formatted_address: s.description })}
             className="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-100 cursor-pointer transition"

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@/lib/loadPlaces', () => ({
 }));
 
 describe('SearchBar', () => {
-  it('shows suggestions on focus and hides them on typing', async () => {
+  it('shows suggestions on click and hides them on escape', async () => {
     const onSearch = jest.fn();
     const Wrapper = () => {
       const [category, setCategory] = React.useState(null);
@@ -40,14 +40,15 @@ describe('SearchBar', () => {
       );
     };
 
-    const { getByPlaceholderText, queryAllByRole } = render(<Wrapper />);
+    const { getByText, getByRole, queryAllByRole } = render(<Wrapper />);
 
-    const input = getByPlaceholderText('Add location');
-    fireEvent.focus(input);
+    const button = getByText('Add location');
+    fireEvent.click(button);
 
     expect(queryAllByRole('dialog').length).toBeGreaterThan(0);
 
-    fireEvent.change(input, { target: { value: 'Cape' } });
+    const form = getByRole('search');
+    fireEvent.keyDown(form, { key: 'Escape' });
 
     await waitFor(() => expect(queryAllByRole('dialog').length).toBe(0));
   });


### PR DESCRIPTION
## Summary
- style location search like other popup fields
- add LocationInput inside popup and simplify SearchBar handling
- clarify search interface documentation

## Testing
- `npm --prefix frontend test frontend/src/components/search/__tests__/SearchBar.test.tsx`
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm --prefix frontend run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689079ecd268832eb4d8c627cfd9cb8a