### PR TITLE
feat: add quote review modal

### DIFF
--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -4,6 +4,7 @@ Clients and artists communicate through the dedicated **Inbox** page. The layout
 
 1. **Conversation list** on the left displays all booking requests. Each item shows the `last_message_content` as a short preview, falling back to the event or service name when there are no messages. Conversations are sorted by `last_message_timestamp` so the most recently active threads appear first. Unread threads show a red dot indicator.
 2. **Chat area** in the center shows all messages for the selected request. Quotes appear as special bubbles with **Accept** and **Decline** buttons for clients.
+   Clicking **Review & Accept Quote** now opens a detailed Quote Review modal showing line items, fees and the total with clear **Accept** and **Decline** actions.
 3. **Booking details panel** on the right summarises key information from the request and, when a quote is accepted, provides quick links to pay the deposit and add the event to a calendar.
 
 Notifications for new messages link directly to the relevant conversation in the Inbox. When the artist sends a final quote the client can open it here, accept it and proceed with payment without leaving the page.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2417,6 +2417,39 @@
         }
       }
     },
+    "/api/v1/quotes/{quote_id}/decline": {
+      "post": {
+        "tags": [
+          "quotes-v2",
+          "QuotesV2"
+        ],
+        "summary": "Decline Quote",
+        "operationId": "decline_quote_api_v1_quotes__quote_id__decline_post",
+        "parameters": [
+          {
+            "name": "quote_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Quote Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuoteV2Read"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/quotes/{quote_id}/pdf": {
       "get": {
         "tags": [

--- a/frontend/src/components/booking/QuoteReviewModal.tsx
+++ b/frontend/src/components/booking/QuoteReviewModal.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { QuoteV2 } from '@/types';
+import { formatCurrency } from '@/lib/utils';
+
+interface Props {
+  open: boolean;
+  quote: QuoteV2 | null;
+  onClose: () => void;
+  onAccept: (quote: QuoteV2) => Promise<void> | void;
+  onDecline: (quote: QuoteV2) => Promise<void> | void;
+}
+
+const QuoteReviewModal: React.FC<Props> = ({
+  open,
+  quote,
+  onClose,
+  onAccept,
+  onDecline,
+}) => {
+  const [loading, setLoading] = useState<'accept' | 'decline' | null>(null);
+
+  if (!open || !quote) return null;
+
+  const handleAccept = async () => {
+    setLoading('accept');
+    try {
+      await onAccept(quote);
+    } finally {
+      setLoading(null);
+      onClose();
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!window.confirm('Are you sure?')) return;
+    setLoading('decline');
+    try {
+      await onDecline(quote);
+    } finally {
+      setLoading(null);
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md">
+        <div className="p-6">
+          <h2 className="text-xl font-semibold mb-4">Quote Review</h2>
+          <ul className="space-y-2">
+            {quote.services.map((s, i) => (
+              <li key={i} className="flex justify-between text-sm">
+                <span>{s.description}</span>
+                <span>{formatCurrency(Number(s.price))}</span>
+              </li>
+            ))}
+            <li className="flex justify-between text-sm">
+              <span>Sound fee</span>
+              <span>{formatCurrency(Number(quote.sound_fee))}</span>
+            </li>
+            <li className="flex justify-between text-sm">
+              <span>Travel fee</span>
+              <span>{formatCurrency(Number(quote.travel_fee))}</span>
+            </li>
+            {quote.discount !== undefined && quote.discount !== null && (
+              <li className="flex justify-between text-sm">
+                <span>Discount</span>
+                <span>-{formatCurrency(Number(quote.discount))}</span>
+              </li>
+            )}
+            <li className="flex justify-between text-sm font-medium border-t pt-2 mt-2">
+              <span>Subtotal</span>
+              <span>{formatCurrency(Number(quote.subtotal))}</span>
+            </li>
+            <li className="flex justify-between text-base font-bold">
+              <span>Total</span>
+              <span>{formatCurrency(Number(quote.total))}</span>
+            </li>
+          </ul>
+        </div>
+        <div className="p-6 bg-gray-50 border-t flex justify-end space-x-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors"
+            disabled={loading !== null}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleDecline}
+            className="bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition-colors flex items-center justify-center min-w-[80px]"
+            disabled={loading !== null}
+          >
+            {loading === 'decline' ? (
+              <div
+                className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"
+                data-testid="decline-spinner"
+              />
+            ) : (
+              'Decline'
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleAccept}
+            className="bg-green-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-green-700 transition-colors flex items-center justify-center min-w-[80px]"
+            disabled={loading !== null}
+          >
+            {loading === 'accept' ? (
+              <div
+                className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"
+                data-testid="accept-spinner"
+              />
+            ) : (
+              'Accept'
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuoteReviewModal;

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -112,7 +112,7 @@ describe('MessageThread system CTAs', () => {
     container.remove();
   });
 
-  it('shows Review & Accept Quote for clients with countdown and scrolls to quote', async () => {
+  it('shows Review & Accept Quote for clients with countdown and opens modal', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
 
@@ -168,13 +168,27 @@ describe('MessageThread system CTAs', () => {
     );
     expect(button).not.toBeNull();
 
-    const scrollSpy = jest.fn();
-    Object.defineProperty(global.HTMLElement.prototype, 'scrollIntoView', {
-      value: scrollSpy,
-      configurable: true,
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 42,
+        booking_request_id: 1,
+        artist_id: 9,
+        client_id: 7,
+        services: [{ description: 'Performance', price: 100 }],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 100,
+        total: 100,
+        status: 'pending',
+        created_at: '',
+        updated_at: '',
+      },
     });
+
     act(() => { button?.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    expect(scrollSpy).toHaveBeenCalled();
+    await act(async () => { await flushPromises(); });
+    expect(api.getQuoteV2).toHaveBeenCalledWith(42);
+    expect(container.textContent).toContain('Quote Review');
 
     act(() => root.unmount());
     container.remove();

--- a/frontend/src/components/booking/__tests__/QuoteReviewModal.test.tsx
+++ b/frontend/src/components/booking/__tests__/QuoteReviewModal.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import QuoteReviewModal from '../QuoteReviewModal';
+import { QuoteV2 } from '@/types';
+
+describe('QuoteReviewModal', () => {
+  const quote: QuoteV2 = {
+    id: 1,
+    booking_request_id: 1,
+    artist_id: 2,
+    client_id: 3,
+    services: [{ description: 'Performance', price: 100 }],
+    sound_fee: 20,
+    travel_fee: 30,
+    subtotal: 150,
+    total: 150,
+    status: 'pending',
+    created_at: '',
+    updated_at: '',
+  };
+
+  it('disables buttons and shows spinner on accept', async () => {
+    const onAccept = jest.fn(() => Promise.resolve());
+    render(
+      <QuoteReviewModal
+        open
+        quote={quote}
+        onClose={() => {}}
+        onAccept={onAccept}
+        onDecline={jest.fn()}
+      />,
+    );
+    const btn = screen.getByText('Accept');
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+    expect(screen.getByTestId('accept-spinner')).toBeInTheDocument();
+    await waitFor(() => expect(onAccept).toHaveBeenCalled());
+  });
+
+  it('confirms and shows spinner on decline', async () => {
+    const onDecline = jest.fn(() => Promise.resolve());
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    render(
+      <QuoteReviewModal
+        open
+        quote={quote}
+        onClose={() => {}}
+        onAccept={jest.fn()}
+        onDecline={onDecline}
+      />,
+    );
+    const btn = screen.getByText('Decline');
+    fireEvent.click(btn);
+    expect(confirmSpy).toHaveBeenCalledWith('Are you sure?');
+    expect(btn).toBeDisabled();
+    expect(screen.getByTestId('decline-spinner')).toBeInTheDocument();
+    await waitFor(() => expect(onDecline).toHaveBeenCalled());
+    confirmSpy.mockRestore();
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -11,6 +11,7 @@ import api, {
   updateQuoteAsClient,
   confirmQuoteBooking,
   acceptQuoteV2,
+  declineQuoteV2,
   createReviewForBooking,
   getReview,
   getServiceReviews,
@@ -265,6 +266,17 @@ describe('acceptQuoteV2', () => {
       '/api/v1/quotes/2/accept?service_id=5',
       {},
     );
+    spy.mockRestore();
+  });
+});
+
+describe('declineQuoteV2', () => {
+  it('posts to decline endpoint', async () => {
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: {} } as unknown as { data: unknown });
+    await declineQuoteV2(9);
+    expect(spy).toHaveBeenCalledWith('/api/v1/quotes/9/decline', {});
     spy.mockRestore();
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -397,6 +397,9 @@ export const acceptQuoteV2 = (quoteId: number, serviceId?: number) => {
   return api.post<BookingSimple>(url, {});
 };
 
+export const declineQuoteV2 = (quoteId: number) =>
+  api.post<QuoteV2>(`${API_V1}/quotes/${quoteId}/decline`, {});
+
 export const getMyArtistQuotes = (params: { skip?: number; limit?: number } = {}) =>
   api.get<Quote[]>(`${API_V1}/quotes/me/artist`, { params });
 


### PR DESCRIPTION
## Summary
- add modal for reviewing quotes with accept and decline actions
- wire up quote review modal in chat thread
- support declining quotes via new API endpoint

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6893269690f4832e898dfb12523104ff