### PR TITLE
feat: add AI quote draft service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ For setup instructions see [README.md](README.md).
 | **Booking Request** | Orchestrates the booking wizard and business rules | `backend/app/api/api_booking_request.py`<br>`frontend/src/components/booking/BookingWizard.tsx` | When a client submits or updates a booking |
 | **Provider Matching** | Selects sound and accommodation providers | `backend/app/crud/crud_service.py`<br>`backend/app/api/api_service.py` | During booking and quote steps |
 | **Travel & Accommodation** | Calculates travel distance, lodging costs, and now weather forecasts | `backend/app/services/booking_quote.py`<br>`backend/app/api/api_weather.py`<br>`frontend/src/app/quote-calculator/page.tsx` | When estimating travel or lodging expenses |
-| **Quote Generator** | Gathers performance, provider, travel, and accommodation costs | `backend/app/api/api_quote.py`<br>`frontend/src/components/booking/MessageThread.tsx` | After all booking info is entered |
+| **Quote Generator** | Gathers performance, provider, travel, and accommodation costs and seeds quotes with AI draft text | `backend/app/api/api_quote.py`<br>`backend/app/services/quote_ai.py`<br>`frontend/src/components/booking/SendQuoteModal.tsx` | After all booking info is entered |
 | **Quote Preview** | Shows an estimated total during the review step | `frontend/src/components/booking/steps/ReviewStep.tsx` | Right before submitting a booking request |
 | **Review** | Manages star ratings and comments for completed bookings | `backend/app/api/api_review.py`<br>`frontend/src/app/artists/[id]/page.tsx` | After a booking is marked completed |
 | **Payment** | Handles deposit or full payments via `/api/v1/payments` | `backend/app/api/api_payment.py` | After quote acceptance |
@@ -49,9 +49,9 @@ For setup instructions see [README.md](README.md).
 
 ### 4. Quote Generator
 
-* **Purpose:** Calculates and presents full, itemized quote: performance fee, provider, travel, accommodation, service fees.
-* **Frontend:** Quote forms in `MessageThread.tsx` show running totals.
-* **Backend:** `api_quote.py` aggregates, formats, and returns structured JSON to frontend.
+* **Purpose:** Calculates and presents full, itemized quote: performance fee, provider, travel, accommodation, service fees. An LLM now drafts an initial description and suggests price tweaks.
+* **Frontend:** `SendQuoteModal.tsx` and quote forms in `MessageThread.tsx` show running totals and AI drafts.
+* **Backend:** `api_quote.py` aggregates, formats, and returns structured JSON to frontend while `services/quote_ai.py` handles LLM interaction.
 
 ### 5. Quote Preview Agent
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   `deposit_due_by`.
 - A new `deposit_due_by` field records when the deposit is due, one week after a quote is accepted.
 - Payment receipts are stored with a `payment_id` so clients can view them from the dashboard.
+- Quote calculator now calls an LLM to draft quote descriptions and suggest price adjustments.
 - Users can download all account data via `/api/v1/users/me/export` and permanently delete their account with `DELETE /api/v1/users/me`.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking request detail pages now display a step-by-step timeline from submission to quote acceptance.

--- a/backend/app/api/api_quote.py
+++ b/backend/app/api/api_quote.py
@@ -16,6 +16,7 @@ from ..crud.crud_booking import (
     create_booking_from_quote,
 )  # Will be created later
 from ..services.booking_quote import calculate_quote_breakdown, calculate_quote
+from ..services.quote_ai import generate_quote_draft
 from decimal import Decimal
 from ..utils import error_response
 
@@ -483,4 +484,9 @@ def calculate_quote_endpoint(
         provider,
         params.accommodation_cost,
     )
+    ai_description, ai_adjustment = generate_quote_draft(
+        "Quick quote", breakdown["total"]
+    )
+    breakdown["ai_description"] = ai_description
+    breakdown["ai_price_adjustment"] = ai_adjustment
     return breakdown

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -119,6 +119,8 @@ class QuoteCalculationResponse(BaseModel):
     provider_cost: Decimal
     accommodation_cost: Decimal
     total: Decimal
+    ai_description: str | None = None
+    ai_price_adjustment: Decimal | None = None
 
 
 class QuoteCalculationParams(BaseModel):

--- a/backend/app/services/quote_ai.py
+++ b/backend/app/services/quote_ai.py
@@ -1,0 +1,60 @@
+import json
+import logging
+import os
+from decimal import Decimal
+from typing import Tuple
+from urllib import request, error
+
+logger = logging.getLogger(__name__)
+
+OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+
+
+def generate_quote_draft(description: str, price: Decimal) -> Tuple[str, Decimal]:
+    """Return an AI-generated description and price adjustment.
+
+    If the OpenAI API key is not configured or any error occurs during the
+    request, a fallback description is returned and the adjustment is ``0``.
+    """
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        logger.info("OPENAI_API_KEY not set; skipping AI draft generation")
+        return description, Decimal("0")
+
+    prompt = (
+        "Given the quote description "
+        f"'{description}' priced at {price} ZAR, suggest an improved "
+        "description and numeric price adjustment in ZAR as JSON with keys "
+        "'description' and 'adjustment'."
+    )
+
+    payload = json.dumps(
+        {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.7,
+        }
+    ).encode("utf-8")
+
+    req = request.Request(
+        OPENAI_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+
+    try:
+        with request.urlopen(req, timeout=15) as resp:
+            body = resp.read()
+        response = json.loads(body)
+        content = response["choices"][0]["message"]["content"]
+        data = json.loads(content)
+        new_description = data.get("description", description)
+        adjustment = Decimal(str(data.get("adjustment", 0)))
+        return new_description, adjustment
+    except Exception as exc:  # noqa: BLE001 - broad to ensure fallback
+        logger.error("AI quote generation failed: %s", exc)
+        return description, Decimal("0")

--- a/backend/tests/test_quote_ai.py
+++ b/backend/tests/test_quote_ai.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+from fastapi.testclient import TestClient
+
+from app.services import quote_ai
+from app.main import app
+
+
+def test_generate_quote_draft_without_key(monkeypatch):
+    desc, adj = quote_ai.generate_quote_draft("test", Decimal("100"))
+    assert desc == "test"
+    assert adj == Decimal("0")
+
+
+def test_calculate_quote_endpoint_includes_ai_fields():
+    client = TestClient(app)
+    res = client.post("/api/v1/quotes/calculate", json={"base_fee": 100, "distance_km": 0})
+    assert res.status_code == 200
+    data = res.json()
+    assert "ai_description" in data
+    assert "ai_price_adjustment" in data

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6621,6 +6621,28 @@
           "total": {
             "type": "string",
             "title": "Total"
+          },
+          "ai_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ai Description"
+          },
+          "ai_price_adjustment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ai Price Adjustment"
           }
         },
         "type": "object",

--- a/frontend/src/components/booking/SendQuoteModal.tsx
+++ b/frontend/src/components/booking/SendQuoteModal.tsx
@@ -5,7 +5,7 @@ import React, {
 } from 'react';
 import { format } from 'date-fns';
 import { ServiceItem, QuoteV2Create, QuoteTemplate } from '@/types';
-import { getQuoteTemplates } from '@/lib/api';
+import { getQuoteTemplates, calculateQuote } from '@/lib/api';
 import { formatCurrency, generateQuoteNumber } from '@/lib/utils';
 import { BottomSheet } from '../ui';
 
@@ -52,6 +52,7 @@ const SendQuoteModal: React.FC<Props> = ({
   const [selectedTemplate, setSelectedTemplate] = useState<number | ''>('');
   const [quoteNumber, setQuoteNumber] = useState('');
   const [description, setDescription] = useState('');
+  const [aiSuggested, setAiSuggested] = useState(false);
 
   const firstFieldRef = useRef<HTMLInputElement>(null);
 
@@ -74,6 +75,7 @@ const SendQuoteModal: React.FC<Props> = ({
       setDiscount(0);
       setExpiresHours(null);
       setDescription('');
+      setAiSuggested(false);
       return;
     }
 
@@ -92,6 +94,25 @@ const SendQuoteModal: React.FC<Props> = ({
       }
     }
   }, [open, selectedTemplate, artistId, initialBaseFee, initialTravelCost, initialSoundNeeded]);
+
+  // Fetch AI-generated draft description and price adjustment
+  useEffect(() => {
+    if (!open) return;
+    calculateQuote({ base_fee: initialBaseFee || 0, distance_km: 0 })
+      .then((res) => {
+        if (res.data.ai_description) {
+          setDescription(res.data.ai_description);
+          setAiSuggested(true);
+        }
+        const adj = res.data.ai_price_adjustment || 0;
+        if (adj) {
+          setServiceFee((prev) => prev + adj);
+        }
+      })
+      .catch((err) => {
+        console.error('AI quote draft failed', err);
+      });
+  }, [open, initialBaseFee]);
 
   // Effect to apply template values or revert to initial props/defaults
   useEffect(() => {
@@ -188,6 +209,11 @@ const SendQuoteModal: React.FC<Props> = ({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
+            {aiSuggested && (
+              <span className="absolute right-2 top-2 text-xs text-indigo-600">
+                AI suggested
+              </span>
+            )}
             <p className="absolute -bottom-5 left-0 text-xs text-gray-500">A brief, descriptive title for this quote.</p>
           </div>
 

--- a/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/SendQuoteModal.test.tsx
@@ -10,6 +10,17 @@ jest.mock('@/lib/api');
 describe('SendQuoteModal', () => {
   beforeEach(() => {
     (api.getQuoteTemplates as jest.Mock).mockResolvedValue({ data: [] });
+    (api.calculateQuote as jest.Mock).mockResolvedValue({
+      data: {
+        base_fee: 500,
+        travel_cost: 0,
+        provider_cost: 0,
+        accommodation_cost: 0,
+        total: 500,
+        ai_description: 'AI draft',
+        ai_price_adjustment: 0,
+      },
+    });
   });
 
   it('prefills travel and sound fees', async () => {
@@ -35,8 +46,10 @@ describe('SendQuoteModal', () => {
 
     const travelInput = div.querySelector('#travel-fee') as HTMLInputElement;
     const soundInput = div.querySelector('#sound-fee') as HTMLInputElement;
+    const descInput = div.querySelector('input[type="text"]') as HTMLInputElement;
     expect(travelInput.value).toBe('150');
     expect(soundInput.value).toBe('250');
+    expect(descInput.value).toBe('AI draft');
 
     act(() => {
       root.unmount();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -268,6 +268,8 @@ export interface QuoteCalculationResponse {
   provider_cost: number;
   accommodation_cost: number;
   total: number;
+  ai_description?: string | null;
+  ai_price_adjustment?: number | null;
 }
 export interface ArtistSoundPreference {
   id: number;


### PR DESCRIPTION
## Summary
- add quote_ai service to generate draft descriptions and price adjustments via LLM
- return AI draft fields from calculate quote endpoint and expose on SendQuoteModal
- document quote generator AI integration

## Testing
- `pytest`
- `npm test` *(fails: TypeError: useSearchParams is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892166e3868832ea06e8e945173e7e6