### PR TITLE
Fix chat header to show correct participant

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Consecutive messages from the same sender now group together, showing the
   relative time only below the last bubble.
 * 1-on-1 threads show the participant avatar and name only in the header for a cleaner look.
+* Chat headers now display the other participant's name so clients see the artist's business name and artists see the client's name.
 * Fixed input bar & auto-scroll on mobile.
 * Desktop bubbles expand wider to avoid unnecessary line breaks.
 * Floating “scroll to latest” button on small screens.

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -114,7 +114,26 @@ export default function MessageThreadWrapper({
       <header className="sticky top-0 z-10 bg-gradient-to-r from-red-600 to-indigo-700 text-white px-4 py-2 flex items-center  md:min-h-[64px]">
         <div className="flex items-center transition-all duration-300 ease-in-out">
           {/* Avatar on left */}
-          {bookingRequest.artist?.profile_picture_url ? (
+          {isUserArtist ? (
+            bookingRequest.client?.profile_picture_url ? (
+              <Image
+                src={getFullImageUrl(bookingRequest.client.profile_picture_url) as string}
+                alt="Client avatar"
+                width={40}
+                height={40}
+                loading="lazy"
+                className="h-10 w-10 rounded-full object-cover border-2 border-white shadow-sm flex-shrink-0"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).src =
+                    getFullImageUrl('/static/default-avatar.svg') as string;
+                }}
+              />
+            ) : (
+              <div className="h-10 w-10 rounded-full bg-red-400 flex items-center justify-center text-base font-medium border-2 border-white shadow-sm flex-shrink-0">
+                {bookingRequest.client?.first_name?.charAt(0) || 'U'}
+              </div>
+            )
+          ) : bookingRequest.artist?.profile_picture_url ? (
             <Link
               href={`/artists/${bookingRequest.artist.id}`}
               aria-label="Artist profile"
@@ -145,7 +164,13 @@ export default function MessageThreadWrapper({
 
           {/* Name next to avatar */}
           <span className="font-semibold text-base sm:text-lg whitespace-nowrap overflow-hidden text-ellipsis ml-2">
-            Chat with {bookingRequest.client?.first_name || bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'User'}
+            Chat with {
+              isUserArtist
+                ? bookingRequest.client?.first_name || 'User'
+                : bookingRequest.artist?.business_name ||
+                  bookingRequest.artist?.user?.first_name ||
+                  'User'
+            }
           </span>
 
           {/* Send Quote button next */}

--- a/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
+++ b/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import MessageThreadWrapper from '../MessageThreadWrapper';
+import * as api from '@/lib/api';
+
+jest.mock('@/lib/api');
+
+jest.mock('../BookingDetailsPanel', () => {
+  const Mock = () => <div />;
+  Mock.displayName = 'MockBookingDetailsPanel';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('@/components/booking/MessageThread', () => {
+  const Mock = () => <div />;
+  Mock.displayName = 'MockMessageThread';
+  return { __esModule: true, default: Mock };
+});
+
+jest.mock('@/hooks/usePaymentModal', () => ({
+  __esModule: true,
+  default: () => ({ openPaymentModal: jest.fn(), paymentModal: null }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} />,
+}));
+
+const bookingRequest = {
+  id: 1,
+  artist: {
+    id: 2,
+    business_name: 'ArtistBiz',
+    user: { first_name: 'Art' },
+    profile_picture_url: null,
+  },
+  client: {
+    id: 3,
+    first_name: 'Client',
+    profile_picture_url: null,
+  },
+};
+
+function setup(userType: 'client' | 'artist') {
+  (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 99, user_type: userType }, loading: false });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+describe('MessageThreadWrapper', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows artist name to client users', async () => {
+    const { container, root } = setup('client');
+    await act(async () => {
+      root.render(
+        <MessageThreadWrapper bookingRequestId={1} bookingRequest={bookingRequest as any} setShowReviewModal={() => {}} />,
+      );
+    });
+    await act(async () => {});
+    const header = container.querySelector('header span');
+    expect(header?.textContent).toBe('Chat with ArtistBiz');
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows client name to artist users', async () => {
+    const { container, root } = setup('artist');
+    await act(async () => {
+      root.render(
+        <MessageThreadWrapper bookingRequestId={1} bookingRequest={bookingRequest as any} setShowReviewModal={() => {}} />,
+      );
+    });
+    await act(async () => {});
+    const header = container.querySelector('header span');
+    expect(header?.textContent).toBe('Chat with Client');
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- show the other participant’s avatar and name in chat threads
- document chat header behavior
- add tests for MessageThreadWrapper header names

## Testing
- `./scripts/test-backend.sh`
- `npm test src/components/inbox/__tests__/MessageThreadWrapper.test.tsx`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError `(0 , _navigation.useSearchParams) is not a function` in multiple suites)*

------
https://chatgpt.com/codex/tasks/task_e_68911cc8ae08832e97803a1a03538b8b