### PR TITLE
refactor: centralize design tokens

### DIFF
--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -7,12 +7,12 @@ This guide documents layout breakpoints, design tokens, and reusable UI patterns
 | Name | Width | Design usage |
 | ---- | ----- | ------------ |
 | `sm` | `BREAKPOINT_SM` (640px) | base mobile layout, `MobileBottomNav` and `BottomSheet` triggers |
-| `md` | 768px | tablet layouts and two-column grids |
-| `lg` | 1024px | desktop layouts with sidebars |
+| `md` | `BREAKPOINT_MD` (768px) | tablet layouts and two-column grids |
+| `lg` | `BREAKPOINT_LG` (1024px) | desktop layouts with sidebars |
 | `xl` | 1280px | wide desktop, max content width |
 | `2xl` | 1536px | very wide screens and large monitors |
 
-The `sm` value comes from [`breakpoints.config.js`](breakpoints.config.js) and is re-exported via `@/lib/breakpoints` for hooks like `useIsMobile` so JavaScript and CSS stay in sync.
+The `sm`, `md`, and `lg` values come from [`breakpoints.config.js`](breakpoints.config.js) and are re-exported via `@/lib/breakpoints` for hooks like `useIsMobile` so JavaScript and CSS stay in sync.
 
 ## CSS Variables
 
@@ -28,6 +28,16 @@ All colors and custom spacing values must be expressed as CSS variables and decl
 ```jsx
 <div className="text-[var(--color-primary)] p-[var(--space-lg)]" />
 ```
+
+### Tokens
+
+| Token | Value | Description |
+| ----- | ----- | ----------- |
+| `--space-px` | `1px` | Hairline spacing for subtle offsets |
+| `--space-1` | `0.25rem` | Base unit for small translations |
+| `--color-foreground-rgb` | `17 24 39` | RGB components of `--color-foreground` |
+| `--shadow-sm` | `0 6px 20px rgb(var(--color-foreground-rgb) / 8%)` | Subtle card shadow |
+| `--shadow-md` | `0 8px 24px rgb(var(--color-foreground-rgb) / 15%)` | Hover card shadow |
 
 ## Component Patterns
 

--- a/frontend/breakpoints.config.js
+++ b/frontend/breakpoints.config.js
@@ -1,3 +1,5 @@
 const BREAKPOINT_SM = 640;
+const BREAKPOINT_MD = 768;
+const BREAKPOINT_LG = 1024;
 
-module.exports = { BREAKPOINT_SM };
+module.exports = { BREAKPOINT_SM, BREAKPOINT_MD, BREAKPOINT_LG };

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -44,6 +44,15 @@
 
   /* additional utility colors */
   --color-indigo-100: #e0e7ff;
+
+  /* spacing tokens */
+  --space-px: 1px;
+  --space-1: 0.25rem;
+
+  /* shadow colors using foreground rgb */
+  --color-foreground-rgb: 17 24 39;
+  --shadow-sm: 0 6px 20px rgb(var(--color-foreground-rgb) / 8%);
+  --shadow-md: 0 8px 24px rgb(var(--color-foreground-rgb) / 15%);
 }
 
 @layer base {

--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -72,7 +72,7 @@ export default function ArtistCard({
 
   return (
     <motion.div
-      whileHover={{ y: -4, boxShadow: '0 8px 24px rgba(0,0,0,0.15)' }}
+      whileHover={{ y: 'calc(-1 * var(--space-1))', boxShadow: 'var(--shadow-md)' }}
       className={clsx(
         'rounded-2xl bg-white shadow-lg overflow-hidden transition-shadow',
         className,

--- a/frontend/src/components/artist/ArtistCardCompact.tsx
+++ b/frontend/src/components/artist/ArtistCardCompact.tsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
 import { getFullImageUrl } from '@/lib/utils';
+import { BREAKPOINT_MD } from '@/lib/breakpoints';
 
 export interface ArtistCardCompactProps
   extends LinkProps,
@@ -56,7 +57,7 @@ export default function ArtistCardCompact({
             src={imageUrl}
             alt={name}
             fill
-            sizes="(max-width:768px) 50vw, 33vw"
+            sizes={`(max-width:${BREAKPOINT_MD}px) 50vw, 33vw`}
             className="object-cover w-full h-full group-hover:scale-105 transition-transform"
             onLoad={() => setLoaded(true)}
             onError={(e) => {
@@ -68,7 +69,7 @@ export default function ArtistCardCompact({
             src={getFullImageUrl('/static/default-avatar.svg') as string}
             alt={name}
             fill
-            sizes="(max-width:768px) 0vw, 33vw"
+            sizes={`(max-width:${BREAKPOINT_MD}px) 0vw, 33vw`}
             className="object-cover w-full h-full"
             onLoad={() => setLoaded(true)}
           />

--- a/frontend/src/components/artist/ArtistsPageHeader.tsx
+++ b/frontend/src/components/artist/ArtistsPageHeader.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { FunnelIcon } from '@heroicons/react/24/outline';
 import SearchModal from '@/components/search/SearchModal';
 import useMediaQuery from '@/hooks/useMediaQuery';
+import { BREAKPOINT_MD } from '@/lib/breakpoints';
 import { format } from 'date-fns';
 import FilterSheet from './FilterSheet';
 import { SLIDER_MIN, SLIDER_MAX } from '@/lib/filter-constants';
@@ -47,7 +48,7 @@ export default function ArtistsPageHeader({
   onFilterClear,
   iconOnly,
 }: ArtistsPageHeaderProps) {
-  const isDesktop = useMediaQuery('(min-width:768px)');
+  const isDesktop = useMediaQuery(`(min-width:${BREAKPOINT_MD}px)`);
   const [searchOpen, setSearchOpen] = useState(false);
   const [filterOpen, setFilterOpen] = useState(false);
 

--- a/frontend/src/components/artist/FilterSheet.tsx
+++ b/frontend/src/components/artist/FilterSheet.tsx
@@ -2,6 +2,7 @@
 import { useRef, useEffect, useState } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import useMediaQuery from "@/hooks/useMediaQuery";
+import { BREAKPOINT_MD } from "@/lib/breakpoints";
 import { BottomSheet } from "@/components/ui";
 import PriceFilter from "@/components/ui/PriceFilter";
 import { createPortal } from "react-dom";
@@ -36,7 +37,7 @@ export default function FilterSheet({
   priceDistribution,
 }: FilterSheetProps) {
   const firstRef = useRef<HTMLInputElement>(null);
-  const isDesktop = useMediaQuery("(min-width:768px)");
+  const isDesktop = useMediaQuery(`(min-width:${BREAKPOINT_MD}px)`);
   const [mounted, setMounted] = useState(false);
   const [localSort, setLocalSort] = useState(initialSort || "");
 

--- a/frontend/src/components/booking/SummarySidebar.tsx
+++ b/frontend/src/components/booking/SummarySidebar.tsx
@@ -99,7 +99,7 @@ export default function SummarySidebar() {
         )}
       </div>
 
-      <div className="flex justify-center w-full" style={{ marginTop: '0.01rem' }}>
+      <div className="flex justify-center w-full mt-[var(--space-px)]">
         <button
           onClick={() => setIsVisible(false)}
           className="text-gray-400 hover:text-gray-800 font-medium py-2 text-sm flex items-center justify-center space-x-1 cursor-pointer"

--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -36,7 +36,7 @@
 }
 
 .shadow-custom {
-  box-shadow: 0 6px 20px rgb(0 0 0 / 8%);
+  box-shadow: var(--shadow-sm);
 }
 
 .progress-bar-fill {

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -15,6 +15,7 @@ import NotificationCard from '../ui/NotificationCard';
 import getNotificationDisplayProps from '@/hooks/getNotificationDisplayProps';
 import { ToggleSwitch, IconButton } from '../ui';
 import type { UnifiedNotification } from '@/types';
+import { BREAKPOINT_SM } from '@/lib/breakpoints';
 
 interface NotificationDrawerProps {
   open: boolean;
@@ -41,8 +42,8 @@ export default function NotificationDrawer({
 }: NotificationDrawerProps) {
   const ROW_HEIGHT = 72;
 
-  // responsive PAGE_SIZE: 3 rows on small (<640px), else 5
-  const getPageSize = () => (window.innerWidth < 640 ? 3 : 5);
+  // responsive PAGE_SIZE: 3 rows on small (<BREAKPOINT_SM), else 5
+  const getPageSize = () => (window.innerWidth < BREAKPOINT_SM ? 3 : 5);
   const [pageSize, setPageSize] = useState(getPageSize);
 
   // update pageSize on window resize

--- a/frontend/src/lib/breakpoints.ts
+++ b/frontend/src/lib/breakpoints.ts
@@ -1,3 +1,7 @@
 // Re-export shared breakpoint constants so application code can import them
 // using the `@/lib` alias while Tailwind consumes the original config.
-export { BREAKPOINT_SM } from '../../breakpoints.config.js';
+export {
+  BREAKPOINT_SM,
+  BREAKPOINT_MD,
+  BREAKPOINT_LG,
+} from '../../breakpoints.config.js';


### PR DESCRIPTION
## Summary
- replace hardcoded breakpoints with shared constants
- convert inline shadows and spacing to CSS variables
- document new design tokens

## Testing
- `npx jest src/components/layout/__tests__/NotificationVirtualization.test.tsx` *(fails: Identifier 'FixedSizeListType' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6891fd0326f4832ea2943a15a3a6cd49