### PR TITLE
Improve NLP date parsing and event type handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,9 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New **Review** step showing cost breakdown and selections.
 * The review page now displays a single optimized summary with event type and
   details and calculates a price estimate based on distance.
+* AI text parsing now respects explicit years (e.g. "birthday 7 April 2026") and
+  recognizes event types defined in `frontend/src/data/eventTypes.json` for
+  easier updates.
 * Success toasts when saving a draft or submitting a request.
 * Simplified buttons sit below each step in a responsive button group. On phones
   the order is **Next**, **Save Draft**, **Back** but remains **Back**, **Save Draft**,

--- a/backend/app/schemas/nlp.py
+++ b/backend/app/schemas/nlp.py
@@ -18,5 +18,8 @@ class ParsedBookingDetails(BaseModel):
     date: Optional[date_type] = Field(None, description="Event date if detected")
     location: Optional[str] = Field(None, description="Event location if detected")
     guests: Optional[int] = Field(None, description="Guest count if detected")
+    event_type: Optional[str] = Field(
+        None, description="Event type if detected, e.g. Birthday or Wedding"
+    )
 
     model_config = {"from_attributes": True}

--- a/backend/app/services/nlp_booking.py
+++ b/backend/app/services/nlp_booking.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+from pathlib import Path
 
 from dateutil import parser
 
@@ -12,13 +14,35 @@ from ..schemas.nlp import ParsedBookingDetails
 logger = logging.getLogger(__name__)
 
 MONTH_PATTERN = (
-    "jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|"
-    "january|february|march|april|june|july|august|september|october|november|december"
+    r"jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+    r"jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?"
 )
 DATE_RE = re.compile(
     rf"(\d{{1,2}}\s+(?:{MONTH_PATTERN})(?:\s+\d{{4}})?)",
     re.IGNORECASE,
 )
+
+EVENT_TYPES_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "frontend"
+    / "src"
+    / "data"
+    / "eventTypes.json"
+)
+try:
+    with EVENT_TYPES_PATH.open(encoding="utf-8") as f:
+        EVENT_TYPES = json.load(f)
+except FileNotFoundError:  # pragma: no cover - missing config
+    EVENT_TYPES = []
+
+if EVENT_TYPES:
+    EVENT_TYPE_RE = re.compile(
+        r"\b(" + "|".join(re.escape(t.lower()) for t in EVENT_TYPES) + r")\b",
+        re.IGNORECASE,
+    )
+else:  # pragma: no cover - defensive
+    EVENT_TYPE_RE = re.compile(r"^$")
+
 LOCATION_RE = re.compile(r"\b(?:in|at)\s+([A-Za-z][A-Za-z ]{2,40})", re.IGNORECASE)
 GUEST_RE = re.compile(r"(\d+)\s*(?:guests?|people|attendees)", re.IGNORECASE)
 
@@ -53,5 +77,13 @@ def extract_booking_details(text: str) -> ParsedBookingDetails:
             result.guests = int(guest_match.group(1))
         except ValueError:  # pragma: no cover - defensive
             logger.debug("Invalid guest count detected: %s", guest_match.group(1))
+    # Event type extraction
+    type_match = EVENT_TYPE_RE.search(cleaned)
+    if type_match:
+        match_lower = type_match.group(1).lower()
+        for t in EVENT_TYPES:
+            if t.lower() == match_lower:
+                result.event_type = t
+                break
 
     return result

--- a/backend/tests/test_nlp_booking.py
+++ b/backend/tests/test_nlp_booking.py
@@ -9,6 +9,7 @@ def test_extract_booking_details_basic():
     assert result.date.isoformat() == "2025-12-25"
     assert result.location == "Cape Town"
     assert result.guests == 50
+    assert result.event_type is None
 
 
 def test_extract_handles_lowercase_location_and_no_year():
@@ -19,3 +20,12 @@ def test_extract_handles_lowercase_location_and_no_year():
     assert result.date.year == expected_year
     assert (result.date.month, result.date.day) == (8, 6)
     assert result.guests is None
+    assert result.event_type == "Birthday"
+
+
+def test_extract_respects_explicit_year_and_event_type():
+    text = "birthday 7 april 2026"
+    result = nlp_booking.extract_booking_details(text)
+    assert (result.date.year, result.date.month, result.date.day) == (2026, 4, 7)
+    assert result.event_type == "Birthday"
+

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -127,7 +127,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   const [calculatedPrice, setCalculatedPrice] = useState<number | null>(null);
   const [baseServicePrice, setBaseServicePrice] = useState<number>(0); // New state for base service price
   const [aiText, setAiText] = useState('');
-  const [parsedDetails, setParsedDetails] = useState<Partial<EventDetails> | null>(null);
+  interface ParsedDetails {
+    eventType?: string;
+    date?: string;
+    location?: string;
+    guests?: number;
+  }
+  const [parsedDetails, setParsedDetails] = useState<ParsedDetails | null>(null);
   const [listening, setListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
@@ -159,16 +165,23 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     if (!aiText.trim()) return;
     try {
       const res = await parseBookingText(aiText);
-      setParsedDetails(res.data);
+      setParsedDetails({
+        eventType: res.data.event_type,
+        date: res.data.date,
+        location: res.data.location,
+        guests: res.data.guests,
+      });
     } catch (err) {
       toast.error((err as Error).message);
     }
   };
 
   const applyParsed = () => {
+    if (parsedDetails?.eventType) setValue('eventType', parsedDetails.eventType);
     if (parsedDetails?.date) setValue('date', new Date(parsedDetails.date));
     if (parsedDetails?.location) setValue('location', parsedDetails.location);
-    if (parsedDetails?.guests !== undefined) setValue('guests', String(parsedDetails.guests));
+    if (parsedDetails?.guests !== undefined)
+      setValue('guests', String(parsedDetails.guests));
     setParsedDetails(null);
   };
 
@@ -527,9 +540,16 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                   <div className="mb-4 border p-2 rounded bg-gray-50">
                     <p className="mb-2">AI Suggestions:</p>
                     <ul className="mb-2 text-sm">
+                      {parsedDetails.eventType && (
+                        <li>Event Type: {parsedDetails.eventType}</li>
+                      )}
                       {parsedDetails.date && <li>Date: {parsedDetails.date}</li>}
-                      {parsedDetails.location && <li>Location: {parsedDetails.location}</li>}
-                      {parsedDetails.guests !== undefined && <li>Guests: {parsedDetails.guests}</li>}
+                      {parsedDetails.location && (
+                        <li>Location: {parsedDetails.location}</li>
+                      )}
+                      {parsedDetails.guests !== undefined && (
+                        <li>Guests: {parsedDetails.guests}</li>
+                      )}
                     </ul>
                     <div className="flex gap-2">
                       <button

--- a/frontend/src/components/booking/steps/EventTypeStep.tsx
+++ b/frontend/src/components/booking/steps/EventTypeStep.tsx
@@ -5,23 +5,13 @@ import clsx from 'clsx';
 import useIsMobile from '@/hooks/useIsMobile';
 import { EventDetails } from '@/contexts/BookingContext';
 import { BottomSheet, Button, CollapsibleSection } from '../../ui';
+import eventTypes from '../../../data/eventTypes.json';
 
 interface Props {
   control: Control<EventDetails>;
   open?: boolean;
   onToggle?: () => void;
 }
-
-const options = [
-  'Corporate',
-  'Private',
-  'Wedding',
-  'Birthday',
-  'Festival',
-  'Restaurant',
-  'Celebration',
-  'Other',
-];
 
 export default function EventTypeStep({ control, open = true, onToggle = () => {} }: Props) {
   const isMobile = useIsMobile();
@@ -59,7 +49,7 @@ export default function EventTypeStep({ control, open = true, onToggle = () => {
                   initialFocus={firstRadioRef}
                 >
                   <fieldset className="p-4 space-y-2">
-                    {options.map((opt, idx) => (
+                    {eventTypes.map((opt, idx) => (
                       <div key={opt}>
                         <input
                           id={`type-${opt}-mobile`}
@@ -84,7 +74,7 @@ export default function EventTypeStep({ control, open = true, onToggle = () => {
               </>
             ) : (
               <fieldset className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                {options.map((opt) => (
+                {eventTypes.map((opt) => (
                   <div key={opt}>
                     <input
                       id={`type-${opt}`}

--- a/frontend/src/data/eventTypes.json
+++ b/frontend/src/data/eventTypes.json
@@ -1,0 +1,10 @@
+[
+  "Corporate",
+  "Private",
+  "Wedding",
+  "Birthday",
+  "Festival",
+  "Restaurant",
+  "Celebration",
+  "Other"
+]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -123,6 +123,7 @@ export interface BookingRequestCreate {
 }
 
 export interface ParsedBookingDetails {
+  event_type?: string;
   date?: string;
   location?: string;
   guests?: number;


### PR DESCRIPTION
## Summary
- parse event type and respect explicit years in natural-language booking text
- load event type options from shared JSON for both backend and frontend
- document dynamic event types in booking wizard section

## Testing
- `PYTHONPATH=backend pytest`
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 40 failed, 66 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68923aff8e2c832ebacce1d57eb0ac89