### PR TITLE
feat: show wizard instructions under step headers

### DIFF
--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -43,7 +43,7 @@ All colors and custom spacing values must be expressed as CSS variables and decl
 
 ### CollapsibleSection
 
-Use `<CollapsibleSection>` from `@/components/ui` for expandable groups. It renders a button with `aria-expanded` and toggles a region identified by `aria-controls`, providing accessible accordions for wizard steps and dashboards.
+Use `<CollapsibleSection>` from `@/components/ui` for expandable groups. It renders a button with `aria-expanded` and toggles a region identified by `aria-controls`, providing accessible accordions for wizard steps and dashboards. The component also accepts an optional `description` prop to display short instructions directly beneath the title and above the divider.
 
 ### BottomSheet
 

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -45,11 +45,11 @@ export default function DateTimeStep({
   return (
     <CollapsibleSection
       title="Date & Time"
+      description="When should we perform?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">When should we perform?</p>
       {loading || (!isMobile && !showPicker) ? (
         <div
           data-testid="calendar-skeleton"

--- a/frontend/src/components/booking/steps/EventDescriptionStep.tsx
+++ b/frontend/src/components/booking/steps/EventDescriptionStep.tsx
@@ -15,11 +15,11 @@ export default function EventDescriptionStep({ control, open = true, onToggle = 
   return (
     <CollapsibleSection
       title="Event Details"
+      description="Tell us a little bit more about your event."
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">Tell us a little bit more about your event.</p>
       <Controller<EventDetails, 'eventDescription'>
         name="eventDescription"
         control={control}

--- a/frontend/src/components/booking/steps/EventTypeStep.tsx
+++ b/frontend/src/components/booking/steps/EventTypeStep.tsx
@@ -32,11 +32,11 @@ export default function EventTypeStep({ control, open = true, onToggle = () => {
   return (
     <CollapsibleSection
       title="Event Type"
+      description="What type of event are you planning?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">What type of event are you planning?</p>
       <Controller<EventDetails, 'eventType'>
         name="eventType"
         control={control}

--- a/frontend/src/components/booking/steps/GuestsStep.tsx
+++ b/frontend/src/components/booking/steps/GuestsStep.tsx
@@ -19,11 +19,11 @@ export default function GuestsStep({ control, open = true, onToggle = () => {} }
   return (
     <CollapsibleSection
       title="Guests"
+      description="How many people?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">How many people?</p>
       <Controller<EventDetails, 'guests'> // Explicitly type Controller
         name="guests"
         control={control}

--- a/frontend/src/components/booking/steps/LocationStep.tsx
+++ b/frontend/src/components/booking/steps/LocationStep.tsx
@@ -109,11 +109,11 @@ export default function LocationStep({
   return (
     <CollapsibleSection
       title="Location"
+      description="Where is the show?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">Where is the show?</p>
       <div ref={containerRef}>
         {shouldLoadMap ? (
           <GoogleMapsLoader>

--- a/frontend/src/components/booking/steps/NotesStep.tsx
+++ b/frontend/src/components/booking/steps/NotesStep.tsx
@@ -53,11 +53,11 @@ export default function NotesStep({
   return (
     <CollapsibleSection
       title="Notes"
+      description="Anything else we should know?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">Anything else we should know?</p>
       <Controller<EventDetails, 'notes'>
         name="notes"
         control={control}

--- a/frontend/src/components/booking/steps/SoundStep.tsx
+++ b/frontend/src/components/booking/steps/SoundStep.tsx
@@ -25,11 +25,11 @@ export default function SoundStep({
   return (
     <CollapsibleSection
       title="Sound"
+      description="Will sound equipment be needed?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">Will sound equipment be needed?</p>
       <Controller<EventDetails, 'sound'>
         name="sound"
         control={control}

--- a/frontend/src/components/booking/steps/VenueStep.tsx
+++ b/frontend/src/components/booking/steps/VenueStep.tsx
@@ -31,11 +31,11 @@ export default function VenueStep({
   return (
     <CollapsibleSection
       title="Venue Type"
+      description="What type of venue is it?"
       open={open}
       onToggle={onToggle}
       className="wizard-step-container"
     >
-      <p className="text-sm text-gray-600">What type of venue is it?</p>
       <Controller<EventDetails, 'venueType'>
         name="venueType"
         control={control}

--- a/frontend/src/components/ui/CollapsibleSection.tsx
+++ b/frontend/src/components/ui/CollapsibleSection.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 
 interface CollapsibleSectionProps {
   title: React.ReactNode;
+  description?: React.ReactNode;
   open: boolean;
   onToggle: () => void;
   children: React.ReactNode;
@@ -13,6 +14,7 @@ interface CollapsibleSectionProps {
 
 export default function CollapsibleSection({
   title,
+  description,
   open,
   onToggle,
   children,
@@ -29,9 +31,16 @@ export default function CollapsibleSection({
           aria-expanded={open}
           aria-controls={contentId}
           onClick={onToggle}
-          className="w-full p-4 min-h-[44px] text-left font-bold border-b flex justify-between focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          className="w-full p-4 min-h-[44px] text-left border-b flex justify-between focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
         >
-          <span>{title}</span>
+          <span className="flex flex-col">
+            <span className="font-bold">{title}</span>
+            {description && (
+              <span className="text-sm font-normal text-gray-600 pt-1">
+                {description}
+              </span>
+            )}
+          </span>
           <span
             aria-hidden="true"
             className={clsx('ml-2 transition-transform', open ? 'rotate-180' : 'rotate-0')}


### PR DESCRIPTION
## Summary
- display step instructions beneath booking wizard headers via new `description` prop on `CollapsibleSection`
- move all booking step helper text into headers with subtle padding
- document `description` option in style guide

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest` *(fails: 50 errors during collection)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892100f4cd0832ea54a54246bdd1625