### PR TITLE
feat: add collapsible booking steps

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -26,6 +26,9 @@ This document outlines key friction points in the current booking wizard and pro
   - Trap focus inside the sheet and close it with Escape or by tapping the
     overlay.
 
+## Event Type & Sound
+* **Improvements:** Both steps now use the same bottom sheet selector pattern on mobile for a consistent touch-friendly experience.
+
 ## Notes
 * **Pain Points:** Large textarea forces users to scroll.
 * **Improvements:**

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -150,7 +150,7 @@
   }
 
   .selectable-card {
-    @apply flex cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-colors hover:bg-gray-50;
+    @apply flex cursor-pointer items-center justify-center rounded-lg border border-gray-300 bg-white p-4 text-sm transition-colors hover:bg-gray-50 min-h-[44px];
   }
 
   .selectable-card-input:focus-visible + .selectable-card {

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -390,8 +390,6 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
   // --- Render Step Logic ---
   const renderStep = () => {
-    const commonProps = { step, steps, onBack: prev, onSaveDraft: saveDraft, onNext: next };
-
     switch (step) {
       case 0: return <DateTimeStep control={control} unavailable={unavailable} />;
       case 1: return <EventTypeStep control={control} />;
@@ -401,24 +399,26 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
           control={control}
           artistLocation={artistLocation}
           setWarning={setWarning}
-          {...commonProps}
         />
       );
-      case 4: return <GuestsStep control={control} {...commonProps} />;
-      case 5: return <VenueStep control={control} {...commonProps} />;
-      case 6: return <SoundStep control={control} {...commonProps} />;
+      case 4: return <GuestsStep control={control} />;
+      case 5: return <VenueStep control={control} />;
+      case 6: return <SoundStep control={control} />;
       case 7: return <NotesStep control={control} setValue={setValue} />;
       case 8: return (
         <ReviewStep
-          {...commonProps}
+          step={step}
+          steps={steps}
+          onBack={prev}
+          onSaveDraft={saveDraft}
+          onNext={submitRequest}
+          submitting={submitting}
           isLoadingReviewData={isLoadingReviewData}
           reviewDataError={reviewDataError}
           calculatedPrice={calculatedPrice}
-          travelResult={travelResult} // Pass travelResult
-          onNext={submitRequest} // Pass submitRequest as onNext for the ReviewStep's button
-          submitting={submitting}
+          travelResult={travelResult}
           submitLabel="Submit Request"
-          baseServicePrice={baseServicePrice} // Pass baseServicePrice
+          baseServicePrice={baseServicePrice}
         />
       );
       default: return null;

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -7,7 +7,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { format, parseISO, isBefore, startOfDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import useIsMobile from '@/hooks/useIsMobile';
-import { DateInput } from '../../ui'; // Assuming DateInput is imported
+import { DateInput, CollapsibleSection } from '../../ui';
 
 // Import EventDetails for correct Control typing
 import { EventDetails } from '@/contexts/BookingContext';
@@ -17,13 +17,16 @@ interface Props {
   control: Control<EventDetails>; // Type control with EventDetails
   unavailable: string[];
   loading?: boolean;
-  // No step, steps, onBack, onSaveDraft, onNext props here.
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 export default function DateTimeStep({
   control,
   unavailable,
   loading = false,
+  open = true,
+  onToggle = () => {},
 }: Props) {
   const isMobile = useIsMobile();
   const filterDate = (date: Date) => {
@@ -32,7 +35,12 @@ export default function DateTimeStep({
     return !unavailable.includes(day) && !isBefore(date, today);
   };
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Date & Time"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       {loading ? (
         <div
           data-testid="calendar-skeleton"
@@ -111,6 +119,6 @@ export default function DateTimeStep({
         />
       )}
       {/* No WizardNav here. Its buttons are now in the parent BookingWizard. */}
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/EventDescriptionStep.tsx
+++ b/frontend/src/components/booking/steps/EventDescriptionStep.tsx
@@ -2,15 +2,23 @@
 import { Control, Controller } from 'react-hook-form';
 import useIsMobile from '@/hooks/useIsMobile';
 import { EventDetails } from '@/contexts/BookingContext';
+import { CollapsibleSection } from '../../ui';
 
 interface Props {
   control: Control<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
-export default function EventDescriptionStep({ control }: Props) {
+export default function EventDescriptionStep({ control, open = true, onToggle = () => {} }: Props) {
   const isMobile = useIsMobile();
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Event Details"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <Controller<EventDetails, 'eventDescription'>
         name="eventDescription"
         control={control}
@@ -24,6 +32,6 @@ export default function EventDescriptionStep({ control }: Props) {
           />
         )}
       />
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/EventTypeStep.tsx
+++ b/frontend/src/components/booking/steps/EventTypeStep.tsx
@@ -1,10 +1,15 @@
 'use client';
+import { useState, useRef } from 'react';
 import { Control, Controller } from 'react-hook-form';
 import clsx from 'clsx';
+import useIsMobile from '@/hooks/useIsMobile';
 import { EventDetails } from '@/contexts/BookingContext';
+import { BottomSheet, Button, CollapsibleSection } from '../../ui';
 
 interface Props {
   control: Control<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 const options = [
@@ -18,31 +23,87 @@ const options = [
   'Other',
 ];
 
-export default function EventTypeStep({ control }: Props) {
+export default function EventTypeStep({ control, open = true, onToggle = () => {} }: Props) {
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const firstRadioRef = useRef<HTMLInputElement>(null);
+
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Event Type"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <Controller<EventDetails, 'eventType'>
         name="eventType"
         control={control}
         render={({ field }) => (
-          <fieldset className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-            {options.map((opt) => (
-              <div key={opt}>
-                <input
-                  id={`type-${opt}`}
-                  type="radio"
-                  className="selectable-card-input"
-                  name={field.name}
-                  value={opt}
-                  checked={field.value === opt}
-                  onChange={(e) => field.onChange(e.target.value)}
-                />
-                <label htmlFor={`type-${opt}`} className={clsx('selectable-card')}>{opt}</label>
-              </div>
-            ))}
-          </fieldset>
+          <>
+            {isMobile ? (
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => setSheetOpen(true)}
+                  className="w-full text-left min-h-[44px]"
+                  ref={buttonRef}
+                >
+                  {field.value || 'Select event type'}
+                </Button>
+                <BottomSheet
+                  open={sheetOpen}
+                  onClose={() => setSheetOpen(false)}
+                  initialFocus={firstRadioRef}
+                >
+                  <fieldset className="p-4 space-y-2">
+                    {options.map((opt, idx) => (
+                      <div key={opt}>
+                        <input
+                          id={`type-${opt}-mobile`}
+                          ref={idx === 0 ? firstRadioRef : undefined}
+                          type="radio"
+                          className="selectable-card-input"
+                          name={field.name}
+                          value={opt}
+                          checked={field.value === opt}
+                          onChange={(e) => {
+                            field.onChange(e.target.value);
+                            setSheetOpen(false);
+                          }}
+                        />
+                        <label htmlFor={`type-${opt}-mobile`} className="selectable-card">
+                          {opt}
+                        </label>
+                      </div>
+                    ))}
+                  </fieldset>
+                </BottomSheet>
+              </>
+            ) : (
+              <fieldset className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                {options.map((opt) => (
+                  <div key={opt}>
+                    <input
+                      id={`type-${opt}`}
+                      type="radio"
+                      className="selectable-card-input"
+                      name={field.name}
+                      value={opt}
+                      checked={field.value === opt}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                    <label htmlFor={`type-${opt}`} className={clsx('selectable-card')}>
+                      {opt}
+                    </label>
+                  </div>
+                ))}
+              </fieldset>
+            )}
+          </>
         )}
       />
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -2,7 +2,7 @@
 // Larger touch targets and contextual help improve usability on mobile.
 import { Controller, Control } from 'react-hook-form';
 import useIsMobile from '@/hooks/useIsMobile';
-import { TextInput } from '../../ui';
+import { TextInput, CollapsibleSection } from '../../ui';
 
 // Import EventDetails if your actual WizardNav uses it for deeper checks
 import { EventDetails } from '@/contexts/BookingContext'; // Added EventDetails
@@ -10,12 +10,19 @@ import { EventDetails } from '@/contexts/BookingContext'; // Added EventDetails
 
 interface Props {
   control: Control<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
-export default function GuestsStep({ control }: Props) {
+export default function GuestsStep({ control, open = true, onToggle = () => {} }: Props) {
   const isMobile = useIsMobile();
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Guests"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <Controller<EventDetails, 'guests'> // Explicitly type Controller
         name="guests"
         control={control}
@@ -30,8 +37,6 @@ export default function GuestsStep({ control }: Props) {
           />
         )}
       />
-
-
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -15,7 +15,7 @@ const Marker = dynamic(
   { ssr: false },
 );
 import { useRef, useState, useEffect } from 'react';
-import { Button, Tooltip } from '../../ui';
+import { Button, Tooltip, CollapsibleSection } from '../../ui';
 import { geocodeAddress, calculateDistanceKm, LatLng } from '@/lib/geo';
 
 // Import EventDetails if your actual WizardNav uses it for deeper checks
@@ -26,6 +26,8 @@ interface Props {
   control: Control<EventDetails>;
   artistLocation?: string | null;
   setWarning: (w: string | null) => void;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 function GoogleMapsLoader({
@@ -54,6 +56,8 @@ export default function LocationStep({
   control,
   artistLocation,
   setWarning,
+  open = true,
+  onToggle = () => {},
 }: Props): JSX.Element {
   const [shouldLoadMap, setShouldLoadMap] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -103,7 +107,12 @@ export default function LocationStep({
   }
 
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Location"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <div ref={containerRef}>
         {shouldLoadMap ? (
           <GoogleMapsLoader>
@@ -197,7 +206,7 @@ export default function LocationStep({
         className="ml-1"
       />
       {geoError && <p className="text-red-600 text-sm">{geoError}</p>}
-      
-    </div>
+
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -5,6 +5,7 @@ import useIsMobile from '@/hooks/useIsMobile';
 import { uploadBookingAttachment } from '@/lib/api';
 import toast from '../../ui/Toast';
 import { useState } from 'react';
+import { CollapsibleSection } from '../../ui';
 // WizardNav is REMOVED from here.
 
 import { EventDetails } from '@/contexts/BookingContext'; // For correct Control and setValue typing
@@ -13,11 +14,15 @@ import { EventDetails } from '@/contexts/BookingContext'; // For correct Control
 interface Props {
   control: Control<EventDetails>;
   setValue: UseFormSetValue<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 export default function NotesStep({
   control,
   setValue,
+  open = true,
+  onToggle = () => {},
 }: Props) {
   const isMobile = useIsMobile();
   const [uploading, setUploading] = useState(false);
@@ -46,7 +51,12 @@ export default function NotesStep({
     }
   }
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Notes"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <Controller<EventDetails, 'notes'>
         name="notes"
         control={control}
@@ -96,6 +106,6 @@ export default function NotesStep({
         </div>
       )}
       {/* WizardNav is REMOVED from here. Buttons are now in the parent BookingWizard's fixed footer. */}
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -6,6 +6,7 @@ import SummarySidebar from '../SummarySidebar';
 import { formatCurrency } from '@/lib/utils';
 import { TravelResult } from '@/lib/travel';
 import { useBooking } from '@/contexts/BookingContext';
+import { CollapsibleSection } from '../../ui';
 
 interface ReviewStepProps {
   step: number;
@@ -23,6 +24,8 @@ interface ReviewStepProps {
   calculatedPrice: number | null; // This prop will still be passed but its value for display will be overridden
   travelResult: TravelResult | null;
   baseServicePrice: number;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 export default function ReviewStep({
@@ -34,6 +37,8 @@ export default function ReviewStep({
   onNext,
   submitLabel = 'Submit Request',
   baseServicePrice,
+  open = true,
+  onToggle = () => {},
 }: ReviewStepProps) {
   const { details } = useBooking();
 
@@ -69,14 +74,14 @@ export default function ReviewStep({
   };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -20 }}
-      transition={{ duration: 0.3 }}
-      className="space-y-6"
-    >
-      <div className="bg-white p-6 md:p-8 rounded-2xl shadow-lg border border-gray-200/80 max-w-2xl mx-auto"> {/* Reverted card styling */}
+    <CollapsibleSection title="Review" open={open} onToggle={onToggle} className="space-y-6">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -20 }}
+        transition={{ duration: 0.3 }}
+        className="bg-white p-6 md:p-8 rounded-2xl shadow-lg border border-gray-200/80 max-w-2xl mx-auto"
+      >
         <p className="text-sm text-gray-500 mb-6">
           This is an estimated cost. The artist will review your request and send a formal quote.
         </p>
@@ -173,7 +178,7 @@ export default function ReviewStep({
             )}
           </button>
         </div>
-      </div>
-    </motion.div>
+      </motion.div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -1,55 +1,114 @@
 'use client';
+import { useState, useRef } from 'react';
 import { Control, Controller } from 'react-hook-form';
+import useIsMobile from '@/hooks/useIsMobile';
+import { BottomSheet, Button, CollapsibleSection } from '../../ui';
 
-// Import EventDetails if your actual WizardNav uses it for deeper checks
-import { EventDetails } from '@/contexts/BookingContext'; // Added EventDetails
+import { EventDetails } from '@/contexts/BookingContext';
 
 interface Props {
   control: Control<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 export default function SoundStep({
   control,
+  open = true,
+  onToggle = () => {},
 }: Props) {
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const firstRadioRef = useRef<HTMLInputElement>(null);
+
   return (
-    <div className="wizard-step-container">
-      <Controller<EventDetails, 'sound'> // Explicitly type Controller
+    <CollapsibleSection
+      title="Sound"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
+      <Controller<EventDetails, 'sound'>
         name="sound"
         control={control}
         render={({ field }) => (
-          <fieldset className="space-y-2">
-            <div>
-              <input
-                id="sound-yes"
-                type="radio"
-                className="selectable-card-input"
-                name={field.name}
-                value="yes"
-                checked={field.value === 'yes'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <label htmlFor="sound-yes" className="selectable-card">
-                Yes
-              </label>
-            </div>
-            <div>
-              <input
-                id="sound-no"
-                type="radio"
-                className="selectable-card-input"
-                name={field.name}
-                value="no"
-                checked={field.value === 'no'}
-                onChange={(e) => field.onChange(e.target.value)}
-              />
-              <label htmlFor="sound-no" className="selectable-card">
-                No
-              </label>
-            </div>
-          </fieldset>
+          <>
+            {isMobile ? (
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => setSheetOpen(true)}
+                  className="w-full text-left min-h-[44px]"
+                  ref={buttonRef}
+                >
+                  {field.value ? `Sound: ${field.value === 'yes' ? 'Yes' : 'No'}` : 'Select sound preference'}
+                </Button>
+                <BottomSheet
+                  open={sheetOpen}
+                  onClose={() => setSheetOpen(false)}
+                  initialFocus={firstRadioRef}
+                >
+                  <fieldset className="p-4 space-y-2">
+                    {['yes', 'no'].map((opt, idx) => (
+                      <div key={opt}>
+                        <input
+                          id={`sound-${opt}-mobile`}
+                          ref={idx === 0 ? firstRadioRef : undefined}
+                          type="radio"
+                          className="selectable-card-input"
+                          name={field.name}
+                          value={opt}
+                          checked={field.value === opt}
+                          onChange={(e) => {
+                            field.onChange(e.target.value);
+                            setSheetOpen(false);
+                          }}
+                        />
+                        <label htmlFor={`sound-${opt}-mobile`} className="selectable-card">
+                          {opt === 'yes' ? 'Yes' : 'No'}
+                        </label>
+                      </div>
+                    ))}
+                  </fieldset>
+                </BottomSheet>
+              </>
+            ) : (
+              <fieldset className="space-y-2 sm:flex sm:space-y-0 sm:gap-2">
+                <div>
+                  <input
+                    id="sound-yes"
+                    type="radio"
+                    className="selectable-card-input"
+                    name={field.name}
+                    value="yes"
+                    checked={field.value === 'yes'}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                  <label htmlFor="sound-yes" className="selectable-card">
+                    Yes
+                  </label>
+                </div>
+                <div>
+                  <input
+                    id="sound-no"
+                    type="radio"
+                    className="selectable-card-input"
+                    name={field.name}
+                    value="no"
+                    checked={field.value === 'no'}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
+                  <label htmlFor="sound-no" className="selectable-card">
+                    No
+                  </label>
+                </div>
+              </fieldset>
+            )}
+          </>
         )}
       />
-
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -2,16 +2,20 @@
 import { Controller, Control } from 'react-hook-form'; // Removed FieldValues
 import { useState, useRef } from 'react';
 import useIsMobile from '@/hooks/useIsMobile';
-import { BottomSheet, Button } from '../../ui';
+import { BottomSheet, Button, CollapsibleSection } from '../../ui';
 
 import { EventDetails } from '@/contexts/BookingContext'; // For correct Control typing
 
 interface Props {
   control: Control<EventDetails>;
+  open?: boolean;
+  onToggle?: () => void;
 }
 
 export default function VenueStep({
   control,
+  open = true,
+  onToggle = () => {},
 }: Props) {
   const isMobile = useIsMobile();
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -25,7 +29,12 @@ export default function VenueStep({
   ];
 
   return (
-    <div className="wizard-step-container">
+    <CollapsibleSection
+      title="Venue Type"
+      open={open}
+      onToggle={onToggle}
+      className="wizard-step-container"
+    >
       <Controller<EventDetails, 'venueType'>
         name="venueType"
         control={control}
@@ -101,6 +110,6 @@ export default function VenueStep({
         )}
       />
 
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/DateTimeStep.test.tsx
@@ -13,11 +13,6 @@ function Wrapper() {
     <DateTimeStep
       control={control as Control<EventDetails>}
       unavailable={[]}
-      step={0}
-      steps={['one']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
     />
   );
 }
@@ -29,11 +24,6 @@ function LoadingWrapper() {
       control={control as Control<EventDetails>}
       unavailable={[]}
       loading
-      step={0}
-      steps={['one']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
     />
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/GuestsStep.test.tsx
@@ -4,18 +4,9 @@ import { act } from 'react';
 import { useForm, Control, FieldValues } from 'react-hook-form';
 import GuestsStep from '../GuestsStep';
 
-function Wrapper({ onNext = () => {} }: { onNext?: () => void }) {
+function Wrapper() {
   const { control } = useForm({ defaultValues: { guests: '' } });
-  return (
-    <GuestsStep
-      control={control as unknown as Control<FieldValues>}
-      step={2}
-      steps={['one', 'two', 'three']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={onNext}
-    />
-  );
+  return <GuestsStep control={control as unknown as Control<FieldValues>} />;
 }
 
 describe('GuestsStep input', () => {
@@ -43,17 +34,11 @@ describe('GuestsStep input', () => {
     expect(input).not.toBeNull();
   });
 
-  it('calls onNext when Next clicked', () => {
-    const nextSpy = jest.fn();
+  it('renders number input', () => {
     act(() => {
-      root.render(React.createElement(Wrapper, { onNext: nextSpy }));
+      root.render(React.createElement(Wrapper));
     });
-    const nextButton = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Next') || b.textContent?.includes('Submit'),
-    ) as HTMLButtonElement;
-    act(() => {
-      nextButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(nextSpy).toHaveBeenCalled();
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input).not.toBeNull();
   });
 });

--- a/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/LocationStep.test.tsx
@@ -41,12 +41,7 @@ function Wrapper() {
     <LocationStep
       control={control as unknown as Control<FieldValues>}
       setWarning={() => {}}
-      step={1}
-      steps={['one', 'two']}
       artistLocation={null}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
     />
   );
 }

--- a/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/NotesStep.test.tsx
@@ -16,11 +16,6 @@ function Wrapper() {
     <NotesStep
       control={control as unknown as Control<FieldValues>}
       setValue={setValue}
-      step={0}
-      steps={['one', 'two']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
     />
   );
 }
@@ -70,18 +65,12 @@ describe('NotesStep attachment upload', () => {
 
     await flushPromises();
 
-    const nextButton = Array.from(container.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Next'),
-    ) as HTMLButtonElement;
-
     expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
-    expect(nextButton.disabled).toBe(true);
 
     await act(async () => {
       resolveUpload();
     });
 
     expect(container.querySelector('[role="progressbar"]')).toBeNull();
-    expect(nextButton.disabled).toBe(false);
   });
 });

--- a/frontend/src/components/booking/steps/__tests__/SoundStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/SoundStep.test.tsx
@@ -6,16 +6,7 @@ import SoundStep from '../SoundStep';
 
 function Wrapper() {
   const { control } = useForm({ defaultValues: { sound: 'yes' } });
-  return (
-    <SoundStep
-      control={control as unknown as Control<FieldValues>}
-      step={1}
-      steps={['one', 'two']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
-    />
-  );
+  return <SoundStep control={control as unknown as Control<FieldValues>} />;
 }
 
 describe('SoundStep radio buttons', () => {

--- a/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/VenueStep.test.tsx
@@ -8,30 +8,12 @@ import VenueStep from '../VenueStep';
 
 function MobileWrapper() {
   const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
-  return (
-    <VenueStep
-      control={control as unknown as Control<FieldValues>}
-      step={2}
-      steps={['one', 'two', 'three']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
-    />
-  );
+  return <VenueStep control={control as unknown as Control<FieldValues>} />;
 }
 
 function Wrapper() {
   const { control } = useForm({ defaultValues: { venueType: 'indoor' } });
-  return (
-    <VenueStep
-      control={control as unknown as Control<FieldValues>}
-      step={2}
-      steps={['one', 'two', 'three']}
-      onBack={() => {}}
-      onSaveDraft={() => {}}
-      onNext={() => {}}
-    />
-  );
+  return <VenueStep control={control as unknown as Control<FieldValues>} />;
 }
 
 describe('VenueStep radio buttons', () => {
@@ -90,7 +72,8 @@ describe('VenueStep bottom sheet mobile', () => {
     await act(async () => {
       root.render(React.createElement(MobileWrapper));
     });
-    const openButton = container.querySelector('button') as HTMLButtonElement;
+    const buttons = Array.from(container.querySelectorAll('button')) as HTMLButtonElement[];
+    const openButton = buttons.find((b) => b.textContent?.includes('Venue')) as HTMLButtonElement;
     act(() => {
       openButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/frontend/src/components/ui/CollapsibleSection.tsx
+++ b/frontend/src/components/ui/CollapsibleSection.tsx
@@ -29,7 +29,7 @@ export default function CollapsibleSection({
           aria-expanded={open}
           aria-controls={contentId}
           onClick={onToggle}
-          className="w-full p-4 text-left font-bold border-b flex justify-between focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          className="w-full p-4 min-h-[44px] text-left font-bold border-b flex justify-between focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
         >
           <span>{title}</span>
           <span


### PR DESCRIPTION
## Summary
- make all booking wizard steps collapsible with accessible headers
- use bottom sheet selectors for event type and sound steps on mobile
- ensure selectable cards meet 44×44px tap target

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: useSearchParams is not a function)*
- `npx playwright test e2e/collapsible-section.spec.ts` *(fails: TypeError: useSearchParams is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6891f3b1b218832eaa655189ff951fd2