### PR TITLE
feat: restore mobile bottom navigation

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -306,7 +306,7 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
 
       <Footer />
 
-      {user && <MobileBottomNav user={user} />}
+      <MobileBottomNav user={user} />
     </div>
   );
 }

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -42,9 +42,7 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
       auth: true,
     },
   ];
-  if (!user) {
-    return null;
-  }
+  const visibleItems = navItems.filter((item) => !item.auth || user);
   // Next.js App Router doesn’t expose pathname in its types, so we use a type assertion
   const pathname = (router as unknown as { pathname?: string }).pathname || '';
   const unreadMessages = notificationItems
@@ -61,7 +59,7 @@ export default function MobileBottomNav({ user }: MobileBottomNavProps) {
       aria-label="Mobile navigation"
     >
       <ul className="flex justify-around h-full">
-        {navItems.map((item) => {
+        {visibleItems.map((item) => {
           const active = pathname === item.href;
           const showBadge = item.name === 'Messages' && unreadMessages > 0;
 

--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -52,14 +52,17 @@ describe('MobileBottomNav', () => {
     container.remove();
   });
 
-  it('does not render when not logged in', () => {
+  it('renders only public links when not logged in', () => {
     mockUseRouter.mockReturnValue({ pathname: '/' });
     act(() => {
-      root.render(
-        React.createElement(MobileBottomNav, { user: null })
-      );
+      root.render(React.createElement(MobileBottomNav, { user: null }));
     });
-    expect(container.innerHTML).toBe('');
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    expect(container.textContent).toContain('Home');
+    expect(container.textContent).toContain('Artists');
+    expect(container.textContent).not.toContain('Messages');
+    expect(container.textContent).not.toContain('Dashboard');
   });
 
   it('renders navigation links when logged in', () => {


### PR DESCRIPTION
## Summary
- always render MobileBottomNav in MainLayout so it appears on mobile
- show only public links when logged out
- add regression test for guest navigation

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6892669ae73c832e976700b86d206acf