### PR TITLE
Align search calendar popup width with other search popups

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -75,7 +75,7 @@ export default function SearchBar({
       const buttonRect = lastActiveButtonRef.current.getBoundingClientRect(); // Coords of clicked button
       const formRect = formRef.current.getBoundingClientRect(); // Coords of the whole search bar
 
-      let top = buttonRect.bottom + window.scrollY + 8; // Default 8px margin below button
+      const top = buttonRect.bottom + window.scrollY + 8; // Default 8px margin below button
       let left = formRect.left + window.scrollX; // Default align with SearchBar's left edge
       let width = formRect.width; // Default popup width equals SearchBar width
       let height: number | undefined;
@@ -85,12 +85,8 @@ export default function SearchBar({
       } else if (activeField === 'category') {
         width = formRect.width / 2; // Half width anchored right
         left = formRect.left + window.scrollX + formRect.width / 2;
-      } else if (activeField === 'when') {
-        top = window.scrollY; // Full-screen overlay starts at top of viewport
-        left = window.scrollX; // Align to left edge of viewport
-        width = window.innerWidth; // Full screen width
-        height = window.innerHeight; // Full screen height
       }
+      // The 'when' popup spans the entire SearchBar width without taking over the screen
 
       setPopupPosition({ top, left, width, height });
     } else {

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -108,6 +108,7 @@ export default function SearchPopupContent({
           <li
             key={s.name}
             role="option"
+            aria-selected="false"
             aria-label={`${s.name}${s.description ? `, ${s.description}` : ''}`}
             onClick={() => handleLocationSelect({ name: s.name, formatted_address: s.description })}
             className="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-100 cursor-pointer transition"
@@ -137,7 +138,7 @@ export default function SearchPopupContent({
     }
 
     return (
-      <div className="flex justify-center items-center w-full h-full">
+      <div className="flex justify-center items-center w-full">
         <h3 className="text-sm font-semibold text-gray-800 sr-only" id="search-popup-label-when">Select date</h3>
         <ReactDatePicker
           selected={when}
@@ -216,7 +217,7 @@ export default function SearchPopupContent({
   const renderDefault = () => (
     <div className="text-center text-gray-500 py-8">
       <h3 className="text-lg font-semibold mb-2" id="search-popup-label-default">Find artists for your event!</h3>
-      <p className="text-sm">Click 'Where', 'When', or 'Category' to start.</p>
+      <p className="text-sm">Click &quot;Where&quot;, &quot;When&quot;, or &quot;Category&quot; to start.</p>
       <div className="mt-6">
         <h4 className="text-md font-semibold text-gray-700 mb-3">Popular Artist Locations</h4>
         <ul className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- keep calendar popup the same style as other search popups while spanning the full search bar width
- tweak popup content styles and accessibility

## Testing
- `npx eslint src/components/search/SearchBar.tsx src/components/search/SearchPopupContent.tsx`
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function, etc.)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(39 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_689084d7fca8832ebfbb54eda7defd9f