### PR TITLE
feat: personalize quote previews

### DIFF
--- a/frontend/src/components/inbox/ConversationList.tsx
+++ b/frontend/src/components/inbox/ConversationList.tsx
@@ -35,7 +35,7 @@ export default function ConversationList({
           if (!artistProfile && !artistUser) return 'Artist';
           return artistProfile?.business_name || artistUser?.first_name || 'Artist';
         })();
-        // Determine avatar URL for the other participant
+
         const avatarUrl =
           currentUser.user_type === 'artist'
             ? req.client?.profile_picture_url
@@ -43,6 +43,25 @@ export default function ConversationList({
 
         const date =
           req.last_message_timestamp || req.updated_at || req.created_at;
+
+        const previewMessage = (() => {
+          if (req.last_message_content === 'Artist sent a quote') {
+            if (currentUser.user_type === 'artist') {
+              return 'You sent a quote';
+            }
+            const businessName =
+              req.artist_profile?.business_name ||
+              req.artist?.first_name ||
+              'Artist';
+            return `${businessName} sent a quote`;
+          }
+          return (
+            req.last_message_content ??
+            req.service?.title ??
+            req.message ??
+            'New Request'
+          );
+        })();
 
         return (
           <div
@@ -98,13 +117,12 @@ export default function ConversationList({
               <div
                 className={clsx(
                   'text-xs truncate',
-                  req.is_unread_by_current_user ? 'font-semibold text-gray-800' : 'text-gray-600' // Stronger font for unread message content
+                  req.is_unread_by_current_user
+                    ? 'font-semibold text-gray-800'
+                    : 'text-gray-600' // Stronger font for unread message content
                 )}
               >
-                {req.last_message_content ??
-                  req.service?.title ??
-                  req.message ??
-                  'New Request'}
+                {previewMessage}
               </div>
             </div>
             {/* Unread Indicator */}

--- a/frontend/src/components/inbox/__tests__/ConversationList.test.tsx
+++ b/frontend/src/components/inbox/__tests__/ConversationList.test.tsx
@@ -65,4 +65,66 @@ describe('ConversationList', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('shows client-facing quote preview', async () => {
+    const requests: BookingRequest[] = [
+      {
+        id: 1,
+        client_id: 1,
+        artist_id: 2,
+        status: 'pending_quote',
+        last_message_content: 'Artist sent a quote',
+        last_message_timestamp: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        client: { id: 1, email: 'a', user_type: 'client', first_name: 'A', last_name: 'B', phone_number: '', is_active: true, is_verified: true },
+        artist: {
+          id: 2,
+          business_name: 'Biz',
+          user: { id: 2, email: 'b', user_type: 'artist', first_name: 'B', last_name: 'C', phone_number: '', is_active: true, is_verified: true },
+          profile_picture_url: null,
+        } as any,
+      } as BookingRequest,
+    ];
+    const { container, root, props } = renderComponent({
+      bookingRequests: requests,
+      currentUser: { id: 1, email: 'a', user_type: 'client', first_name: 'A', last_name: 'B', phone_number: '', is_active: true, is_verified: true },
+    });
+    await act(async () => {
+      root.render(<ConversationList {...props} />);
+    });
+    await flushPromises();
+    expect(container.textContent).toContain('Biz sent a quote');
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows artist-facing quote preview', async () => {
+    const requests: BookingRequest[] = [
+      {
+        id: 1,
+        client_id: 2,
+        artist_id: 1,
+        status: 'pending_quote',
+        last_message_content: 'Artist sent a quote',
+        last_message_timestamp: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        client: { id: 2, email: 'b', user_type: 'client', first_name: 'Client', last_name: 'X', phone_number: '', is_active: true, is_verified: true },
+        artist: { id: 1, email: 'a', user_type: 'artist', first_name: 'Art', last_name: 'Ist', phone_number: '', is_active: true, is_verified: true },
+        artist_profile: { business_name: 'Biz', profile_picture_url: null } as any,
+      } as BookingRequest,
+    ];
+    const { container, root, props } = renderComponent({
+      bookingRequests: requests,
+      currentUser: { id: 1, email: 'a', user_type: 'artist', first_name: 'Art', last_name: 'Ist', phone_number: '', is_active: true, is_verified: true },
+    });
+    await act(async () => {
+      root.render(<ConversationList {...props} />);
+    });
+    await flushPromises();
+    expect(container.textContent).toContain('You sent a quote');
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- personalize conversation previews for quote messages
- add tests for client and artist quote previews

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6891e1a88ef4832ea5606a521ede3a8d