### PR TITLE
feat: handle prediction updates in search fields

### DIFF
--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -27,7 +27,12 @@ export interface SearchFieldsProps {
   // Ref forwarded to the internal location input so parent components can focus it
   // The ref's `current` will be `null` initially but will point to the input element once mounted
   locationInputRef: React.MutableRefObject<HTMLInputElement | null>;
-  onPredictionsChange: (
+  /**
+   * Callback fired whenever the Google Places autocomplete predictions update.
+   * Made optional so callers that do not need prediction data do not have to
+   * provide a handler.
+   */
+  onPredictionsChange?: (
     predictions: google.maps.places.AutocompletePrediction[],
   ) => void;
 }


### PR DESCRIPTION
## Summary
- allow SearchFields to receive optional onPredictionsChange callback for location autocomplete

## Testing
- `./scripts/test-all.sh` (fails: Test run aborted)
- `npm run lint` (fails: ESLint reported 13 errors)


------
https://chatgpt.com/codex/tasks/task_e_689090b03adc832ebebeedd4d9e71de2