### PR TITLE
feat: improve mobile inbox navigation

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,7 +124,7 @@ The `/inbox` page accepts a `requestId` to open a specific conversation and an o
 /inbox?requestId=42&sendQuote=1
 ```
 
-On small screens the conversation list is rendered inside a scrollable card, and selecting a conversation smoothly focuses the chat thread.
+On small screens the inbox initially displays only the conversation list. Tapping a conversation opens the chat thread and hides the list, and a back button returns to the conversation list.
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary
- show only conversation list on mobile inbox until a chat is selected
- add back navigation and responsive handling for message threads
- document mobile inbox behavior in frontend README

## Testing
- `npm --prefix frontend run lint` *(fails: several lint errors)*
- `./scripts/test-all.sh` *(aborted: dependency installation and test run did not complete)*
- `npx --prefix frontend jest src/app/inbox/__tests__/InboxPage.test.tsx` *(fails: babel transform error)*

------
https://chatgpt.com/codex/tasks/task_e_6892715403b0832eb100953faec54e79