### PR TITLE
Use shared breakpoint for mobile detection

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,13 @@ Primary, secondary and outline buttons now use the brand color for borders and b
 
 See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary of spacing, typography and component styles.
 
+### Responsive Breakpoints
+
+The `BREAKPOINT_SM` constant in `breakpoints.config.js` defines the `sm`
+screen width for both Tailwind and client-side hooks such as `useIsMobile`.
+Importing this shared value keeps style breakpoints and JavaScript logic in
+sync, ensuring responsive behavior matches the design system.
+
 ### Search Interface
 
 The global search bar and its compact pill are rendered only on the home page and artist pages. Other routes omit these elements for a cleaner layout. On the artists listing page, the header loads directly in its compact pill state, preserving any category, location, and date selections from the URL and showing the filter icon beside the pill for quick refinement. Clicking the pill now expands the full SearchBar above the filter controls, and the compact pill mirrors the collapsed SearchBar by displaying any selected category, location, and dates when the full bar is hidden. For addresses, the pill shows only the street name to keep things concise.

--- a/frontend/breakpoints.config.js
+++ b/frontend/breakpoints.config.js
@@ -1,0 +1,3 @@
+const BREAKPOINT_SM = 640;
+
+module.exports = { BREAKPOINT_SM };

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -4,6 +4,21 @@
 import React from "react";
 import "@/tests/mocks/no-network";
 
+// Provide a basic matchMedia stub for hooks that query media features.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
 jest.mock('next/navigation', () => {
   return {
     useRouter: () => ({

--- a/frontend/src/lib/__tests__/isMobile.test.ts
+++ b/frontend/src/lib/__tests__/isMobile.test.ts
@@ -1,15 +1,31 @@
 import isMobileScreen from '../isMobile';
+import { BREAKPOINT_SM } from '@/lib/breakpoints';
 
 describe('isMobileScreen', () => {
-  const g = global as unknown as { window?: { innerWidth: number } };
+  const g = global as unknown as { window?: typeof window };
+  const query = `(max-width: ${BREAKPOINT_SM - 1}px)`;
 
-  it('returns true when window width is below 640', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true });
+  it('returns true when screen width is below sm breakpoint', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: jest.fn().mockImplementation((q) => ({
+        matches: q === query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+      writable: true,
+    });
     expect(isMobileScreen()).toBe(true);
   });
 
-  it('returns false when window width is 640 or more', () => {
-    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
+  it('returns false when screen width is sm breakpoint or wider', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+      writable: true,
+    });
     expect(isMobileScreen()).toBe(false);
   });
 

--- a/frontend/src/lib/breakpoints.ts
+++ b/frontend/src/lib/breakpoints.ts
@@ -1,0 +1,3 @@
+// Re-export shared breakpoint constants so application code can import them
+// using the `@/lib` alias while Tailwind consumes the original config.
+export { BREAKPOINT_SM } from '../../breakpoints.config.js';

--- a/frontend/src/lib/isMobile.ts
+++ b/frontend/src/lib/isMobile.ts
@@ -1,4 +1,10 @@
+import { BREAKPOINT_SM } from '@/lib/breakpoints';
+
+/**
+ * Determine if the current viewport is below the small breakpoint.
+ * Uses `matchMedia` so the value mirrors Tailwind's `sm` screen.
+ */
 export default function isMobileScreen(): boolean {
   if (typeof window === 'undefined') return false;
-  return window.innerWidth < 640;
+  return window.matchMedia(`(max-width: ${BREAKPOINT_SM - 1}px)`).matches;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,6 @@
 const colors = require("tailwindcss/colors");
+const defaultTheme = require("tailwindcss/defaultTheme");
+const { BREAKPOINT_SM } = require("./breakpoints.config");
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -9,6 +11,10 @@ module.exports = {
     "./src/styles/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
+    screens: {
+      ...defaultTheme.screens,
+      sm: `${BREAKPOINT_SM}px`,
+    },
     extend: {
       fontFamily: {
         sans: ["var(--font-sans)"],


### PR DESCRIPTION
## Summary
- replace `window.innerWidth` checks with `matchMedia` using a shared `BREAKPOINT_SM`
- export the breakpoint from a shared config consumed by Tailwind and hooks
- document and test the new responsive breakpoint behavior

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test src/lib/__tests__/isMobile.test.ts src/hooks/__tests__/useIsMobile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891f3a4a1c4832e821b906f1fa8e09c