### PR TITLE
feat: unify navigation components

### DIFF
--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -53,6 +53,13 @@ Use `<CollapsibleSection>` from `@/components/ui` for expandable groups. It rend
 
 Mobile navigation uses the `MobileBottomNav` component. It appears only below the `sm` breakpoint, hides on downward scroll, and supports unread message badges. Keep route names and icons consistent across the app.
 
+### Navigation Guidelines
+
+- All navigation links and buttons should use the shared `NavLink` component or the `navItemClasses` utility to ensure consistent typography and spacing.
+- Interactive targets must be at least `44x44px` (`min-w-[44px] min-h-[44px]`).
+- Provide either visible text or an `aria-label` for every interactive element.
+- Active links are styled by passing `isActive` to `NavLink`.
+
 ## Maintenance
 
 Review and update this file alongside major UI or design system changes.

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import NotificationBell from './NotificationBell'; // Assuming NotificationBell 
 import BookingRequestIcon from './BookingRequestIcon'; // Assuming BookingRequestIcon is set up
 import MobileMenuDrawer from './MobileMenuDrawer'; // Assuming MobileMenuDrawer is set up
 import SearchBar from '../search/SearchBar'; // The full search bar component
+import { navItemClasses } from './navStyles';
 import { UI_CATEGORY_TO_SERVICE, SERVICE_TO_UI_CATEGORY, UI_CATEGORIES } from '@/lib/categoryMap';
 import { Avatar } from '../ui'; // Assuming Avatar is set up
 import clsx from 'clsx';
@@ -244,14 +245,24 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
             {user ? (
               <>
                 {user.user_type === 'artist' && (
-                  <button onClick={toggleArtistView} className="text-sm text-gray-700">
+                  <button
+                    onClick={toggleArtistView}
+                    className={clsx(navItemClasses, 'text-gray-700')}
+                  >
                     {artistViewActive ? 'Switch to Booking' : 'Switch to Artist View'}
                   </button>
                 )}
-                <BookingRequestIcon />
-                <NotificationBell />
+                <div className={navItemClasses}>
+                  <BookingRequestIcon />
+                </div>
+                <div className={navItemClasses}>
+                  <NotificationBell />
+                </div>
                 <Menu as="div" className="relative">
-                  <Menu.Button className="flex rounded-full bg-gray-100 text-sm focus:outline-none">
+                  <Menu.Button
+                    aria-label="Account menu"
+                    className={clsx(navItemClasses, 'rounded-full bg-gray-100 text-sm focus:outline-none')}
+                  >
                     <Avatar
                       src={user.profile_picture_url || null}
                       initials={user.first_name?.[0] || user.email[0]}
@@ -292,9 +303,16 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                 </Menu>
               </>
             ) : (
-              <div className="space-x-4">
-                <Link href="/login" className="text-sm text-gray-600">Sign in</Link>
-                <Link href="/register" className="text-sm text-white bg-brand-dark px-3 py-1 rounded">Sign up</Link>
+              <div className="flex gap-2">
+                <Link href="/login" className={clsx(navItemClasses, 'text-gray-600')}>
+                  Sign in
+                </Link>
+                <Link
+                  href="/register"
+                  className={clsx(navItemClasses, 'bg-brand-dark text-white rounded')}
+                >
+                  Sign up
+                </Link>
               </div>
             )}
           </div>

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
   HomeIcon,
@@ -12,6 +11,9 @@ import type { User } from '@/types';
 import useNotifications from '@/hooks/useNotifications';
 import type { UnifiedNotification } from '@/types';
 import useScrollDirection from '@/hooks/useScrollDirection';
+import NavLink from './NavLink';
+import { navItemClasses } from './navStyles';
+import clsx from 'clsx';
 
 interface MobileBottomNavProps {
   user: User | null;
@@ -24,10 +26,6 @@ interface Item {
   auth?: boolean;
 }
 
-function classNames(...classes: (string | false | undefined)[]) {
-  return classes.filter(Boolean).join(' ');
-}
-
 export default function MobileBottomNav({ user }: MobileBottomNavProps) {
   const router = useRouter();
   const { items } = useNotifications();
@@ -37,7 +35,12 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
     { name: 'Home', href: '/', icon: HomeIcon },
     { name: 'Artists', href: '/artists', icon: UsersIcon },
     { name: 'Messages', href: '/inbox', icon: ChatBubbleLeftRightIcon, auth: true },
-    { name: 'Dashboard', href: user?.user_type === 'artist' ? '/dashboard/artist' : '/dashboard/client', icon: UserCircleIcon, auth: true },
+    {
+      name: 'Dashboard',
+      href: user?.user_type === 'artist' ? '/dashboard/artist' : '/dashboard/client',
+      icon: UserCircleIcon,
+      auth: true,
+    },
   ];
   if (!user) {
     return null;
@@ -51,7 +54,7 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
 
   return (
     <nav
-      className={classNames(
+      className={clsx(
         'fixed bottom-0 w-full h-[56px] py-1 bg-background border-t shadow z-50 sm:hidden transition-transform pb-safe',
         scrollDir === 'down' ? 'translate-y-full' : 'translate-y-0',
       )}
@@ -64,30 +67,31 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
 
           return (
             <li key={item.name} className="flex-1">
-              <Link
+              <NavLink
                 href={item.href}
+                isActive={active}
                 aria-current={active ? 'page' : undefined}
-                className={classNames(
-                  'flex flex-col items-center justify-center gap-1 py-0.5 transition-colors no-underline hover:no-underline',
+                aria-label={item.name}
+                className={clsx(
+                  navItemClasses,
+                  'flex flex-col items-center justify-center gap-1 h-full',
                   active
-                    ? 'text-brand-dark border-b-2 border-brand-dark'
-                    : 'text-gray-500 hover:text-gray-700'
+                    ? 'text-brand-dark border-brand-dark'
+                    : 'text-gray-500 hover:text-gray-700',
                 )}
               >
-                <div className="flex flex-col items-center space-y-0.5">
-                  <div className="relative flex items-center justify-center">
-                    <item.icon className="h-6 w-6" aria-hidden="true" />
-                    {showBadge && (
-                      <span
-                        className="absolute top-0 right-0 inline-flex translate-x-1/2 -translate-y-1/2 items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
-                      >
-                        {badgeCount}
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-[11px]">{item.name}</span>
+                <div className="relative flex items-center justify-center">
+                  <item.icon className="h-6 w-6" aria-hidden="true" />
+                  {showBadge && (
+                    <span
+                      className="absolute top-0 right-0 inline-flex translate-x-1/2 -translate-y-1/2 items-center justify-center px-1.5 py-0.5 text-[11px] font-bold leading-none text-white bg-red-600 rounded-full ring-2 ring-white"
+                    >
+                      {badgeCount}
+                    </span>
+                  )}
                 </div>
-              </Link>
+                <span className="text-[11px]">{item.name}</span>
+              </NavLink>
             </li>
           );
         })}

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -3,8 +3,10 @@
 import { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import Link from 'next/link';
+import clsx from 'clsx';
 import type { User } from '@/types';
+import NavLink from './NavLink';
+import { navItemClasses } from './navStyles';
 
 interface NavItem {
   name: string;
@@ -19,10 +21,6 @@ interface MobileMenuDrawerProps {
   user: User | null;
   logout: () => void;
   pathname: string;
-}
-
-function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ');
 }
 
 export default function MobileMenuDrawer({
@@ -64,139 +62,137 @@ export default function MobileMenuDrawer({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                  aria-label="Close menu"
+                  className={clsx(
+                    navItemClasses,
+                    'rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+                  )}
                 >
-                  <span className="sr-only">Close menu</span>
                   <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                 </button>
               </div>
               <div className="mt-4 space-y-1 px-2">
                 {navigation.map((item) => (
-                  <Link
+                  <NavLink
                     key={item.name}
                     href={item.href}
                     onClick={onClose}
-                    className={classNames(
-                      pathname === item.href
-                        ? 'bg-brand-light border-brand text-brand-dark'
-                        : 'border-transparent text-gray-700 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900',
-                      'block border-l-4 px-3 py-2 text-base font-medium no-underline hover:no-underline'
-                    )}
+                    isActive={pathname === item.href}
+                    className="block border-l-4 text-base"
                   >
                     {item.name}
-                  </Link>
+                  </NavLink>
                 ))}
               </div>
               {(drawerNavigation ?? []).length > 0 && (
                 <div className="mt-2 space-y-1 px-2">
                   {(drawerNavigation ?? []).map((item) => (
-                    <Link
+                    <NavLink
                       key={item.name}
                       href={item.href}
                       onClick={onClose}
-                      className={classNames(
-                        pathname === item.href
-                          ? "bg-brand-light border-brand text-brand-dark"
-                          : "border-transparent text-gray-700 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900",
-                        "block border-l-4 px-3 py-2 text-base font-medium no-underline hover:no-underline",
-                      )}
+                      isActive={pathname === item.href}
+                      className="block border-l-4 text-base"
                     >
                       {item.name}
-                    </Link>
+                    </NavLink>
                   ))}
                 </div>
               )}
               <div className="mt-4 border-t border-gray-200 pt-4 px-2">
                 {user ? (
                   <>
-                    <Link
+                    <NavLink
                       href={user.user_type === 'artist' ? '/dashboard/artist' : '/dashboard/client'}
                       onClick={onClose}
-                      className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                     >
                       Dashboard
-                    </Link>
+                    </NavLink>
                     {user.user_type === 'artist' && (
-                      <Link
-                    href="/dashboard/profile/edit"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    Edit Profile
-                  </Link>
-                )}
-                {user.user_type === 'artist' && (
-                  <Link
-                    href="/dashboard/quotes"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    Quotes
-                  </Link>
-                )}
-                {user.user_type === 'artist' && (
-                  <Link
-                    href="/dashboard/profile/quote-templates"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    Quote Templates
-                  </Link>
-                )}
-                {user.user_type === 'client' && (
-                  <Link
-                    href="/dashboard/client/bookings"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    My Bookings
-                  </Link>
-                )}
-                {user.user_type === 'client' && (
-                  <Link
-                    href="/dashboard/client/quotes"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    My Quotes
-                  </Link>
-                )}
-                {user.user_type === 'client' && (
-                  <Link
-                    href="/account"
-                    onClick={onClose}
-                    className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                  >
-                    Account
-                  </Link>
-                )}
-                <button
-                  type="button"
-                  onClick={() => {
-                    logout();
-                    onClose();
+                      <NavLink
+                        href="/dashboard/profile/edit"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        Edit Profile
+                      </NavLink>
+                    )}
+                    {user.user_type === 'artist' && (
+                      <NavLink
+                        href="/dashboard/quotes"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        Quotes
+                      </NavLink>
+                    )}
+                    {user.user_type === 'artist' && (
+                      <NavLink
+                        href="/dashboard/profile/quote-templates"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        Quote Templates
+                      </NavLink>
+                    )}
+                    {user.user_type === 'client' && (
+                      <NavLink
+                        href="/dashboard/client/bookings"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        My Bookings
+                      </NavLink>
+                    )}
+                    {user.user_type === 'client' && (
+                      <NavLink
+                        href="/dashboard/client/quotes"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        My Quotes
+                      </NavLink>
+                    )}
+                    {user.user_type === 'client' && (
+                      <NavLink
+                        href="/account"
+                        onClick={onClose}
+                        className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      >
+                        Account
+                      </NavLink>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        logout();
+                        onClose();
                       }}
-                      className="block w-full text-left px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      className={clsx(
+                        navItemClasses,
+                        'block w-full text-left text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                      )}
                     >
                       Sign out
                     </button>
                   </>
                 ) : (
                   <>
-                    <Link
+                    <NavLink
                       href="/login"
                       onClick={onClose}
-                      className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                     >
                       Sign in
-                    </Link>
-                    <Link
+                    </NavLink>
+                    <NavLink
                       href="/register"
                       onClick={onClose}
-                      className="block px-3 py-2 no-underline hover:no-underline text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                      className="block text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                     >
                       Sign up
-                    </Link>
+                    </NavLink>
                   </>
                 )}
               </div>

--- a/frontend/src/components/layout/NavLink.tsx
+++ b/frontend/src/components/layout/NavLink.tsx
@@ -2,6 +2,7 @@
 import Link, { LinkProps } from 'next/link';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import clsx from 'clsx';
+import { navLinkClasses } from './navStyles';
 
 interface NavLinkProps
   extends LinkProps,
@@ -19,13 +20,7 @@ export default function NavLink({
   return (
     <Link
       {...props}
-      className={clsx(
-        'inline-flex items-center border-b-2 px-1 pt-1 text-sm font-medium transition-colors no-underline hover:no-underline',
-        isActive
-          ? 'border-primary text-gray-900'
-          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
-        className,
-      )}
+      className={clsx(navLinkClasses(isActive), className)}
     >
       {children}
     </Link>

--- a/frontend/src/components/layout/__tests__/HeaderProfileMenu.test.tsx
+++ b/frontend/src/components/layout/__tests__/HeaderProfileMenu.test.tsx
@@ -30,7 +30,7 @@ describe('Header profile menu', () => {
 
     render(<Header headerState="initial" onForceHeaderState={jest.fn()} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'A' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Account menu' }));
     expect(await screen.findByText('Edit Profile')).toBeTruthy();
   });
 });

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -97,6 +97,18 @@ describe('MobileBottomNav', () => {
     expect(activeLink).not.toBeNull();
   });
 
+  it('nav links meet touch target size', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/' });
+    act(() => {
+      root.render(
+        React.createElement(MobileBottomNav, { user: {} as User })
+      );
+    });
+    const link = container.querySelector('a');
+    expect(link?.className).toContain('min-w-[44px]');
+    expect(link?.className).toContain('min-h-[44px]');
+  });
+
   it('hides on scroll down and shows on scroll up', () => {
     mockUseRouter.mockReturnValue({ pathname: '/' });
     Object.defineProperty(window, 'scrollY', { value: 0, writable: true });

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -5,6 +5,11 @@ import { act } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 import type { User } from '@/types';
 
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: (props: any) => <a {...props} />,
+}));
+
 
 const nav = [
   { name: 'Home', href: '/' },
@@ -67,10 +72,28 @@ describe('MobileMenuDrawer', () => {
       );
     });
     await flushPromises();
-    const span = document.querySelector('span.sr-only');
-    const button = span?.parentElement as HTMLButtonElement | null;
+    const button = document.querySelector('button[aria-label="Close menu"]');
     expect(button?.className).toContain('focus-visible:ring-2');
     expect(button?.className).toContain('focus-visible:ring-brand');
+  });
+
+  it('navigation links have minimum touch size', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          user: null,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await flushPromises();
+    const link = document.querySelector('a');
+    expect(link?.className).toContain('min-w-[44px]');
+    expect(link?.className).toContain('min-h-[44px]');
   });
 
   it('shows artist links for artists', async () => {

--- a/frontend/src/components/layout/__tests__/NavLink.test.tsx
+++ b/frontend/src/components/layout/__tests__/NavLink.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import NavLink from '../NavLink';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: (props: any) => <a {...props} />,
+}));
+
+describe('NavLink', () => {
+  it('applies touch target size and active styles', () => {
+    const { getByText, rerender } = render(<NavLink href="/foo">Foo</NavLink>);
+    const link = getByText('Foo');
+    expect(link.className).toContain('min-w-[44px]');
+    expect(link.className).toContain('min-h-[44px]');
+    expect(link.className).not.toContain('border-primary');
+    rerender(
+      <NavLink href="/foo" isActive>
+        Foo
+      </NavLink>,
+    );
+    expect(link.className).toContain('border-primary');
+  });
+});

--- a/frontend/src/components/layout/navStyles.ts
+++ b/frontend/src/components/layout/navStyles.ts
@@ -1,0 +1,12 @@
+import clsx from 'clsx';
+
+export const navItemClasses = 'inline-flex items-center justify-center min-h-[44px] min-w-[44px] px-3 text-sm font-medium no-underline hover:no-underline';
+
+export const navLinkClasses = (isActive?: boolean) =>
+  clsx(
+    navItemClasses,
+    'border-b-2 transition-colors',
+    isActive
+      ? 'border-primary text-gray-900'
+      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+  );


### PR DESCRIPTION
## Summary
- refactor NavLink with shared navStyles and 44px touch targets
- apply NavLink across header, mobile drawer, and bottom nav
- document navigation guidelines and add coverage

## Testing
- `npx jest src/components/layout/__tests__/NavLink.test.tsx src/components/layout/__tests__/MobileBottomNav.test.tsx src/components/layout/__tests__/MobileMenuDrawer.test.tsx`
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68920b4efc04832ea113659cb9048755