### PR TITLE
Add artist recommendation service and endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ For setup instructions see [README.md](README.md).
 | **Notification** | Sends emails, chat alerts, and booking status updates | `backend/app/api/api_notification.py`<br>`backend/app/utils/notifications.py`<br>`frontend/hooks/useNotifications.ts` | On status changes, messages, actions |
 | **Chat** | Manages client–artist chat and WebSocket updates | `backend/app/api/api_message.py`<br>`backend/app/api/api_ws.py`<br>`frontend/src/components/booking/MessageThread.tsx` | Always on for active bookings |
 | **Caching** | Caches artist lists using Redis | `backend/app/utils/redis_cache.py`<br>`backend/app/api/v1/api_artist.py` | On artist list requests |
+| **Recommendation** | Provides personalized artist suggestions with fallback to top-rated when data is sparse | `backend/app/services/recommendation_service.py`<br>`backend/app/api/api_artist.py`<br>`frontend/src/app/artists/page.tsx` | When a user views artist listings |
 | **Personalized Video** | Automates Q&A for custom video requests | `frontend/src/components/booking/PersonalizedVideoFlow.tsx`<br>`frontend/src/lib/videoFlow.ts` | When `service_type` is Personalized Video |
 | **Availability** | Checks artist/service availability in real time | `backend/app/api/v1/api_artist.py`<br>`frontend/src/components/booking/BookingWizard.tsx` | On date selection and booking start |
 | **Form State** | Maintains booking progress across steps | `frontend/src/components/booking/BookingWizard.tsx`<br>`frontend/src/contexts/BookingContext.tsx` | Throughout the user session |
@@ -114,6 +115,13 @@ For setup instructions see [README.md](README.md).
 * **Purpose:** Ensures all inputs are correct (dates, emails, phone, logic like “accommodation required if >X km”).
 * **Frontend:** Inline validation on form steps, helpful error messages.
 * **Backend:** Schema and Pydantic model validation for all POSTs/PATCHes.
+
+### 15. Recommendation Agent
+
+* **Purpose:** Suggests artists tailored to a client's past activity with fallback to top-rated performers.
+* **Frontend:** `frontend/src/app/artists/page.tsx` displays a recommended section on the artists page.
+* **Backend:** `backend/app/services/recommendation_service.py` ranks artists and `/api/v1/artists/recommended` exposes them.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   global rule in `globals.css`.
 - Homepage search now lives in the header on a light gray background.
 - Collapsed search bar truncates long locations with an ellipsis so the text never wraps.
+- Personalized artist suggestions are available via `/api/v1/artists/recommended` and displayed on the Artists page.
 - Fixed an initial load bug where a selected date sent an invalid `when` value and caused a 422 error.
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map **Musician / Band** to the `Live Performance` service

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,6 +51,9 @@ class Settings(BaseSettings):
     # Default currency code used across the application
     DEFAULT_CURRENCY: str = "ZAR"
 
+    # Recommendation fallback list size
+    RECOMMENDATION_FALLBACK_LIMIT: int = 5
+
     # Login rate limiting
     MAX_LOGIN_ATTEMPTS: int = 5
     LOGIN_ATTEMPT_WINDOW: int = 300  # seconds

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,7 +71,8 @@ from .api import (
 from routes import distance
 
 # The “artist‐profiles” router lives under app/api/v1/
-from .api.v1 import api_artist
+from .api.v1 import api_artist as api_artist_profiles
+from .api import api_artist as api_artist_recommendation
 
 from .core.config import settings
 from .utils.redis_cache import close_redis_client
@@ -213,7 +214,14 @@ app.include_router(api_oauth.router, prefix="/auth", tags=["auth"])
 
 # ─── ARTIST‐PROFILE ROUTES (under /api/v1/artist-profiles) ──────────────────────────
 app.include_router(
-    api_artist.router, prefix=f"{api_prefix}/artist-profiles", tags=["artist-profiles"]
+    api_artist_profiles.router, prefix=f"{api_prefix}/artist-profiles", tags=["artist-profiles"]
+)
+
+# ─── ARTIST RECOMMENDATION ROUTES (under /api/v1/artists) ─────────────────────
+app.include_router(
+    api_artist_recommendation.recommendation_router,
+    prefix=f"{api_prefix}/artists",
+    tags=["artists"],
 )
 
 

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -1,0 +1,79 @@
+"""Service for generating artist recommendations."""
+
+from collections import Counter
+from typing import List
+import logging
+
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from ..models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
+from ..models.request_quote import BookingRequest, BookingRequestStatus
+from ..models.service import Service
+from ..models.review import Review
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class RecommendationService:
+    """Provide artist recommendations based on user history.
+
+    The service first attempts to find the user's most common service type
+    from completed booking requests and recommends top rated artists offering
+    that service. If insufficient data exists, it falls back to globally
+    top‑rated artists. The fallback list size is configurable via the
+    ``RECOMMENDATION_FALLBACK_LIMIT`` setting.
+    """
+
+    def __init__(self, fallback_limit: int | None = None) -> None:
+        self.fallback_limit = fallback_limit or settings.RECOMMENDATION_FALLBACK_LIMIT
+
+    def _top_rated(self, db: Session, limit: int) -> List[ArtistProfile]:
+        """Return top rated artists regardless of service type."""
+        return (
+            db.query(ArtistProfile)
+            .outerjoin(Review, Review.artist_id == ArtistProfile.user_id)
+            .group_by(ArtistProfile.user_id)
+            .order_by(func.coalesce(func.avg(Review.rating), 0).desc())
+            .limit(limit)
+            .all()
+        )
+
+    def recommend_for_user(
+        self, db: Session, user_id: int, limit: int = 5
+    ) -> List[ArtistProfile]:
+        """Return a ranked list of recommended artists for ``user_id``."""
+        service_rows = (
+            db.query(Service.service_type)
+            .join(BookingRequest, BookingRequest.service_id == Service.id)
+            .filter(BookingRequest.client_id == user_id)
+            .filter(BookingRequest.status == BookingRequestStatus.REQUEST_COMPLETED)
+            .all()
+        )
+
+        if service_rows:
+            top_type = Counter([row[0] for row in service_rows]).most_common(1)[0][0]
+            recs = (
+                db.query(ArtistProfile)
+                .join(Service, Service.artist_id == ArtistProfile.user_id)
+                .outerjoin(Review, Review.artist_id == ArtistProfile.user_id)
+                .filter(Service.service_type == top_type)
+                .group_by(ArtistProfile.user_id)
+                .order_by(func.coalesce(func.avg(Review.rating), 0).desc())
+                .limit(limit)
+                .all()
+            )
+            if len(recs) < limit:
+                fallback = self._top_rated(db, self.fallback_limit)
+                seen = {a.user_id for a in recs}
+                for artist in fallback:
+                    if artist.user_id in seen:
+                        continue
+                    recs.append(artist)
+                    if len(recs) >= limit:
+                        break
+            return recs
+
+        logger.info("No historical data for user %s; using fallback", user_id)
+        return self._top_rated(db, limit)

--- a/backend/tests/test_recommendation_endpoint.py
+++ b/backend/tests/test_recommendation_endpoint.py
@@ -1,0 +1,76 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.models.base import BaseModel
+from app.models.user import User, UserType
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.api.dependencies import get_db, get_current_user
+
+
+def setup_app(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def override_user(user):
+    def _override():
+        return user
+    app.dependency_overrides[get_current_user] = _override
+
+
+def test_recommendations_fallback(monkeypatch):
+    Session = setup_app(monkeypatch)
+    db = Session()
+
+    artist = User(
+        email="artist@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.ARTIST,
+    )
+    db.add(artist)
+    db.commit()
+    db.refresh(artist)
+    profile = ArtistProfileV2(user_id=artist.id, business_name="Test Artist")
+    db.add(profile)
+    db.commit()
+
+    client_user = User(
+        email="client@test.com",
+        password="x",
+        first_name="C",
+        last_name="L",
+        user_type=UserType.CLIENT,
+    )
+    db.add(client_user)
+    db.commit()
+    db.refresh(client_user)
+
+    override_user(client_user)
+    client = TestClient(app)
+    res = client.get("/api/v1/artists/recommended")
+    assert res.status_code == 200
+    body = res.json()
+    assert isinstance(body, list)
+    assert body[0]["business_name"] == "Test Artist"
+
+    app.dependency_overrides.clear()

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1021,7 +1021,7 @@
           "Services"
         ],
         "summary": "Create Service",
-        "description": "Create a new service for the currently authenticated artist.\nFull path \u2192 POST /api/v1/services/",
+        "description": "Create a new service for the currently authenticated artist.\nFull path → POST /api/v1/services/",
         "operationId": "create_service_api_v1_services__post",
         "requestBody": {
           "content": {
@@ -1069,7 +1069,7 @@
           "Services"
         ],
         "summary": "Update Service",
-        "description": "Update a service owned by the currently authenticated artist.\nFull path \u2192 PUT /api/v1/services/{service_id}",
+        "description": "Update a service owned by the currently authenticated artist.\nFull path → PUT /api/v1/services/{service_id}",
         "operationId": "update_service_api_v1_services__service_id__put",
         "security": [
           {
@@ -1126,7 +1126,7 @@
           "Services"
         ],
         "summary": "Read Service",
-        "description": "Get a specific service by its ID (publicly accessible).\nFull path \u2192 GET /api/v1/services/{service_id}",
+        "description": "Get a specific service by its ID (publicly accessible).\nFull path → GET /api/v1/services/{service_id}",
         "operationId": "read_service_api_v1_services__service_id__get",
         "parameters": [
           {
@@ -1168,7 +1168,7 @@
           "Services"
         ],
         "summary": "Delete Service",
-        "description": "Delete a service owned by the currently authenticated artist.\nFull path \u2192 DELETE /api/v1/services/{service_id}",
+        "description": "Delete a service owned by the currently authenticated artist.\nFull path → DELETE /api/v1/services/{service_id}",
         "operationId": "delete_service_api_v1_services__service_id__delete",
         "security": [
           {
@@ -1210,7 +1210,7 @@
           "Services"
         ],
         "summary": "Read Services By Artist",
-        "description": "Get all services offered by a specific artist (by their user_id).\nFull path \u2192 GET /api/v1/services/artist/{artist_user_id}",
+        "description": "Get all services offered by a specific artist (by their user_id).\nFull path → GET /api/v1/services/artist/{artist_user_id}",
         "operationId": "read_services_by_artist_api_v1_services_artist__artist_user_id__get",
         "parameters": [
           {
@@ -1469,7 +1469,7 @@
           "bookings"
         ],
         "summary": "Read Booking Details",
-        "description": "Return the details of a single booking.  \nAccessible if the current user is either the booking\u2019s client or the booking\u2019s artist.",
+        "description": "Return the details of a single booking.  \nAccessible if the current user is either the booking’s client or the booking’s artist.",
         "operationId": "read_booking_details_api_v1_bookings__booking_id__get",
         "security": [
           {
@@ -4335,6 +4335,44 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/artists/recommended": {
+      "get": {
+        "tags": [
+          "artists"
+        ],
+        "summary": "Get recommended artists",
+        "description": "Return personalized artist recommendations for the current user.",
+        "operationId": "recommended_artists_api_v1_artists_recommended_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "title": "Limit",
+              "type": "integer",
+              "default": 5
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Recommended Artists",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtistProfileResponse"
+                  }
+                }
               }
             }
           }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -188,6 +188,11 @@ export const getArtist = async (userId: number) => {
   return { ...res, data: normalizeArtistProfile(res.data) };
 };
 
+export const getRecommendedArtists = async (limit = 5) => {
+  const res = await api.get<ArtistProfile[]>(`${API_V1}/artists/recommended`, { params: { limit } });
+  return res.data.map(normalizeArtistProfile);
+};
+
 export const getArtistAvailability = (artistId: number) =>
   api.get<{ unavailable_dates: string[] }>(`${API_V1}/artist-profiles/${artistId}/availability`);
 


### PR DESCRIPTION
## Summary
- add recommendation service to rank artists with configurable fallback
- expose `/api/v1/artists/recommended` endpoint and wire into frontend
- show personalized suggestions on Artists page and document new agent

## Testing
- `./scripts/test-all.sh` *(fails: multiple frontend test suites)*

------
https://chatgpt.com/codex/tasks/task_e_689210cc0160832e8b2f2717425bd55f