### PR TITLE
Fix datepicker overflow on large screens

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -141,7 +141,7 @@
   /* Booking wizard common styles */
   .wizard-step-container {
     /* Ensure a consistent width across all booking steps */
-    @apply w-full mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-1;
+    @apply w-full mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8;
     /* Keep height stable so the card doesn't jump between steps */
     @apply lg:min-h-[400px];
   }


### PR DESCRIPTION
## Summary
- ensure BookingWizard's date picker fits within step container on wide layouts

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689207a12300832e922fc17061e4b056