### PR TITLE
feat(inbox): open send quote modal via URL param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ keeps the current view, e.g.
 * Chat attachment button stays inline with the message input and send button on all screens.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details. Message notifications open directly to this page so clients can read and respond without hunting for the correct thread.
+* URL parameters on `/inbox` include `requestId` to select a conversation and `sendQuote=1` to open the Send Quote modal for artists.
 * `/booking-requests` lists all requests with search and filters. Search and filter inputs now include hidden labels for screen readers.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.
 * Tap a booking request card to open `/booking-requests/[id]`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -107,6 +107,14 @@ The `/booking` page requires an `artist_id` query parameter and accepts an optio
 
 Passing `service_id` skips the service selection step when a user clicks "Request Booking" on a service card.
 
+### Inbox URL Parameters
+
+The `/inbox` page accepts a `requestId` to open a specific conversation and an optional `sendQuote=1` flag. When present, the Send Quote modal opens automatically for artist users.
+
+```
+/inbox?requestId=42&sendQuote=1
+```
+
 ## Dashboard
 
 The artist dashboard includes a quotes page for managing offers. The `EditQuoteModal` allows artists to modify quote details and price inline without leaving the list. It opens when clicking the "Edit" button next to a pending quote and mirrors the style of `SendQuoteModal`. Both modals now wrap the sound fee, travel fee, discount, accommodation, and expiry fields in accessible labels so screen readers announce each input.

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import Link from 'next/link';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { Booking, BookingRequest } from '@/types';
 import MessageThread from '../booking/MessageThread';
 import BookingDetailsPanel from './BookingDetailsPanel';
@@ -44,6 +45,8 @@ export default function MessageThreadWrapper({
 
   const [isUserArtist, setIsUserArtist] = useState(false);
   const { user } = api.useAuth();
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
     if (user && user.user_type === 'artist') {
@@ -55,6 +58,27 @@ export default function MessageThreadWrapper({
 
   const [showSidePanel, setShowSidePanel] = useState(false);
   const [showQuoteModal, setShowQuoteModal] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get('sendQuote') === '1') {
+      setShowQuoteModal(true);
+    }
+  }, [searchParams]);
+
+  const handleSetShowQuoteModal = useCallback(
+    (show: boolean) => {
+      setShowQuoteModal(show);
+      const params = new URLSearchParams(searchParams.toString());
+      if (show) {
+        params.set('sendQuote', '1');
+      } else {
+        params.delete('sendQuote');
+      }
+      const queryString = params.toString();
+      router.replace(queryString ? `?${queryString}` : '', { scroll: false });
+    },
+    [searchParams, router],
+  );
 
   const { openPaymentModal, paymentModal } = usePaymentModal(
     useCallback(({ status, amount, receiptUrl: url }) => {
@@ -164,7 +188,7 @@ export default function MessageThreadWrapper({
           {isUserArtist && !bookingConfirmed && (
             <button
               type="button"
-              onClick={() => setShowQuoteModal(true)}
+              onClick={() => handleSetShowQuoteModal(true)}
               aria-label="Send Quote"
               className="ml-2 p-1 rounded-full hover:bg-white/20 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
             >
@@ -297,7 +321,7 @@ export default function MessageThreadWrapper({
             }}
             onShowReviewModal={setShowReviewModal}
             showQuoteModal={showQuoteModal}
-            setShowQuoteModal={setShowQuoteModal}
+            setShowQuoteModal={handleSetShowQuoteModal}
           />
         </div>
 

--- a/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
+++ b/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import MessageThreadWrapper from '../MessageThreadWrapper';
 import * as api from '@/lib/api';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 jest.mock('@/lib/api');
 
@@ -13,7 +14,7 @@ jest.mock('../BookingDetailsPanel', () => {
 });
 
 jest.mock('@/components/booking/MessageThread', () => {
-  const Mock = () => <div />;
+  const Mock = jest.fn(() => <div />);
   Mock.displayName = 'MockMessageThread';
   return { __esModule: true, default: Mock };
 });
@@ -33,6 +34,11 @@ jest.mock('next/image', () => ({
   default: (props: any) => <img {...props} />,
 }));
 
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
 const bookingRequest = {
   id: 1,
   artist: {
@@ -48,8 +54,10 @@ const bookingRequest = {
   },
 };
 
-function setup(userType: 'client' | 'artist') {
+function setup(userType: 'client' | 'artist', params = '') {
   (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 99, user_type: userType }, loading: false });
+  (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(params));
+  (useRouter as jest.Mock).mockReturnValue({ replace: jest.fn() });
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -101,6 +109,23 @@ describe('MessageThreadWrapper', () => {
     const hideButton = container.querySelector('button[aria-label="Hide details panel"]');
     expect(showButton).not.toBeNull();
     expect(hideButton).toBeNull();
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('opens quote modal when sendQuote param is present', async () => {
+    const { container, root } = setup('artist', 'sendQuote=1');
+    const MessageThreadMock = require('../MessageThread').default as jest.Mock;
+    await act(async () => {
+      root.render(
+        <MessageThreadWrapper bookingRequestId={1} bookingRequest={bookingRequest as any} setShowReviewModal={() => {}} />,
+      );
+    });
+    await act(async () => {});
+    expect(MessageThreadMock).toHaveBeenCalledWith(
+      expect.objectContaining({ showQuoteModal: true }),
+      expect.anything(),
+    );
     act(() => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary
- allow Send Quote modal to be opened via `sendQuote` URL parameter
- document new inbox parameters in README files
- test inbox thread wrapper behavior with Next.js navigation mocks

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npx jest src/components/inbox/__tests__/MessageThreadWrapper.test.tsx` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6891aeb5d9a8832ea9cc6eeb12a71813