### PR TITLE
fix: show correct counterpart names in messaging

### DIFF
--- a/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
+++ b/frontend/src/app/booking-requests/__tests__/BookingRequestsPage.test.tsx
@@ -50,6 +50,7 @@ function setup(markItem = jest.fn()) {
         created_at: '2025-06-01T00:00:00Z',
         updated_at: '',
         client: { first_name: 'Alice', last_name: 'A' },
+        artist: { business_name: 'Artist One', user: { first_name: 'AO' } },
         service: { service_type: 'Live Performance' },
       },
       {
@@ -61,6 +62,7 @@ function setup(markItem = jest.fn()) {
         created_at: '2025-06-02T00:00:00Z',
         updated_at: '',
         client: { first_name: 'Bob', last_name: 'B' },
+        artist: { business_name: 'Artist Two', user: { first_name: 'AT' } },
         service: { service_type: 'Custom Song' },
       },
     ],
@@ -99,7 +101,7 @@ describe('BookingRequestsPage', () => {
     });
     await flushPromises();
     const input = container.querySelector(
-      'input[aria-label="Search by client name"]',
+      'input[aria-label="Search by artist name"]',
     ) as HTMLInputElement;
     act(() => {
       input.value = 'Bob';
@@ -107,7 +109,7 @@ describe('BookingRequestsPage', () => {
     });
     await flushPromises();
     const bobRow = Array.from(container.querySelectorAll('li[data-request-id]')).find((li) =>
-      li.textContent?.includes('Bob B'),
+      li.textContent?.includes('Artist Two'),
     );
     expect(bobRow).toBeTruthy();
     act(() => {

--- a/frontend/src/app/booking-requests/page.tsx
+++ b/frontend/src/app/booking-requests/page.tsx
@@ -73,9 +73,13 @@ export default function BookingRequestsPage() {
     const lowerSearch = search.toLowerCase();
     return requests
       .filter((r) => {
-        const name = r.client
-          ? `${r.client.first_name} ${r.client.last_name}`.toLowerCase()
-          : '';
+        const name = user?.user_type === 'artist'
+          ? r.client
+            ? `${r.client.first_name} ${r.client.last_name}`.toLowerCase()
+            : ''
+          : r.artist
+            ? (r.artist.business_name || r.artist.user?.first_name || '').toLowerCase()
+            : '';
         const matchesSearch = name.includes(lowerSearch);
         const matchesStatus =
           !statusFilter || r.status === statusFilter;
@@ -83,7 +87,7 @@ export default function BookingRequestsPage() {
           !serviceFilter || r.service?.service_type === serviceFilter;
         return matchesSearch && matchesStatus && matchesService;
       });
-  }, [requests, search, statusFilter, serviceFilter]);
+  }, [requests, search, statusFilter, serviceFilter, user]);
 
 
   const handleRowClick = async (id: number) => {
@@ -123,8 +127,8 @@ export default function BookingRequestsPage() {
             <div className="p-2 space-y-2 sm:flex sm:space-y-0 sm:space-x-2 bg-gray-50">
               <input
                 type="text"
-                placeholder="Search by client name"
-                aria-label="Search by client name"
+                placeholder={user?.user_type === 'artist' ? 'Search by client name' : 'Search by artist name'}
+                aria-label={user?.user_type === 'artist' ? 'Search by client name' : 'Search by artist name'}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="border rounded-md p-1 text-sm flex-1"

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -74,6 +74,7 @@ interface MessageThreadProps {
   clientId?: number;
   artistId?: number;
   artistAvatarUrl?: string | null;
+  clientAvatarUrl?: string | null;
   isSystemTyping?: boolean;
   serviceName?: string;
   initialNotes?: string | null;
@@ -112,6 +113,8 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
       onQuoteSent,
       serviceId,
       artistName = 'Artist',
+      clientName = 'Client',
+      clientAvatarUrl = null,
       clientId: propClientId,
       artistId: propArtistId,
       artistAvatarUrl = null,
@@ -623,23 +626,46 @@ useEffect(() => {
                   {/* Sender Name/Avatar for received messages (not system or self) */}
                   {!isSenderSelf && !isSystemMessage && (
                     <div className="flex items-center mb-1">
-                      {artistAvatarUrl ? (
-                        <Image
-                          src={getFullImageUrl(artistAvatarUrl) as string}
-                          alt="Artist avatar"
-                          width={20}
-                          height={20}
-                          className="h-5 w-5 rounded-full object-cover mr-2"
-                          onError={(e) => {
-                            (e.currentTarget as HTMLImageElement).src = getFullImageUrl('/static/default-avatar.svg') as string;
-                          }}
-                        />
-                      ) : (
-                        <div className="h-5 w-5 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium mr-2">
-                          {artistName?.charAt(0)}
-                        </div>
-                      )}
-                      <span className="text-xs font-semibold text-gray-700">{artistName}</span>
+                      {user?.user_type === 'artist'
+                        ? clientAvatarUrl
+                          ? (
+                              <Image
+                                src={getFullImageUrl(clientAvatarUrl) as string}
+                                alt="Client avatar"
+                                width={20}
+                                height={20}
+                                className="h-5 w-5 rounded-full object-cover mr-2"
+                                onError={(e) => {
+                                  (e.currentTarget as HTMLImageElement).src = getFullImageUrl('/static/default-avatar.svg') as string;
+                                }}
+                              />
+                            )
+                          : (
+                              <div className="h-5 w-5 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium mr-2">
+                                {clientName?.charAt(0)}
+                              </div>
+                            )
+                        : artistAvatarUrl
+                          ? (
+                              <Image
+                                src={getFullImageUrl(artistAvatarUrl) as string}
+                                alt="Artist avatar"
+                                width={20}
+                                height={20}
+                                className="h-5 w-5 rounded-full object-cover mr-2"
+                                onError={(e) => {
+                                  (e.currentTarget as HTMLImageElement).src = getFullImageUrl('/static/default-avatar.svg') as string;
+                                }}
+                              />
+                            )
+                          : (
+                              <div className="h-5 w-5 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium mr-2">
+                                {artistName?.charAt(0)}
+                              </div>
+                            )}
+                      <span className="text-xs font-semibold text-gray-700">
+                        {user?.user_type === 'artist' ? clientName : artistName}
+                      </span>
                     </div>
                   )}
 
@@ -769,7 +795,7 @@ useEffect(() => {
           {isSystemTyping && (
             <div className="flex items-end gap-2 self-start">
               <div className="h-7 w-7 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium shadow-sm">
-                {artistName?.charAt(0)}
+                {user?.user_type === 'artist' ? clientName?.charAt(0) : artistName?.charAt(0)}
               </div>
               <div className="bg-gray-200 rounded-2xl px-3 py-1.5 shadow-sm">
                 <div className="flex space-x-0.5 animate-pulse">

--- a/frontend/src/components/dashboard/BookingRequestCard.tsx
+++ b/frontend/src/components/dashboard/BookingRequestCard.tsx
@@ -11,6 +11,7 @@ import {
 import { BookingRequest } from '@/types';
 import { formatStatus } from '@/lib/utils';
 import { Avatar } from '../ui';
+import { useAuth } from '@/contexts/AuthContext';
 
 const getBadgeClass = (status: string): string => {
   if (
@@ -40,10 +41,16 @@ export interface BookingRequestCardProps {
 }
 
 export default function BookingRequestCard({ req }: BookingRequestCardProps) {
-  const avatarSrc = req.client?.profile_picture_url || null;
-  const clientName = req.client
-    ? `${req.client.first_name} ${req.client.last_name}`
-    : 'Unknown Client';
+  const { user } = useAuth();
+  const isUserArtist = user?.user_type === 'artist';
+  const avatarSrc = isUserArtist
+    ? req.client?.profile_picture_url || null
+    : req.artist?.profile_picture_url || null;
+  const displayName = isUserArtist
+    ? req.client
+      ? `${req.client.first_name} ${req.client.last_name}`
+      : 'Unknown Client'
+    : req.artist?.business_name || req.artist?.user?.first_name || 'Unknown Artist';
   const ServiceIcon =
     req.service?.title === 'Live Musiek' ? MicrophoneIcon : MusicalNoteIcon;
   const formattedDate = format(new Date(req.created_at), 'dd MMM yyyy');
@@ -53,12 +60,12 @@ export default function BookingRequestCard({ req }: BookingRequestCardProps) {
       <div className="flex gap-4 items-center">
         <Avatar
           src={avatarSrc}
-          initials={clientName.charAt(0)}
+          initials={displayName.charAt(0)}
           size={48}
           className="bg-blue-100 w-12 h-12"
         />
         <div>
-          <div className="font-bold text-gray-800">{clientName}</div>
+          <div className="font-bold text-gray-800">{displayName}</div>
           <div className="flex items-center gap-1 text-sm text-gray-600">
             <ServiceIcon className="w-4 h-4" />
             <span>{req.service?.title || '—'}</span>

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { act } from 'react';
 import BookingRequestCard from '../BookingRequestCard';
 import type { BookingRequest, Service } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/contexts/AuthContext');
 
 const baseReq: BookingRequest = {
   id: 1,
@@ -21,7 +24,22 @@ const baseReq: BookingRequest = {
     is_active: true,
     is_verified: true,
     profile_picture_url: null,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any,
+  artist: {
+    id: 3,
+    business_name: 'The Band',
+    user: {
+      id: 3,
+      email: 'a@band.com',
+      user_type: 'artist',
+      first_name: 'Band',
+      last_name: 'Leader',
+      phone_number: '',
+      is_active: true,
+      is_verified: true,
+      profile_picture_url: null,
+    },
+    profile_picture_url: null,
   } as any,
   service: { id: 9, artist_id: 3, title: 'Live Musiek' } as Service,
 } as BookingRequest;
@@ -35,6 +53,7 @@ describe('BookingRequestCard', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
+    (useAuth as jest.Mock).mockReturnValue({ user: { user_type: 'artist' } });
   });
 
   afterEach(() => {
@@ -75,6 +94,14 @@ describe('BookingRequestCard', () => {
     });
     const img = container.querySelector('img');
     expect(img).toBeNull();
+  });
+
+  it('shows artist business name to client users', () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { user_type: 'client' } });
+    act(() => {
+      root.render(React.createElement(BookingRequestCard, { req: baseReq }));
+    });
+    expect(container.textContent).toContain('The Band');
   });
 
   it('applies status badge classes based on status', () => {

--- a/frontend/src/components/inbox/BookingDetailsPanel.tsx
+++ b/frontend/src/components/inbox/BookingDetailsPanel.tsx
@@ -3,6 +3,7 @@
 import { format, parseISO, isValid } from 'date-fns';
 import { Booking, BookingRequest, Review } from '@/types';
 import Button from '../ui/Button';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface ParsedBookingDetails {
   eventType?: string;
@@ -32,6 +33,8 @@ export default function BookingDetailsPanel({
   setShowReviewModal,
   paymentModal,
 }: BookingDetailsPanelProps) {
+  const { user } = useAuth();
+  const isUserArtist = user?.user_type === 'artist';
 
   const cleanLocation = (locationString: string | undefined) => {
     if (!locationString) return 'N/A';
@@ -52,16 +55,22 @@ export default function BookingDetailsPanel({
     <div className="bg-white shadow-sm flex flex-col h-full rounded-2xl overflow-hidden">
       <dl className="flex-1 overflow-y-auto space-y-2 text-sm text-gray-800 p-4">
             <div className="flex justify-between">
-              <dt className="font-medium">Client</dt>
+              <dt className="font-medium">{isUserArtist ? 'Client' : 'Artist'}</dt>
               <dd>
-                {bookingRequest.client
-                  ? `${bookingRequest.client.first_name} ${bookingRequest.client.last_name}`
-                  : 'N/A'}
+                {isUserArtist
+                  ? bookingRequest.client
+                    ? `${bookingRequest.client.first_name} ${bookingRequest.client.last_name}`
+                    : 'N/A'
+                  : bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'N/A'}
               </dd>
             </div>
             <div className="flex justify-between">
               <dt className="font-medium">Email</dt>
-              <dd>{bookingRequest.client?.email || 'N/A'}</dd>
+              <dd>
+                {isUserArtist
+                  ? bookingRequest.client?.email || 'N/A'
+                  : bookingRequest.artist?.user?.email || 'N/A'}
+              </dd>
             </div>
             <div className="flex justify-between">
               <dt className="font-medium">Service</dt>

--- a/frontend/src/components/inbox/ConversationList.tsx
+++ b/frontend/src/components/inbox/ConversationList.tsx
@@ -34,11 +34,11 @@ export default function ConversationList({
           if (!artist) return 'Artist';
           return artist.business_name || artist.user?.first_name || 'Artist';
         })();
-        // Use getFullImageUrl for avatarUrl to ensure correct paths and handling
-        const fullAvatarUrl =
-          (currentUser.user_type === 'artist'
+        // Determine avatar URL for the other participant
+        const avatarUrl =
+          currentUser.user_type === 'artist'
             ? req.client?.profile_picture_url
-            : req.artist?.profile_picture_url) || '/static/default-avatar.svg'; // Fallback to a default SVG if no URL
+            : req.artist?.profile_picture_url;
 
         const date =
           req.last_message_timestamp || req.updated_at || req.created_at;
@@ -63,21 +63,19 @@ export default function ConversationList({
             )}
           >
             {/* Avatar Handling */}
-            {fullAvatarUrl ? (
+            {avatarUrl ? (
               <Image
-                src={getFullImageUrl(fullAvatarUrl) as string} // Ensure getFullImageUrl is applied
-                alt={`${otherName} avatar`} // More descriptive alt text
+                src={getFullImageUrl(avatarUrl) as string}
+                alt={`${otherName} avatar`}
                 width={40}
                 height={40}
-                loading="lazy" // Lazy load images
-                className="rounded-full object-cover flex-shrink-0 border border-gray-200" // Added a subtle border
+                loading="lazy"
+                className="rounded-full object-cover flex-shrink-0 border border-gray-200"
                 onError={(e) => {
-                  // Fallback to a generic avatar if the specific image fails to load
                   (e.currentTarget as HTMLImageElement).src = getFullImageUrl('/static/default-avatar.svg') as string;
                 }}
               />
             ) : (
-              // Fallback for no avatar URL (should ideally be covered by fullAvatarUrl logic)
               <div className="h-10 w-10 rounded-full bg-indigo-500 text-white flex-shrink-0 flex items-center justify-center font-medium text-lg">
                 {otherName.charAt(0)}
               </div>

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -154,11 +154,7 @@ export default function MessageThreadWrapper({
             </Link>
           ) : (
             <div className="h-10 w-10 rounded-full bg-red-400 flex items-center justify-center text-base font-medium border-2 border-white shadow-sm flex-shrink-0">
-              {(
-                bookingRequest.artist?.business_name ||
-                bookingRequest.artist?.user?.first_name ||
-                bookingRequest.client?.first_name
-              )?.charAt(0) || 'U'}
+              {(bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name || 'U').charAt(0)}
             </div>
           )}
 
@@ -288,6 +284,7 @@ export default function MessageThreadWrapper({
             clientName={bookingRequest.client?.first_name}
             artistName={bookingRequest.artist?.business_name || bookingRequest.artist?.user?.first_name}
             artistAvatarUrl={bookingRequest.artist?.profile_picture_url ?? null}
+            clientAvatarUrl={bookingRequest.client?.profile_picture_url ?? null}
             serviceName={bookingRequest.service?.title}
             initialNotes={bookingRequest.message ?? null}
             initialBaseFee={bookingRequest.service?.price ? Number(bookingRequest.service.price) : undefined}

--- a/frontend/src/components/inbox/__tests__/ConversationList.test.tsx
+++ b/frontend/src/components/inbox/__tests__/ConversationList.test.tsx
@@ -45,7 +45,12 @@ describe('ConversationList', () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         client: { id: 1, email: 'a', user_type: 'client', first_name: 'A', last_name: 'B', phone_number: '', is_active: true, is_verified: true },
-        artist: { id: 2, email: 'b', user_type: 'artist', first_name: 'B', last_name: 'C', phone_number: '', is_active: true, is_verified: true },
+        artist: {
+          id: 2,
+          business_name: 'Biz',
+          user: { id: 2, email: 'b', user_type: 'artist', first_name: 'B', last_name: 'C', phone_number: '', is_active: true, is_verified: true },
+          profile_picture_url: null,
+        } as any,
       } as BookingRequest,
     ];
     const { container, root, props } = renderComponent({
@@ -56,7 +61,7 @@ describe('ConversationList', () => {
       root.render(<ConversationList {...props} />);
     });
     await flushPromises();
-    expect(container.textContent).toContain('B');
+    expect(container.textContent).toContain('Biz');
     act(() => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary
- display the other participant's name and avatar based on current user role across conversations and booking requests
- allow searching booking requests by artist when viewed by clients
- ensure side panel shows correct party info

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: useSearchParams is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689120d1697c832ea1d30d8404e46254