### PR TITLE
Improve mobile hamburger menu layout

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -47,6 +47,7 @@ This document outlines key friction points in the current booking wizard and pro
 * Provide skeleton loaders for availability checks and quote calculations.
 * Maintain the existing <code>MobileBottomNav</code> for consistent navigation.
 * Keep the hamburger menu visible so the main navigation drawer is always accessible. ✅ Implemented July 2025.
+* Simplify the hamburger menu by deduplicating links and grouping related items under clear section headings. ✅ Implemented July 2025.
 
 ## Collapsible Sections Component
 The `CollapsibleSection` component replaces raw `<details>` elements in the booking wizard. Each step header is rendered as a button with proper `aria-expanded` state so screen readers and keyboard users can toggle sections just as easily as touch users.

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -362,7 +362,6 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
         open={menuOpen}
         onClose={() => setMenuOpen(false)}
         navigation={clientNav}
-        drawerNavigation={clientNav}
         user={user}
         logout={logout}
         pathname={pathname}

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -17,7 +17,11 @@ interface MobileMenuDrawerProps {
   open: boolean;
   onClose: () => void;
   navigation: NavItem[];
-  drawerNavigation?: NavItem[];
+  /**
+   * Optional additional navigation items. Any links that duplicate the main
+   * `navigation` list are filtered out to avoid confusion in the drawer.
+   */
+  secondaryNavigation?: NavItem[];
   user: User | null;
   logout: () => void;
   pathname: string;
@@ -27,11 +31,15 @@ export default function MobileMenuDrawer({
   open,
   onClose,
   navigation,
-  drawerNavigation = [],
+  secondaryNavigation = [],
   user,
   logout,
   pathname,
 }: MobileMenuDrawerProps) {
+  // Remove duplicates so the same link never appears twice
+  const extraNavigation = secondaryNavigation.filter(
+    (item) => !navigation.some((nav) => nav.href === item.href),
+  );
   return (
     <Transition.Root show={open} as={Fragment}>
       <Dialog as="div" className="relative z-40" onClose={onClose}>
@@ -71,22 +79,10 @@ export default function MobileMenuDrawer({
                   <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                 </button>
               </div>
-              <div className="mt-4 space-y-1 px-2">
-                {navigation.map((item) => (
-                  <NavLink
-                    key={item.name}
-                    href={item.href}
-                    onClick={onClose}
-                    isActive={pathname === item.href}
-                    className="block border-l-4 text-base"
-                  >
-                    {item.name}
-                  </NavLink>
-                ))}
-              </div>
-              {(drawerNavigation ?? []).length > 0 && (
-                <div className="mt-2 space-y-1 px-2">
-                  {(drawerNavigation ?? []).map((item) => (
+              <div className="mt-4 px-2">
+                <h3 className="px-2 text-xs font-semibold text-gray-500 uppercase">Explore</h3>
+                <div className="mt-2 space-y-1">
+                  {navigation.map((item) => (
                     <NavLink
                       key={item.name}
                       href={item.href}
@@ -98,8 +94,27 @@ export default function MobileMenuDrawer({
                     </NavLink>
                   ))}
                 </div>
+              </div>
+              {extraNavigation.length > 0 && (
+                <div className="mt-4 border-t border-gray-200 pt-4 px-2">
+                  <h3 className="px-2 text-xs font-semibold text-gray-500 uppercase">More</h3>
+                  <div className="mt-2 space-y-1">
+                    {extraNavigation.map((item) => (
+                      <NavLink
+                        key={item.name}
+                        href={item.href}
+                        onClick={onClose}
+                        isActive={pathname === item.href}
+                        className="block border-l-4 text-base"
+                      >
+                        {item.name}
+                      </NavLink>
+                    ))}
+                  </div>
+                </div>
               )}
               <div className="mt-4 border-t border-gray-200 pt-4 px-2">
+                <h3 className="px-2 text-xs font-semibold text-gray-500 uppercase">Account</h3>
                 {user ? (
                   <>
                     <NavLink

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -2,12 +2,13 @@ import { flushPromises } from "@/test/utils/flush";
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 import type { User } from '@/types';
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: (props: any) => <a {...props} />,
+  default: (props: ComponentPropsWithoutRef<'a'>) => <a {...props} />,
 }));
 
 
@@ -135,5 +136,26 @@ describe('MobileMenuDrawer', () => {
     const body = document.body.textContent || '';
     expect(body).toContain('My Bookings');
     expect(body).toContain('Account');
+  });
+
+  it('deduplicates items across navigation sections', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          secondaryNavigation: nav,
+          user: null,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await flushPromises();
+    const links = Array.from(document.querySelectorAll('a')).filter(
+      (a) => a.textContent === 'Home',
+    );
+    expect(links).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Organize the mobile navigation drawer with an optional secondary list and automatic deduplication.
- Group links into clearly labeled sections to avoid confusion.
- Document the streamlined hamburger menu in the mobile UX report and test link deduplication.

## Testing
- `npm run lint` *(fails: multiple existing lint errors in unrelated files)*
- `npx next lint --file src/components/layout/MobileMenuDrawer.tsx --file src/components/layout/Header.tsx --file src/components/layout/__tests__/MobileMenuDrawer.test.tsx`
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `npm test` *(fails: multiple failing tests, e.g., ReferenceError in api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689216a28a94832e97497b525eaacef2