### PR TITLE
Remove search UI from artist view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,7 +1443,7 @@ When logged in as an artist, the navigation bar shows **Today**, **View Profile*
 client view, returning the standard navigation links and redirecting to the
 homepage. When switching back to artist view you are taken to the artist
 dashboard. In artist view the header search bar and compact search pill are
-replaced by a **View Profile** link. The toggle appears left of the booking
+removed entirely so only the navigation links remain, including a single **View Profile** link. The toggle appears left of the booking
 request icon for quick access. On mobile the drawer lists both sets of links so
 switching views is always possible. All other artist options are available from
 the mobile menu or profile dropdown.

--- a/frontend/src/__tests__/artistViewToggle.test.tsx
+++ b/frontend/src/__tests__/artistViewToggle.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import Header from '../components/layout/Header';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -14,7 +13,7 @@ jest.mock('@/contexts/AuthContext');
 const mockUseAuth = useAuth as jest.Mock;
 
 describe('Header artist view', () => {
-  it('shows artist links and profile pill when artistViewActive', () => {
+  it('shows artist links without search when artistViewActive', () => {
     const toggleArtistView = jest.fn();
     mockUseAuth.mockReturnValue({
       user: { id: 1, user_type: 'artist', email: 'a', first_name: 'A', last_name: 'B' },
@@ -26,8 +25,10 @@ describe('Header artist view', () => {
     expect(screen.getByText('Today')).toBeTruthy();
     expect(screen.getByText('Services')).toBeTruthy();
     expect(screen.getByText('Messages')).toBeTruthy();
-    expect(screen.getAllByText('View Profile').length).toBeGreaterThan(1);
+    expect(screen.getAllByText('View Profile')).toHaveLength(1);
     expect(screen.queryByText('Add artist')).toBeNull();
+    expect(screen.queryByText('Add location')).toBeNull();
+    expect(document.querySelector('#compact-search-trigger')).toBeNull();
     expect(mockUseAuth).toHaveBeenCalled();
   });
 
@@ -42,5 +43,18 @@ describe('Header artist view', () => {
     expect(screen.getByText('Artists')).toBeTruthy();
     expect(screen.queryByText('Today')).toBeNull();
     expect(mockUseAuth).toHaveBeenCalled();
+  });
+
+  it('keeps nav links visible when search bar is hidden in compact mode', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, user_type: 'artist', email: 'a', first_name: 'A', last_name: 'B' },
+      logout: jest.fn(),
+      artistViewActive: false,
+      toggleArtistView: jest.fn(),
+    });
+    render(<Header headerState="compacted" onForceHeaderState={jest.fn()} showSearchBar={false} />);
+    expect(screen.getByText('Artists')).toBeTruthy();
+    const wrapper = document.querySelector('.header-nav-links');
+    expect(wrapper?.className).not.toContain('opacity-0');
   });
 });

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -196,10 +196,14 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
           {/* Center Section: Dynamically switches between Nav Links and Compact Pill */}
           <div className="hidden md:flex justify-center flex-grow relative">
             {/* Nav Links (Visible initially, and when compact search expands) */}
-            <div className={clsx("content-area-wrapper header-nav-links", {
-              "opacity-0 pointer-events-none": headerState === 'compacted',
-              "opacity-100 pointer-events-auto transition-opacity duration-300 delay-100": headerState !== 'compacted'
-            })}>
+            <div
+              className={clsx('content-area-wrapper header-nav-links', {
+                'opacity-0 pointer-events-none':
+                  headerState === 'compacted' && !isArtistView && showSearchBar,
+                'opacity-100 pointer-events-auto transition-opacity duration-300 delay-100':
+                  headerState !== 'compacted' || isArtistView || !showSearchBar,
+              })}
+            >
               <nav className="flex gap-6">
                 {user?.user_type === 'artist' && artistViewActive ? (
                   <ArtistNav user={user} pathname={pathname} />
@@ -210,32 +214,14 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
             </div>
 
             {/* Compact Search Pill (Visible when scrolled/compacted) */}
-            {isArtistView ? (
-              <div
-                className={clsx(
-                  "compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex items-center justify-center gap-2",
-                  {
-                    "opacity-0 pointer-events-none": headerState !== 'compacted',
-                    "opacity-100 pointer-events-auto transition-opacity duration-300 delay-100":
-                      headerState === 'compacted',
-                  },
-                )}
-              >
-                <Link
-                  href={`/artists/${user!.id}`}
-                  className="flex-1 w-full max-w-xl flex items-center justify-center px-4 py-2 border border-gray-300 rounded-full shadow-sm hover:shadow-md text-sm"
-                >
-                  View Profile
-                </Link>
-              </div>
-            ) : (
+            {!isArtistView &&
               showSearchBar && (
                 <div
                   className={clsx(
-                    "compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex items-center justify-center gap-2",
+                    'compact-pill-wrapper absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full flex items-center justify-center gap-2',
                     {
-                      "opacity-0 pointer-events-none": headerState !== 'compacted',
-                      "opacity-100 pointer-events-auto transition-opacity duration-300 delay-100":
+                      'opacity-0 pointer-events-none': headerState !== 'compacted',
+                      'opacity-100 pointer-events-auto transition-opacity duration-300 delay-100':
                         headerState === 'compacted',
                     },
                   )}
@@ -264,8 +250,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                   </button>
                   {filterControl && <div className="shrink-0">{filterControl}</div>}
                 </div>
-              )
-            )}
+              )}
           </div>
 
             {/* Icons */}
@@ -345,25 +330,14 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
 
         {/* Full Search Bar (Visible initially, and when expanded from compact). */}
         {/* Always render even when extraBar is present so compact mode can expand. */}
-        {isArtistView ? (
-          <div
-            className="content-area-wrapper header-full-search-bar mt-3 max-w-4xl mx-auto relative"
-          >
-            <Link
-              href={`/artists/${user!.id}`}
-              className="block w-full text-center px-4 py-3 border border-gray-300 rounded-full shadow-sm hover:shadow-md text-sm"
-            >
-              View Profile
-            </Link>
-          </div>
-        ) : (
+        {!isArtistView &&
           showSearchBar && (
             <div
               className={clsx(
-                "content-area-wrapper header-full-search-bar mt-3 max-w-4xl mx-auto relative",
+                'content-area-wrapper header-full-search-bar mt-3 max-w-4xl mx-auto relative',
                 {
-                  "opacity-0 scale-y-0 h-0 pointer-events-none": headerState === 'compacted',
-                  "opacity-100 scale-y-100 pointer-events-auto": headerState !== 'compacted',
+                  'opacity-0 scale-y-0 h-0 pointer-events-none': headerState === 'compacted',
+                  'opacity-100 scale-y-100 pointer-events-auto': headerState !== 'compacted',
                 },
               )}
             >
@@ -379,8 +353,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                 compact={false} // This SearchBar is always the "full" one for visuals
               />
             </div>
-          )
-        )}
+          )}
 
         {/* Extra content bar (if needed, its visibility logic might need to align with headerState) */}
         {extraBar && (headerState === 'initial' || headerState === 'expanded-from-compact') && (


### PR DESCRIPTION
## Summary
- hide header search UI when viewing as an artist and keep navigation visible
- verify artist header renders no search elements and only one profile link
- keep nav links visible on artist profile headers when the search bar is disabled
- document that artist view removes header search bar and compact pill

## Testing
- `FAST=1 ./scripts/test-all.sh`
- `cd frontend && npx jest src/__tests__/artistViewToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6893016173a8832eb4421173aea47acb