### PR TITLE
fix: handle AI event description state

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -68,6 +68,14 @@ const schema = yup.object<EventDetails>().shape({
   attachment_url: yup.string().optional(),
 });
 
+// Details returned by the AI parser
+interface ParsedBookingDetails {
+  eventType?: string;
+  date?: string;
+  location?: string;
+  guests?: number;
+}
+
 // --- Wizard Steps & Instructions ---
 const steps = [
   'Event Details',
@@ -126,6 +134,10 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   const [isLoadingReviewData, setIsLoadingReviewData] = useState(false);
   const [calculatedPrice, setCalculatedPrice] = useState<number | null>(null);
   const [baseServicePrice, setBaseServicePrice] = useState<number>(0); // New state for base service price
+  const [aiText, setAiText] = useState(''); // Raw event description entered or transcribed
+  const [parsedDetails, setParsedDetails] = useState<ParsedBookingDetails | null>(null); // AI-extracted details
+  const [listening, setListening] = useState(false); // Whether speech recognition is active
+  const recognitionRef = useRef<SpeechRecognition | null>(null); // SpeechRecognition instance
 
   const isMobile = useIsMobile();
   const hasLoaded = useRef(false);

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -1,10 +1,9 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import BookingWizard from '../BookingWizard';
 import { BookingProvider, useBooking } from '@/contexts/BookingContext';
 import { useAuth } from '@/contexts/AuthContext';
 import * as api from '@/lib/api';
-import { flushPromises } from '@/test/utils/flush';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
@@ -38,6 +37,13 @@ describe('BookingWizard instructions', () => {
   it('shows first step instruction', () => {
     render(<Wrapper />);
     expect(document.body.textContent).toContain('Tell us a little bit more about your event.');
+  });
+
+  it('renders AI text input and updates its value', () => {
+    render(<Wrapper />);
+    const textarea = screen.getByLabelText('Describe your event') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Birthday party' } });
+    expect(textarea.value).toBe('Birthday party');
   });
 
 });


### PR DESCRIPTION
## Summary
- define state for AI-assisted event descriptions in booking wizard
- add unit test covering AI text input

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689256b69ad0832ebe03f37528fe00bd