### PR TITLE
Hide location suggestions after typing

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,7 +40,7 @@ See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary o
 
 The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.
 
-Focusing the location input now opens a popup of suggested destinations while the cursor remains in the search bar. As soon as the user types, the popup closes and Google Places autocomplete suggestions appear directly beneath the input.
+Focusing the location input opens a popup of suggested destinations while the cursor remains in the search bar. Once the user types, this popup closes and will not reappear, while Google Places autocomplete suggestions show directly beneath the input.
 All popups are constrained to the search bar's width, and the location autocomplete dropdown now uses the same styling and size as the other popups.
 
 ### Loading Indicators

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -55,6 +55,9 @@ export default function SearchBar({
   const [isSubmitting, setSubmitting] = useState(false);
   const [activeField, setActiveField] = useState<ActivePopup>(null);
   const [showInternalPopup, setShowInternalPopup] = useState(false);
+  // Tracks if the user has typed in the location field so that suggested destinations
+  // popup does not reappear once dismissed
+  const [locationPopupDismissed, setLocationPopupDismissed] = useState(false);
 
   // NEW: State to store the position of the clicked field and width of the search bar
   const [popupPosition, setPopupPosition] = useState<{ top: number; left: number; width: number; } | null>(null);
@@ -100,22 +103,34 @@ export default function SearchBar({
   const handleLocationChange = useCallback(
     (value: string) => {
       setLocation(value);
+      if (!locationPopupDismissed && value.trim().length > 0) {
+        setLocationPopupDismissed(true);
+      }
       if (showInternalPopup && activeField === 'location') {
         closeThisSearchBarsInternalPopups();
       }
     },
-    [setLocation, showInternalPopup, activeField, closeThisSearchBarsInternalPopups],
+    [
+      setLocation,
+      showInternalPopup,
+      activeField,
+      closeThisSearchBarsInternalPopups,
+      locationPopupDismissed,
+    ],
   );
 
   const handleFieldClick = useCallback(
     (fieldId: SearchFieldId, element: HTMLElement) => {
+      if (fieldId === 'location' && locationPopupDismissed) {
+        return;
+      }
       setActiveField(fieldId);
       setShowInternalPopup(true);
       // Store the element that triggered the popup so we can restore focus later
       lastActiveButtonRef.current = element;
       // Position is calculated in useLayoutEffect
     },
-    [],
+    [locationPopupDismissed],
   );
 
   // Close popups when clicking outside the search form or its floating content

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -50,5 +50,10 @@ describe('SearchBar', () => {
     fireEvent.change(input, { target: { value: 'Cape' } });
 
     await waitFor(() => expect(queryAllByRole('dialog').length).toBe(0));
+
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+
+    await waitFor(() => expect(queryAllByRole('dialog').length).toBe(0));
   });
 });


### PR DESCRIPTION
## Summary
- prevent location suggestion popup from reappearing after user begins typing
- document that typing permanently dismisses suggestions
- test that refocusing after typing keeps suggestions hidden

## Testing
- `npx jest src/components/search/__tests__/SearchBar.test.tsx --maxWorkers=50%`
- `./scripts/test-all.sh` *(fails: TypeError: useSearchParams is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68907eaab678832e844786640272c713