### PR TITLE
feat(messages): add visibility and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Backend now defines a unified `BookingStatus` enum in `backend/app/models/booking_status.py` shared by bookings and booking requests.
 - Error fallback messages now detect authentication failures and prompt users to log in.
 - Booking request API responses now include `last_message_content` and `last_message_timestamp` so inbox conversations sort by recent chats.
+- Messages now include a `message_type` (`USER`, `QUOTE`, `SYSTEM`) and `visible_to`
+  (`artist`, `client`, `both`) field so threads render and filter correctly for
+  each participant.
 - Backend now fetches these fields using a single optimized query for improved performance.
 - Booking request endpoints now embed the artist's business name so clients no longer see placeholder `user/unknown` names.
 

--- a/backend/alembic/versions/f23ad0e57c1d_add_visible_to_and_update_message_type.py
+++ b/backend/alembic/versions/f23ad0e57c1d_add_visible_to_and_update_message_type.py
@@ -1,0 +1,47 @@
+"""add visible_to and update message_type values
+
+Revision ID: f23ad0e57c1d
+Revises: e03ae2c1f3b6
+Create Date: 2025-09-30 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f23ad0e57c1d"
+down_revision: Union[str, None] = "e03ae2c1f3b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    visible_enum = sa.Enum("artist", "client", "both", name="visibleto")
+    message_enum = sa.Enum("USER", "QUOTE", "SYSTEM", name="messagetype")
+    visible_enum.create(op.get_bind(), checkfirst=True)
+    message_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "messages",
+        sa.Column("visible_to", visible_enum, nullable=False, server_default="both"),
+    )
+    op.execute("UPDATE messages SET message_type='USER' WHERE message_type='text'")
+    op.execute("UPDATE messages SET message_type=upper(message_type)")
+    op.alter_column(
+        "messages",
+        "message_type",
+        existing_type=sa.String(),
+        type_=message_enum,
+        existing_nullable=False,
+        server_default="USER",
+    )
+    op.alter_column("messages", "message_type", server_default=None)
+    op.alter_column("messages", "visible_to", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "visible_to")
+    op.execute("UPDATE messages SET message_type=lower(message_type)")
+    op.execute("DROP TYPE IF EXISTS visibleto")
+    op.execute("DROP TYPE IF EXISTS messagetype")
+

--- a/backend/app/api/api_message.py
+++ b/backend/app/api/api_message.py
@@ -54,7 +54,14 @@ def read_messages(
             {},
             status.HTTP_403_FORBIDDEN,
         )
-    db_messages = crud.crud_message.get_messages_for_request(db, request_id)
+    viewer = (
+        models.VisibleTo.CLIENT
+        if current_user.id == booking_request.client_id
+        else models.VisibleTo.ARTIST
+    )
+    db_messages = crud.crud_message.get_messages_for_request(
+        db, request_id, viewer
+    )
     result = []
     for m in db_messages:
         avatar_url = None
@@ -145,6 +152,7 @@ def create_message(
         sender_type=sender_type,
         content=message_in.content,
         message_type=message_in.message_type,
+        visible_to=message_in.visible_to,
         quote_id=message_in.quote_id,
         attachment_url=message_in.attachment_url,
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,7 +10,7 @@ from .quote_template import QuoteTemplate
 from .booking_simple import BookingSimple
 from .sound_provider import SoundProvider
 from .artist_sound_preference import ArtistSoundPreference
-from .message import Message, SenderType, MessageType
+from .message import Message, SenderType, MessageType, VisibleTo
 from .notification import Notification, NotificationType
 from .calendar_account import CalendarAccount, CalendarProvider
 from .email_token import EmailToken
@@ -37,6 +37,7 @@ __all__ = [
     "QuoteStatusV2",
     "SenderType",
     "MessageType",
+    "VisibleTo",
     "Notification",
     "NotificationType",
     "CalendarAccount",

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -19,9 +19,19 @@ class SenderType(str, enum.Enum):
     ARTIST = "artist"
 
 class MessageType(str, enum.Enum):
-    TEXT = "text"
-    QUOTE = "quote"
-    SYSTEM = "system"
+    """Type of message being stored."""
+
+    USER = "USER"
+    QUOTE = "QUOTE"
+    SYSTEM = "SYSTEM"
+
+
+class VisibleTo(str, enum.Enum):
+    """Specify who can view a given message."""
+
+    ARTIST = "artist"
+    CLIENT = "client"
+    BOTH = "both"
 
 
 class Message(BaseModel):
@@ -31,7 +41,12 @@ class Message(BaseModel):
     booking_request_id = Column(Integer, ForeignKey("booking_requests.id"), nullable=False)
     sender_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     sender_type = Column(Enum(SenderType), nullable=False)
-    message_type = Column(Enum(MessageType), nullable=False, default=MessageType.TEXT)
+    message_type = Column(
+        Enum(MessageType), nullable=False, default=MessageType.USER
+    )
+    visible_to = Column(
+        Enum(VisibleTo), nullable=False, default=VisibleTo.BOTH
+    )
     content = Column(Text, nullable=False)
     # Link to the newer quotes_v2 table so quote messages render properly
     quote_id = Column(Integer, ForeignKey("quotes_v2.id"), nullable=True)

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel
 from datetime import datetime
-from ..models.message import SenderType, MessageType
+from ..models.message import SenderType, MessageType, VisibleTo
 
 
 class MessageCreate(BaseModel):
     content: str
-    message_type: MessageType = MessageType.TEXT
+    message_type: MessageType = MessageType.USER
+    visible_to: VisibleTo = VisibleTo.BOTH
     quote_id: int | None = None
     attachment_url: str | None = None
 
@@ -16,6 +17,7 @@ class MessageResponse(BaseModel):
     sender_id: int
     sender_type: SenderType
     message_type: MessageType
+    visible_to: VisibleTo
     content: str
     quote_id: int | None = None
     attachment_url: str | None = None

--- a/backend/tests/test_booking_request_last_message.py
+++ b/backend/tests/test_booking_request_last_message.py
@@ -71,7 +71,7 @@ def test_read_my_client_booking_requests_last_message_ordering():
         client.id,
         SenderType.CLIENT,
         "hi",
-        MessageType.TEXT,
+        MessageType.USER,
     )
     m1.timestamp = earlier
     db.add(m1)
@@ -81,7 +81,7 @@ def test_read_my_client_booking_requests_last_message_ordering():
         artist.id,
         SenderType.ARTIST,
         "reply",
-        MessageType.TEXT,
+        MessageType.USER,
     )
     m2.timestamp = later
     db.add(m2)
@@ -91,7 +91,7 @@ def test_read_my_client_booking_requests_last_message_ordering():
         client.id,
         SenderType.CLIENT,
         "ping",
-        MessageType.TEXT,
+        MessageType.USER,
     )
     m3.timestamp = later2
     db.add(m3)

--- a/backend/tests/test_dashboard_stats.py
+++ b/backend/tests/test_dashboard_stats.py
@@ -52,7 +52,7 @@ def test_get_dashboard_stats():
         booking_request_id=req2.id,
         sender_id=artist.id,
         sender_type=SenderType.ARTIST,
-        message_type=MessageType.TEXT,
+        message_type=MessageType.USER,
         content="hello",
     )
     db.add(msg)

--- a/backend/tests/test_message_flow.py
+++ b/backend/tests/test_message_flow.py
@@ -84,7 +84,7 @@ def test_message_response_includes_avatar_url_for_artist():
     db.add(br)
     db.commit()
 
-    msg_in = MessageCreate(content="hello", message_type=MessageType.TEXT)
+    msg_in = MessageCreate(content="hello", message_type=MessageType.USER)
     result = api_message.create_message(br.id, msg_in, db, current_user=artist)
 
     assert result["avatar_url"] == "/static/profile_pics/pic.jpg"
@@ -120,7 +120,7 @@ def test_message_response_includes_avatar_url_for_client():
     db.add(br)
     db.commit()
 
-    msg_in = MessageCreate(content="hi", message_type=MessageType.TEXT)
+    msg_in = MessageCreate(content="hi", message_type=MessageType.USER)
     result = api_message.create_message(br.id, msg_in, db, current_user=client)
 
     assert result["avatar_url"] == "/static/profile_pics/client.jpg"
@@ -155,7 +155,7 @@ def test_mark_messages_read_updates_flag():
     db.add(br)
     db.commit()
 
-    msg_in = MessageCreate(content="hello", message_type=MessageType.TEXT)
+    msg_in = MessageCreate(content="hello", message_type=MessageType.USER)
     api_message.create_message(br.id, msg_in, db, current_user=artist)
 
     # Ensure message unread initially

--- a/backend/tests/test_message_visible_to.py
+++ b/backend/tests/test_message_visible_to.py
@@ -1,0 +1,83 @@
+import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import models
+from app.api import api_message
+from app.crud import crud_message
+from app.models.base import BaseModel
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_read_messages_filters_by_visible_to():
+    db = setup_db()
+    client = models.User(
+        email="c@test.com",
+        password="x",
+        first_name="C",
+        last_name="Client",
+        user_type=models.UserType.CLIENT,
+    )
+    artist = models.User(
+        email="a@test.com",
+        password="x",
+        first_name="A",
+        last_name="Artist",
+        user_type=models.UserType.ARTIST,
+    )
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    br = models.BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        status=models.BookingStatus.PENDING_QUOTE,
+        created_at=datetime.datetime.utcnow(),
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    crud_message.create_message(
+        db,
+        booking_request_id=br.id,
+        sender_id=client.id,
+        sender_type=models.SenderType.CLIENT,
+        content="hi",
+        message_type=models.MessageType.USER,
+        visible_to=models.VisibleTo.BOTH,
+    )
+    crud_message.create_message(
+        db,
+        booking_request_id=br.id,
+        sender_id=artist.id,
+        sender_type=models.SenderType.ARTIST,
+        content="secret",
+        message_type=models.MessageType.USER,
+        visible_to=models.VisibleTo.ARTIST,
+    )
+    crud_message.create_message(
+        db,
+        booking_request_id=br.id,
+        sender_id=client.id,
+        sender_type=models.SenderType.CLIENT,
+        content="note",
+        message_type=models.MessageType.USER,
+        visible_to=models.VisibleTo.CLIENT,
+    )
+
+    client_msgs = api_message.read_messages(br.id, db=db, current_user=client)
+    assert len(client_msgs) == 2
+    assert {m["content"] for m in client_msgs} == {"hi", "note"}
+
+    artist_msgs = api_message.read_messages(br.id, db=db, current_user=artist)
+    assert len(artist_msgs) == 2
+    assert {m["content"] for m in artist_msgs} == {"hi", "secret"}

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -103,7 +103,7 @@ def test_message_creates_notification():
     db.commit()
     db.refresh(br)
 
-    msg_in = MessageCreate(content="hello", message_type=MessageType.TEXT)
+    msg_in = MessageCreate(content="hello", message_type=MessageType.USER)
     api_message.create_message(br.id, msg_in, db, current_user=client)
 
     notifs = crud_notification.get_notifications_for_user(db, artist.id)
@@ -259,7 +259,7 @@ def test_thread_notification_summary():
 
     # send multiple messages from client -> artist
     for _ in range(5):
-        msg_in = MessageCreate(content="hi", message_type=MessageType.TEXT)
+        msg_in = MessageCreate(content="hi", message_type=MessageType.USER)
         api_message.create_message(br.id, msg_in, db, current_user=client)
 
     threads = crud_notification.get_message_thread_notifications(db, artist.id)
@@ -310,7 +310,7 @@ def test_thread_notification_shows_client_avatar():
 
     api_message.create_message(
         br.id,
-        MessageCreate(content="hi", message_type=MessageType.TEXT),
+        MessageCreate(content="hi", message_type=MessageType.USER),
         db,
         current_user=client,
     )
@@ -358,7 +358,7 @@ def test_thread_notification_uses_business_name_for_artist():
     db.commit()
     db.refresh(br)
 
-    msg_in = MessageCreate(content="hello", message_type=MessageType.TEXT)
+    msg_in = MessageCreate(content="hello", message_type=MessageType.USER)
     api_message.create_message(br.id, msg_in, db, current_user=artist)
 
     threads = crud_notification.get_message_thread_notifications(db, client.id)
@@ -406,7 +406,7 @@ def test_thread_notification_includes_booking_details():
     # create a normal message to generate a notification
     api_message.create_message(
         br.id,
-        MessageCreate(content="hello", message_type=MessageType.TEXT),
+        MessageCreate(content="hello", message_type=MessageType.USER),
         db,
         current_user=client,
     )
@@ -742,7 +742,7 @@ def test_notifications_endpoint_returns_sender_name():
         sender=client_user,
         booking_request_id=br.id,
         content="hello",
-        message_type=MessageType.TEXT,
+        message_type=MessageType.USER,
     )
     db.close()
 

--- a/backend/tests/test_service_delete.py
+++ b/backend/tests/test_service_delete.py
@@ -64,7 +64,7 @@ def test_delete_service_cascades_messages():
         sender_id=client_user.id,
         sender_type=SenderType.CLIENT,
         content='hi',
-        message_type=MessageType.TEXT,
+        message_type=MessageType.USER,
     )
     db.add(msg)
     db.commit()

--- a/backend/tests/test_user_export_delete.py
+++ b/backend/tests/test_user_export_delete.py
@@ -129,7 +129,7 @@ def create_data(Session):
         booking_request_id=br.id,
         sender_id=client.id,
         sender_type=SenderType.CLIENT,
-        message_type=MessageType.TEXT,
+        message_type=MessageType.USER,
         content='Hello',
     )
     db.add(msg)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -989,6 +989,61 @@
         }
       }
     },
+    "/api/v1/artists/recommended": {
+      "get": {
+        "tags": [
+          "artists"
+        ],
+        "summary": "Get recommended artists",
+        "description": "Return personalized artist suggestions for the current user.",
+        "operationId": "recommended_artists_api_v1_artists_recommended_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 20,
+              "minimum": 1,
+              "default": 5,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtistProfileResponse"
+                  },
+                  "title": "Response Recommended Artists Api V1 Artists Recommended Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/services/": {
       "get": {
         "tags": [
@@ -1021,7 +1076,7 @@
           "Services"
         ],
         "summary": "Create Service",
-        "description": "Create a new service for the currently authenticated artist.\nFull path → POST /api/v1/services/",
+        "description": "Create a new service for the currently authenticated artist.\nFull path \u2192 POST /api/v1/services/",
         "operationId": "create_service_api_v1_services__post",
         "requestBody": {
           "content": {
@@ -1069,7 +1124,7 @@
           "Services"
         ],
         "summary": "Update Service",
-        "description": "Update a service owned by the currently authenticated artist.\nFull path → PUT /api/v1/services/{service_id}",
+        "description": "Update a service owned by the currently authenticated artist.\nFull path \u2192 PUT /api/v1/services/{service_id}",
         "operationId": "update_service_api_v1_services__service_id__put",
         "security": [
           {
@@ -1126,7 +1181,7 @@
           "Services"
         ],
         "summary": "Read Service",
-        "description": "Get a specific service by its ID (publicly accessible).\nFull path → GET /api/v1/services/{service_id}",
+        "description": "Get a specific service by its ID (publicly accessible).\nFull path \u2192 GET /api/v1/services/{service_id}",
         "operationId": "read_service_api_v1_services__service_id__get",
         "parameters": [
           {
@@ -1168,7 +1223,7 @@
           "Services"
         ],
         "summary": "Delete Service",
-        "description": "Delete a service owned by the currently authenticated artist.\nFull path → DELETE /api/v1/services/{service_id}",
+        "description": "Delete a service owned by the currently authenticated artist.\nFull path \u2192 DELETE /api/v1/services/{service_id}",
         "operationId": "delete_service_api_v1_services__service_id__delete",
         "security": [
           {
@@ -1210,7 +1265,7 @@
           "Services"
         ],
         "summary": "Read Services By Artist",
-        "description": "Get all services offered by a specific artist (by their user_id).\nFull path → GET /api/v1/services/artist/{artist_user_id}",
+        "description": "Get all services offered by a specific artist (by their user_id).\nFull path \u2192 GET /api/v1/services/artist/{artist_user_id}",
         "operationId": "read_services_by_artist_api_v1_services_artist__artist_user_id__get",
         "parameters": [
           {
@@ -1469,7 +1524,7 @@
           "bookings"
         ],
         "summary": "Read Booking Details",
-        "description": "Return the details of a single booking.  \nAccessible if the current user is either the booking’s client or the booking’s artist.",
+        "description": "Return the details of a single booking.  \nAccessible if the current user is either the booking\u2019s client or the booking\u2019s artist.",
         "operationId": "read_booking_details_api_v1_bookings__booking_id__get",
         "security": [
           {
@@ -1784,6 +1839,49 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/booking-requests/parse": {
+      "post": {
+        "tags": [
+          "booking-requests",
+          "Booking Requests"
+        ],
+        "summary": "Parse Booking Text",
+        "description": "Parse free-form text and extract event details.",
+        "operationId": "parse_booking_text_api_v1_booking_requests_parse_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BookingParseRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParsedBookingDetails"
+                }
               }
             }
           },
@@ -4340,44 +4438,6 @@
           }
         }
       }
-    },
-    "/api/v1/artists/recommended": {
-      "get": {
-        "tags": [
-          "artists"
-        ],
-        "summary": "Get recommended artists",
-        "description": "Return personalized artist recommendations for the current user.",
-        "operationId": "recommended_artists_api_v1_artists_recommended_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "title": "Limit",
-              "type": "integer",
-              "default": 5
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Recommended Artists",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ArtistProfileResponse"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components": {
@@ -5267,6 +5327,22 @@
         ],
         "title": "BookingDetailsSummary"
       },
+      "BookingParseRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Text",
+            "description": "Free-form event description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "BookingParseRequest",
+        "description": "Request body containing raw event description."
+      },
       "BookingRequestCreate": {
         "properties": {
           "service_id": {
@@ -5602,25 +5678,6 @@
           "created_at"
         ],
         "title": "BookingRequestResponse"
-      },
-      "BookingStatus": {
-        "type": "string",
-        "enum": [
-          "pending",
-          "confirmed",
-          "completed",
-          "cancelled",
-          "draft",
-          "pending_quote",
-          "quote_provided",
-          "pending_artist_confirmation",
-          "request_confirmed",
-          "request_completed",
-          "request_declined",
-          "request_withdrawn",
-          "quote_rejected"
-        ],
-        "title": "BookingStatus"
       },
       "BookingRequestUpdateByArtist": {
         "properties": {
@@ -6018,6 +6075,26 @@
         ],
         "title": "BookingSimpleRead"
       },
+      "BookingStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "confirmed",
+          "completed",
+          "cancelled",
+          "draft",
+          "pending_quote",
+          "quote_provided",
+          "pending_artist_confirmation",
+          "request_confirmed",
+          "request_completed",
+          "request_declined",
+          "request_withdrawn",
+          "quote_rejected"
+        ],
+        "title": "BookingStatus",
+        "description": "Central booking status enumeration used across the application."
+      },
       "BookingUpdate": {
         "properties": {
           "status": {
@@ -6255,7 +6332,11 @@
           },
           "message_type": {
             "$ref": "#/components/schemas/MessageType",
-            "default": "text"
+            "default": "USER"
+          },
+          "visible_to": {
+            "$ref": "#/components/schemas/VisibleTo",
+            "default": "both"
           },
           "quote_id": {
             "anyOf": [
@@ -6305,6 +6386,9 @@
           },
           "message_type": {
             "$ref": "#/components/schemas/MessageType"
+          },
+          "visible_to": {
+            "$ref": "#/components/schemas/VisibleTo"
           },
           "content": {
             "type": "string",
@@ -6361,6 +6445,7 @@
           "sender_id",
           "sender_type",
           "message_type",
+          "visible_to",
           "content",
           "timestamp"
         ],
@@ -6369,11 +6454,12 @@
       "MessageType": {
         "type": "string",
         "enum": [
-          "text",
-          "quote",
-          "system"
+          "USER",
+          "QUOTE",
+          "SYSTEM"
         ],
-        "title": "MessageType"
+        "title": "MessageType",
+        "description": "Type of message being stored."
       },
       "NotificationResponse": {
         "properties": {
@@ -6465,6 +6551,62 @@
           "review_request"
         ],
         "title": "NotificationType"
+      },
+      "ParsedBookingDetails": {
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date",
+            "description": "Event date if detected"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "description": "Event location if detected"
+          },
+          "guests": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guests",
+            "description": "Guest count if detected"
+          },
+          "event_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type",
+            "description": "Event type if detected"
+          }
+        },
+        "type": "object",
+        "title": "ParsedBookingDetails",
+        "description": "Structured details extracted from text."
       },
       "PaymentCreate": {
         "properties": {
@@ -6604,6 +6746,17 @@
             "type": "string",
             "title": "Travel Cost"
           },
+          "travel_mode": {
+            "type": "string",
+            "title": "Travel Mode"
+          },
+          "travel_estimates": {
+            "items": {
+              "$ref": "#/components/schemas/TravelEstimate"
+            },
+            "type": "array",
+            "title": "Travel Estimates"
+          },
           "provider_cost": {
             "type": "string",
             "title": "Provider Cost"
@@ -6621,6 +6774,8 @@
         "required": [
           "base_fee",
           "travel_cost",
+          "travel_mode",
+          "travel_estimates",
           "provider_cost",
           "accommodation_cost",
           "total"
@@ -7880,6 +8035,25 @@
         "title": "ThreadNotificationResponse",
         "description": "Aggregated message notifications for a chat thread."
       },
+      "TravelEstimate": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "title": "Mode"
+          },
+          "cost": {
+            "type": "string",
+            "title": "Cost"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode",
+          "cost"
+        ],
+        "title": "TravelEstimate",
+        "description": "Individual travel mode cost estimate."
+      },
       "UserCreate": {
         "properties": {
           "email": {
@@ -8036,6 +8210,16 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "VisibleTo": {
+        "type": "string",
+        "enum": [
+          "artist",
+          "client",
+          "both"
+        ],
+        "title": "VisibleTo",
+        "description": "Specify who can view a given message."
       },
       "app__schemas__quote_v2__QuoteCreate": {
         "properties": {


### PR DESCRIPTION
## Summary
- extend Message model with `message_type` and `visible_to`
- filter chat messages by visibility for current user
- document and test message visibility behavior

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd backend && PYTHONPATH=. pytest tests/test_message_visible_to.py`


------
https://chatgpt.com/codex/tasks/task_e_68930f21f3b4832eb3248704d40a2605