### PR TITLE
fix: expand message thread on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Desktop bubbles expand wider to avoid unnecessary line breaks.
 * Floating “scroll to latest” button on small screens.
 * File uploads show an inline progress bar and the send button is disabled until complete.
+* Message composer now accounts for the mobile bottom navigation, staying above it with safe-area padding.
 * Artists can now review itemized quotes in a **View Quote** modal. Quote numbers are generated automatically, today's date appears, and a short description can be added. A compact **Choose template** dropdown sits beside the "View Quote" title and the **Add Item** button now sits below the travel fee. The bottom of the modal mirrors the booking review step with an estimated cost breakdown and a **Submit Request** button. Clients can accept or decline, and accepted quotes show a confirmation banner.
 * When booking details include estimated costs, the modal pre-fills the service, travel, and sound fees so artists have a starting point.
 * The modal uses the same horizontal layout for service, sound, travel, and discount fees as the "Add Item" rows. Added line items now share the same bordered row styling with padding and rounded corners so everything aligns consistently. These fee fields are editable so artists can enter amounts directly. Future releases will add PDF preview, currency symbols inside inputs, and an artist signature/terms block.

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -36,6 +36,7 @@ import usePaymentModal from '@/hooks/usePaymentModal';
 import QuoteBubble from './QuoteBubble';
 import useWebSocket from '@/hooks/useWebSocket';
 import { format } from 'date-fns';
+import { FixedSizeList as List } from 'react-window';
 
 
 // Constants
@@ -590,7 +591,7 @@ useEffect(() => {
     );
 
     return (
-      <div className="flex flex-col h-full rounded-b-2xl overflow-hidden">
+      <div className="flex flex-col h-full rounded-b-2xl overflow-hidden w-full">
         {/* Messages Container */}
         <div
           ref={messagesContainerRef}
@@ -901,7 +902,7 @@ useEffect(() => {
             {/* Message Input Form */}
             <form
               onSubmit={handleSendMessage}
-              className="sticky bottom-0 bg-white border-t border-gray-100 flex items-center gap-x-2 px-3 py-2.5 shadow-lg"
+              className="sticky bottom-[56px] sm:bottom-0 bg-white border-t border-gray-100 flex items-center gap-x-2 px-3 py-2.5 shadow-lg pb-safe"
             >
               <input
                 id="file-upload"

--- a/frontend/src/components/inbox/MessageThreadWrapper.tsx
+++ b/frontend/src/components/inbox/MessageThreadWrapper.tsx
@@ -124,7 +124,7 @@ export default function MessageThreadWrapper({
   }
 
   return (
-    <div className="flex flex-col h-full bg-white shadow-xl border border-gray-100 relative">
+    <div className="flex flex-col h-full w-full bg-white shadow-xl border border-gray-100 relative">
       {/* Unified Header */}
       <header className="sticky top-0 z-10 bg-gradient-to-r from-red-600 to-indigo-700 text-white px-4 py-2 flex items-center  md:min-h-[64px]">
         <div className="flex items-center transition-all duration-300 ease-in-out">
@@ -290,10 +290,13 @@ export default function MessageThreadWrapper({
       )}
 
       {/* Main Content Area */}
-      <div className="flex flex-1 min-h-0 flex-col md:flex-row relative">
-        <div className={`flex-1 min-w-0 p-4 transition-[width] duration-300 ease-in-out ${
-          showSidePanel ? 'md:w-[calc(100%-300px)] lg:w-[calc(100%-360px)]' : 'md:w-full'
-        }`}>         
+      <div className="flex flex-1 min-h-0 flex-col md:flex-row relative w-full">
+        <div
+          data-testid="thread-container"
+          className={`flex-1 min-w-0 w-full p-4 transition-[width] duration-300 ease-in-out ${
+            showSidePanel ? 'md:w-[calc(100%-300px)] lg:w-[calc(100%-360px)]' : 'md:w-full'
+          }`}
+        >
           <MessageThread
             bookingRequestId={bookingRequestId}
             serviceId={bookingRequest.service_id ?? undefined}

--- a/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
+++ b/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
@@ -129,4 +129,19 @@ describe('MessageThreadWrapper', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('fills width on mobile screens', async () => {
+    (global as any).innerWidth = 500;
+    const { container, root } = setup('client');
+    await act(async () => {
+      root.render(
+        <MessageThreadWrapper bookingRequestId={1} bookingRequest={bookingRequest as any} setShowReviewModal={() => {}} />,
+      );
+    });
+    await act(async () => {});
+    const thread = container.querySelector('[data-testid="thread-container"]');
+    expect(thread?.className).toContain('w-full');
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure booking message thread spans full width on small screens
- keep composer above MobileBottomNav with safe-area padding
- cover mobile viewport width in MessageThreadWrapper tests

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689206e27760832eb1f2fa0e86e72e6e