### PR TITLE
feat: hide chat booking summary by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
 * Booking notes are visible only on the Booking details page, appearing beneath the Venue Type line in the details box, and are hidden from chat threads and booking request screens.
-* Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. Small chevron icons indicate the state.
+* Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. The details are collapsed by default so the header shows **Show details** until the section is opened. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles and subtitles wrap up to two lines using the `line-clamp-2` utility so full names remain visible.
 * Avatars fall back to the sender's initials when no profile photo is available. If neither a picture nor initials are present, a default patterned placeholder is shown so every notification has a recognizable icon.
 * The drawer slides in from the right on a simple white panel with a soft shadow. Badges disappear when the unread count is 0.

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -56,15 +56,6 @@ export default function MessageThreadWrapper({
   const [showSidePanel, setShowSidePanel] = useState(false);
   const [showQuoteModal, setShowQuoteModal] = useState(false);
 
-  useEffect(() => {
-    const handleInitialPanelState = () => {
-      setShowSidePanel(window.innerWidth >= 768);
-    };
-    handleInitialPanelState();
-    window.addEventListener('resize', handleInitialPanelState);
-    return () => window.removeEventListener('resize', handleInitialPanelState);
-  }, []);
-
   const { openPaymentModal, paymentModal } = usePaymentModal(
     useCallback(({ status, amount, receiptUrl: url }) => {
       setPaymentStatus(status);

--- a/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
+++ b/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
@@ -88,4 +88,20 @@ describe('MessageThreadWrapper', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('starts with booking details hidden', async () => {
+    const { container, root } = setup('client');
+    await act(async () => {
+      root.render(
+        <MessageThreadWrapper bookingRequestId={1} bookingRequest={bookingRequest as any} setShowReviewModal={() => {}} />,
+      );
+    });
+    await act(async () => {});
+    const showButton = container.querySelector('button[aria-label="Show booking details"]');
+    const hideButton = container.querySelector('button[aria-label="Hide details panel"]');
+    expect(showButton).not.toBeNull();
+    expect(hideButton).toBeNull();
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- start chat booking details panel hidden
- test default hidden state
- document default collapsed booking details panel

## Testing
- `./scripts/test-all.sh` *(fails: 41 failed, 63 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689198633f38832ead911034e2a4008e