### PR TITLE
feat: show artist avatar for booking alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,14 +892,14 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Booking notes are visible only on the Booking details page, appearing beneath the Venue Type line in the details box, and are hidden from chat threads and booking request screens.
 * Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. The details are collapsed by default so the header shows **Show details** until the section is opened. Small chevron icons indicate the state.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles and subtitles wrap up to two lines using the `line-clamp-2` utility so full names remain visible.
-* Avatars fall back to the sender's initials when no profile photo is available. If neither a picture nor initials are present, a default patterned placeholder is shown so every notification has a recognizable icon.
+* Avatars fall back to a default placeholder image when no profile photo is available so every notification displays a consistent picture.
 * The drawer slides in from the right on a simple white panel with a soft shadow. Badges disappear when the unread count is 0.
 * Notification cards keep softly rounded corners and a gentle shadow. Unread items show a thin brand-colored strip on the left.
 * Each card displays a circular avatar, bold title, one-line subtitle, relative timestamp and a small status icon on the right. Icons are color-coded (green for confirmed, indigo for reminders, amber for due alerts).
 * The header now just shows the “Notifications” title, an **Unread** toggle and a close **X** button.
 * A full-width rounded **Clear All** button stays pinned to the bottom of the panel.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" only the first time a booking is confirmed. Subsequent reminders omit the greeting. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
-* Booking confirmed and deposit due notifications now show the artist's avatar so users can immediately recognize who the alert is from.
+* Booking confirmed and deposit due notifications now show the artist's avatar so users can immediately recognize who the alert is from. When the artist hasn't uploaded a photo, the default avatar is used.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
 * Message notifications now include the sender name in both the stored text and the API response so the drawer can display "New message from Alice" without additional lookups.
 * Clicking a new message alert opens `/inbox?requestId={id}` with the conversation active.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -17,6 +17,8 @@ Important fields returned by `/api/v1/notifications`:
 - **link** – relative path to navigate to when the card is clicked. The UI uses
   `router.push(link)` so paths must be valid client routes.
 - **avatar_url** – optional profile picture for the relevant artist or client.
+  When absent, the UI displays a default placeholder image so booking
+  confirmations and deposit reminders still show an avatar.
 
 Clicking a card marks the notification read then navigates to `link`. The card
 shows a coloured icon based on the status, the sender name as the title and a

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -156,11 +156,11 @@ export default function NotificationListItem({
   className = '',
 }: NotificationListItemProps) {
   const p = parseItem(n);
-  // Display the profile picture when available, falling back to the avatar URL.
-  // If neither exists, the Avatar component uses initials or an icon so deposit
-  // due and booking confirmed alerts can show the artist's image while other
-  // notifications still render a meaningful placeholder.
-  const avatarSrc = p.avatarUrl || undefined;
+  // Always display a photo: use the profile picture when available and fall
+  // back to the default placeholder image when it's missing. This ensures
+  // booking confirmed and deposit due alerts show the artist's avatar for
+  // clients, while other notifications still render a consistent image.
+  const avatarSrc = p.avatarUrl || '/static/default-avatar.svg';
 
   return (
     <div
@@ -180,7 +180,7 @@ export default function NotificationListItem({
         className
       )}
     >
-      <Avatar src={avatarSrc} initials={p.initials} icon={p.icon} size={44} />
+      <Avatar src={avatarSrc} size={44} />
       <div className="flex-1 mx-3">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-2 flex-1 min-w-0">

--- a/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationListItem.test.tsx
@@ -306,7 +306,7 @@ describe('NotificationListItem', () => {
     expect(img?.getAttribute('src')).toContain('profile.jpg');
   });
 
-  it('falls back to the icon when no avatar URL is provided', () => {
+  it('falls back to a default avatar when no avatar URL is provided', () => {
     const n: UnifiedNotification = {
       type: 'deposit_due',
       timestamp: new Date().toISOString(),
@@ -324,8 +324,8 @@ describe('NotificationListItem', () => {
     });
 
     const img = container.querySelector('img');
-    expect(img).toBeNull();
-    expect(container.textContent).toContain('💰');
+    expect(img?.getAttribute('src')).toContain('default-avatar.svg');
+    expect(container.textContent).not.toContain('💰');
   });
 
   it('passes avatarUrl to Avatar component', () => {


### PR DESCRIPTION
## Summary
- show profile pictures in notification list items with default avatar fallback
- adjust notification tests for new avatar behavior
- document default avatar fallback in notification docs and README

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6891ccf395b4832e8d82ff431c5b1b97