### PR TITLE
feat(search): unify location suggestions

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -55,9 +55,8 @@ export default function SearchBar({
   const [isSubmitting, setSubmitting] = useState(false);
   const [activeField, setActiveField] = useState<ActivePopup>(null);
   const [showInternalPopup, setShowInternalPopup] = useState(false);
-  // Tracks if the user has typed in the location field so that suggested destinations
-  // popup does not reappear once dismissed
-  const [locationPopupDismissed, setLocationPopupDismissed] = useState(false);
+  const [locationPredictions, setLocationPredictions] =
+    useState<google.maps.places.AutocompletePrediction[]>([]);
 
   // NEW: State to store the position and size of the popup
   const [popupPosition, setPopupPosition] =
@@ -112,34 +111,19 @@ export default function SearchBar({
   const handleLocationChange = useCallback(
     (value: string) => {
       setLocation(value);
-      if (!locationPopupDismissed && value.trim().length > 0) {
-        setLocationPopupDismissed(true);
-      }
-      if (showInternalPopup && activeField === 'location') {
-        closeThisSearchBarsInternalPopups();
-      }
     },
-    [
-      setLocation,
-      showInternalPopup,
-      activeField,
-      closeThisSearchBarsInternalPopups,
-      locationPopupDismissed,
-    ],
+    [setLocation],
   );
 
   const handleFieldClick = useCallback(
     (fieldId: SearchFieldId, element: HTMLElement) => {
-      if (fieldId === 'location' && locationPopupDismissed) {
-        return;
-      }
       setActiveField(fieldId);
       setShowInternalPopup(true);
       // Store the element that triggered the popup so we can restore focus later
       lastActiveButtonRef.current = element;
       // Position is calculated in useLayoutEffect
     },
-    [locationPopupDismissed],
+    [],
   );
 
   // Close popups when clicking outside the search form or its floating content
@@ -201,6 +185,7 @@ export default function SearchBar({
           onFieldClick={handleFieldClick}
           locationInputRef={locationInputRef}
           compact={compact}
+          onPredictionsChange={setLocationPredictions}
         />
         <button
           type="submit"
@@ -276,6 +261,7 @@ export default function SearchBar({
                   closeAllPopups={closeThisSearchBarsInternalPopups}
                   locationInputRef={locationInputRef}
                   categoryListboxOptionsRef={categoryListboxOptionsRef}
+                  locationPredictions={locationPredictions}
                 />
               )}
             </div>

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -27,6 +27,9 @@ export interface SearchFieldsProps {
   // Ref forwarded to the internal location input so parent components can focus it
   // The ref's `current` will be `null` initially but will point to the input element once mounted
   locationInputRef: React.MutableRefObject<HTMLInputElement | null>;
+  onPredictionsChange: (
+    predictions: google.maps.places.AutocompletePrediction[],
+  ) => void;
 }
 
 export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
@@ -42,6 +45,7 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
       onFieldClick,
       compact = false,
       locationInputRef,
+      onPredictionsChange,
     },
     ref
   ) => {
@@ -148,6 +152,8 @@ export const SearchFields = forwardRef<HTMLDivElement, SearchFieldsProps>(
             location ? 'text-gray-800' : 'text-gray-500',
             compact ? 'text-sm' : 'text-base text-xs',
           )}
+          showDropdown={false}
+          onPredictionsChange={onPredictionsChange}
         />
 
         {location && activeField !== 'location' && (

--- a/frontend/src/components/search/SearchModal.tsx
+++ b/frontend/src/components/search/SearchModal.tsx
@@ -74,6 +74,7 @@ export default function SearchModal({
           activeField={null}
           onFieldClick={handleFieldClick}
           locationInputRef={locationInputRef}
+          onPredictionsChange={() => {}}
         />
         <div className="flex justify-between pt-4">
           <button

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -6,7 +6,7 @@ import SearchBar from '../SearchBar';
 jest.mock('next/dynamic', () => () => {
   const Stub = ({ activeField }: { activeField: string }) =>
     activeField === 'location' ? <div role="dialog">Suggestions</div> : null;
-  return Stub;
+  return Stub as React.FC<any>;
 });
 
 jest.mock('@/lib/loadPlaces', () => ({
@@ -21,7 +21,7 @@ jest.mock('@/lib/loadPlaces', () => ({
 }));
 
 describe('SearchBar', () => {
-  it('shows suggestions on focus and hides them on typing', async () => {
+  it('keeps suggestions visible when typing in location', async () => {
     const onSearch = jest.fn();
     const Wrapper = () => {
       const [category, setCategory] = React.useState(null);
@@ -49,11 +49,6 @@ describe('SearchBar', () => {
 
     fireEvent.change(input, { target: { value: 'Cape' } });
 
-    await waitFor(() => expect(queryAllByRole('dialog').length).toBe(0));
-
-    fireEvent.blur(input);
-    fireEvent.focus(input);
-
-    await waitFor(() => expect(queryAllByRole('dialog').length).toBe(0));
+    await waitFor(() => expect(queryAllByRole('dialog').length).toBeGreaterThan(0));
   });
 });


### PR DESCRIPTION
## Summary
- keep search popup open while typing and show Google predictions
- feed predictions from LocationInput into popup content
- expose LocationInput predictions via callback to parent components

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd frontend && npx jest src/components/ui/__tests__/Stepper.test.tsx --runInBand` *(fails: Stepper progress bar — renders steps and highlights the current one)*

------
https://chatgpt.com/codex/tasks/task_e_68908ba210d8832e82d597c7853fd288