### PR TITLE
fix: add safe area padding to mobile nav

### DIFF
--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -10,7 +10,6 @@ import {
 } from '@heroicons/react/24/outline';
 import type { User } from '@/types';
 import useNotifications from '@/hooks/useNotifications';
-import { toUnifiedFromNotification } from '@/hooks/notificationUtils';
 import type { UnifiedNotification } from '@/types';
 import useScrollDirection from '@/hooks/useScrollDirection';
 
@@ -53,7 +52,7 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   return (
     <nav
       className={classNames(
-        'fixed bottom-0 w-full h-[56px] py-1 bg-background border-t shadow z-50 sm:hidden transition-transform',
+        'fixed bottom-0 w-full h-[56px] py-1 bg-background border-t shadow z-50 sm:hidden transition-transform pb-safe',
         scrollDir === 'down' ? 'translate-y-full' : 'translate-y-0',
       )}
       aria-label="Mobile navigation"

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -71,6 +71,8 @@ describe('MobileBottomNav', () => {
     });
     expect(container.textContent).toContain('Home');
     expect(container.textContent).toContain('Artists');
+    const nav = container.querySelector('nav');
+    expect(nav?.className).toContain('pb-safe');
   });
 
   it('shows unread message count badge', () => {


### PR DESCRIPTION
## Summary
- ensure the mobile bottom navigation respects device safe areas
- verify the mobile nav applies safe-area padding in unit tests

## Testing
- `npx eslint src/components/layout/MobileBottomNav.tsx src/components/layout/__tests__/MobileBottomNav.test.tsx`
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6891f2f3db04832e8a61bc1132eaf91f