### PR TITLE
fix: prevent react-datepicker click-outside error

### DIFF
--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -84,6 +84,9 @@ export default function DateTimeStep({
                   filterDate={filterDate}
                   minDate={startOfDay(new Date())}
                   onChange={(date: Date | null) => field.onChange(date)}
+                  // react-datepicker expects a function for onClickOutside; provide
+                  // a no-op handler to prevent runtime errors when clicking elsewhere.
+                  onClickOutside={() => {}}
                   renderCustomHeader={(
                     {
                       date,

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -191,6 +191,8 @@ export default function SearchPopupContent({
         <ReactDatePicker
           selected={when}
           onChange={handleDateSelect}
+          // Provide handler so react-datepicker's outside click logic always has a function to call
+          onClickOutside={closeAllPopups}
           dateFormat="MMM d, yyyy"
           inline
           calendarClassName="react-datepicker-custom-calendar"


### PR DESCRIPTION
## Summary
- add no-op onClickOutside handler for booking calendar
- wire search popup datepicker onClickOutside to close the popup

## Testing
- `./scripts/test-all.sh`
- `cd frontend && npm test src/app/dashboard/quotes/__tests__/EditQuoteModal.test.tsx` *(fails: TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_68925a3cd1d8832eae460fa4a926ef98