### PR TITLE
docs: add frontend style guide

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,6 +36,8 @@ Primary, secondary and outline buttons now use the brand color for borders and b
 
 See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary of spacing, typography and component styles.
 
+[STYLE_GUIDE.md](STYLE_GUIDE.md) documents Tailwind breakpoints, CSS variables and UI patterns like `CollapsibleSection` and `BottomSheet`. Update it whenever major UI changes are introduced.
+
 ### Responsive Breakpoints
 
 The `BREAKPOINT_SM` constant in `breakpoints.config.js` defines the `sm`

--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -1,0 +1,48 @@
+# Frontend Style Guide
+
+This guide documents layout breakpoints, design tokens, and reusable UI patterns. For project setup and testing instructions, see [README.md](README.md). Update this file whenever the interface changes significantly.
+
+## Tailwind Breakpoints
+
+| Name | Width | Design usage |
+| ---- | ----- | ------------ |
+| `sm` | `BREAKPOINT_SM` (640px) | base mobile layout, `MobileBottomNav` and `BottomSheet` triggers |
+| `md` | 768px | tablet layouts and two-column grids |
+| `lg` | 1024px | desktop layouts with sidebars |
+| `xl` | 1280px | wide desktop, max content width |
+| `2xl` | 1536px | very wide screens and large monitors |
+
+The `sm` value comes from [`breakpoints.config.js`](breakpoints.config.js) and is re-exported via `@/lib/breakpoints` for hooks like `useIsMobile` so JavaScript and CSS stay in sync.
+
+## CSS Variables
+
+All colors and custom spacing values must be expressed as CSS variables and declared in [`src/app/globals.css`](src/app/globals.css). Reference them with `var(--token-name)` instead of hard-coded hex or pixel values:
+
+```css
+:root {
+  --color-primary: #ff5a5f;
+  --space-lg: 1.5rem;
+}
+```
+
+```jsx
+<div className="text-[var(--color-primary)] p-[var(--space-lg)]" />
+```
+
+## Component Patterns
+
+### CollapsibleSection
+
+Use `<CollapsibleSection>` from `@/components/ui` for expandable groups. It renders a button with `aria-expanded` and toggles a region identified by `aria-controls`, providing accessible accordions for wizard steps and dashboards.
+
+### BottomSheet
+
+`<BottomSheet>` displays a sliding panel anchored to the viewport bottom. It wraps Headless UI's `Dialog` to trap focus, animates with Tailwind transitions, and returns focus to the trigger on close. Apply it for mobile pickers, filter sheets, and modal forms.
+
+### Mobile Navigation
+
+Mobile navigation uses the `MobileBottomNav` component. It appears only below the `sm` breakpoint, hides on downward scroll, and supports unread message badges. Keep route names and icons consistent across the app.
+
+## Maintenance
+
+Review and update this file alongside major UI or design system changes.


### PR DESCRIPTION
## Summary
- document Tailwind breakpoints, CSS variables, and common UI patterns in `frontend/STYLE_GUIDE.md`
- link style guide from `frontend/README.md` and note that it must be updated when major UI changes occur

## Testing
- Documentation only; no tests run


------
https://chatgpt.com/codex/tasks/task_e_6891f74c685c832eb6e5246a60ddbbca