### PR TITLE
feat: hide booking summary until toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   included in the booking summary.
 * Booking summary fonts now match the step cards for a more polished look.
 * Input fields no longer auto-focus on mobile so the on-screen keyboard stays hidden until tapped.
-* Summary sidebar collapses into a `<details>` section on phones so you can hide the order overview.
+* Booking summary is hidden by default and can be expanded with a "Show Details" toggle.
 * Steps now animate with **framer-motion** and the progress dots stay clickable for all completed steps.
 * Redesigned wizard uses animated stepper circles and spacious rounded cards for each step. Buttons have improved focus styles and align responsively.
 * The flow now begins with **Date & Time** followed by **Event Type** and **Event Details** so clients choose when first.

--- a/frontend/src/components/booking/SummarySidebar.tsx
+++ b/frontend/src/components/booking/SummarySidebar.tsx
@@ -2,14 +2,14 @@
 import { useBooking } from '@/contexts/BookingContext';
 import { format, parseISO, isValid } from 'date-fns';
 import { motion } from 'framer-motion';
-import React, { useState } from 'react'; // Import useState
+import React, { useState } from 'react';
 
 export default function SummarySidebar() {
   const { details } = useBooking();
   const dateValue =
     typeof details.date === 'string' ? parseISO(details.date) : details.date;
 
-  const [isExpanded, setIsExpanded] = useState(false); // State to manage expansion
+  const [isVisible, setIsVisible] = useState(false);
 
   const cleanLocation = (locationString: string) => {
     if (!locationString) return '';
@@ -19,9 +19,18 @@ export default function SummarySidebar() {
     return cleaned;
   };
 
-  const toggleExpanded = () => {
-    setIsExpanded(!isExpanded);
-  };
+  if (!isVisible) {
+    return (
+      <div className="flex justify-center w-full p-0">
+        <button
+          onClick={() => setIsVisible(true)}
+          className="text-gray-400 hover:text-gray-800 font-medium py-2 text-sm flex items-center justify-center space-x-1 cursor-pointer"
+        >
+          <span className="text-xs">Show Details</span>
+        </button>
+      </div>
+    );
+  }
 
   return (
     <motion.div
@@ -32,7 +41,6 @@ export default function SummarySidebar() {
     >
       <h2 className="text-2xl font-bold text-gray-900 mb-1">Booking Summary</h2>
 
-      {/* Always visible details */}
       <div className="space-y-3">
         {details.eventType && (
           <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
@@ -57,64 +65,46 @@ export default function SummarySidebar() {
             </dd>
           </div>
         )}
+        {details.eventDescription && (
+          <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
+            <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Details</dt>
+            <dd className="text-sm text-gray-900 text-right flex-grow">{details.eventDescription}</dd>
+          </div>
+        )}
+        {details.guests && (
+          <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
+            <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Guests</dt>
+            <dd className="text-sm text-gray-900 text-right flex-grow">{details.guests}</dd>
+          </div>
+        )}
+        {details.venueType && (
+          <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
+            <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Venue</dt>
+            <dd className="text-sm text-gray-900 text-right flex-grow">{details.venueType}</dd>
+          </div>
+        )}
+        {details.sound && (
+          <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
+            <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Sound Needed</dt>
+            <dd className="text-sm text-gray-900 text-right flex-grow">
+              {details.sound === 'yes' ? 'Yes' : 'No'}
+            </dd>
+          </div>
+        )}
+        {details.notes && (
+          <div className="flex items-start justify-between py-1 border-b border-gray-100 last:border-b-0">
+            <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Notes</dt>
+            <dd className="text-sm text-gray-900 text-right flex-grow">{details.notes}</dd>
+          </div>
+        )}
       </div>
 
-      {/* Conditionally visible details */}
-      {isExpanded && (
-        <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.3 }}
-          className="space-y-3 overflow-hidden" // overflow-hidden to help with height transition
-        >
-          {details.eventDescription && (
-            <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
-              <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Details</dt>
-              <dd className="text-sm text-gray-900 text-right flex-grow">{details.eventDescription}</dd>
-            </div>
-          )}
-          {details.guests && (
-            <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
-              <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Guests</dt>
-              <dd className="text-sm text-gray-900 text-right flex-grow">{details.guests}</dd>
-            </div>
-          )}
-          {details.venueType && (
-            <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
-              <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Venue</dt>
-              <dd className="text-sm text-gray-900 text-right flex-grow">{details.venueType}</dd>
-            </div>
-          )}
-          {details.sound && (
-            <div className="flex items-center justify-between py-1 border-b border-gray-100 last:border-b-0">
-              <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Sound Needed</dt>
-              <dd className="text-sm text-gray-900 text-right flex-grow">
-                {details.sound === 'yes' ? 'Yes' : 'No'}
-              </dd>
-            </div>
-          )}
-          {details.notes && (
-            <div className="flex items-start justify-between py-1 border-b border-gray-100 last:border-b-0">
-              <dt className="text-sm font-medium text-gray-700 flex-shrink-0 w-1/3">Notes</dt>
-              <dd className="text-sm text-gray-900 text-right flex-grow">{details.notes}</dd>
-            </div>
-          )}
-        </motion.div>
-      )}
-
-      {/* More subtle Expand/Collapse Button - Positioned to the right */}
       <div className="flex justify-center w-full" style={{ marginTop: '0.01rem' }}>
         <button
-          onClick={toggleExpanded}
+          onClick={() => setIsVisible(false)}
           className="text-gray-400 hover:text-gray-800 font-medium py-2 text-sm flex items-center justify-center space-x-1 cursor-pointer"
         >
-          <span className="text-xs">
-            {isExpanded ? 'Hide Details' : 'Show More'}
-          </span>
-          <span className={`transform transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`}>
-            
-          </span>
+          <span className="text-xs">Hide Details</span>
         </button>
       </div>
     </motion.div>

--- a/frontend/src/components/booking/__tests__/SummarySidebar.test.tsx
+++ b/frontend/src/components/booking/__tests__/SummarySidebar.test.tsx
@@ -42,6 +42,11 @@ describe('SummarySidebar', () => {
     act(() => {
       root.render(<SummarySidebar />);
     });
+    expect(container.textContent).not.toContain('Jan 2, 2024');
+    const button = container.querySelector('button');
+    act(() => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
     expect(container.textContent).toContain('Jan 2, 2024');
     expect(container.textContent).toContain('Wedding');
     expect(container.textContent).toContain('A small ceremony');
@@ -64,6 +69,11 @@ describe('SummarySidebar', () => {
     });
     act(() => {
       root.render(<SummarySidebar />);
+    });
+    expect(container.textContent).not.toContain('May 3, 2024');
+    const button = container.querySelector('button');
+    act(() => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(container.textContent).toContain('May 3, 2024');
     expect(container.textContent).toContain('50');


### PR DESCRIPTION
## Summary
- hide booking summary behind a Show Details toggle
- update SummarySidebar tests for new toggle behavior
- document that the booking summary starts collapsed

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68919e281450832e98732a80734346dd