### PR TITLE
feat: add quote action hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,6 +822,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Frontend helper `acceptQuoteV2(quoteId, serviceId?)` automatically appends
   `?service_id={serviceId}` to this request when a service ID is provided.
 * The client quote detail page now uses this endpoint when clients click **Accept**.
+* React hooks `useSendQuote`, `useAcceptQuote`, and `useDeclineQuote` wrap these quote endpoints and return typed `Message` data with the shared `BookingStatus` enum.
 * Quote V2 error handling logs the acting user and quote details and returns structured responses for easier debugging.
 * Backend helper `error_response` now logs its message and field errors before raising an exception.
 * Many endpoints previously raising `HTTPException` directly now return this structured error format for consistency.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -130,6 +130,8 @@ On small screens the inbox initially displays only the conversation list. Tappin
 
 The artist dashboard includes a quotes page for managing offers. The `EditQuoteModal` allows artists to modify quote details and price inline without leaving the list. It opens when clicking the "Edit" button next to a pending quote and mirrors the style of `SendQuoteModal`. Both modals now use the shared `BottomSheet` component so they display full screen on mobile and center on larger screens. Trigger buttons expose `aria-expanded` and focus returns after closing. Sound, travel, discount, accommodation, and expiry fields remain wrapped in accessible labels so screen readers announce each input.
 
+Helper hooks `useSendQuote`, `useAcceptQuote`, and `useDeclineQuote` are available for interacting with quote endpoints in components and pages.
+
 The View Quote modal also generates a quote number automatically, shows today's date and a description box, and positions a compact **Choose template** dropdown next to the title. The **Add Item** button sits beneath the travel fee input. Service, sound, travel, and discount fees use the same horizontal pair layout as custom items, and newly added rows inherit the bordered styling so they visually match the preset fees. The bottom now mirrors the booking Review step, listing base fee, travel and sound costs, taxes and an estimated total above a **Submit Request** button. Future enhancements will include a PDF preview option, currency symbols within each field, and a signature/terms section.
 
 ### Artist Listing

--- a/frontend/src/hooks/__tests__/useQuoteActions.test.ts
+++ b/frontend/src/hooks/__tests__/useQuoteActions.test.ts
@@ -1,0 +1,60 @@
+import { useAcceptQuote, useDeclineQuote, useSendQuote } from '../useQuoteActions';
+import type { QuoteV2Create } from '@/types';
+
+describe('quote action hooks', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      status: 200,
+    });
+  });
+
+  it('sends correct payload when sending a quote', async () => {
+    const sendQuote = useSendQuote();
+    const payload: QuoteV2Create = {
+      booking_request_id: 1,
+      artist_id: 2,
+      client_id: 3,
+      services: [],
+      sound_fee: 0,
+      travel_fee: 0,
+    };
+    await sendQuote(payload);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/quotes',
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
+
+  it('posts to accept endpoint with service id', async () => {
+    const acceptQuote = useAcceptQuote();
+    await acceptQuote(5, 7);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/quotes/5/accept?service_id=7',
+      {
+        method: 'POST',
+        body: '{}',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
+
+  it('posts to decline endpoint', async () => {
+    const declineQuote = useDeclineQuote();
+    await declineQuote(9);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/quotes/9/decline',
+      {
+        method: 'POST',
+        body: '{}',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  });
+});

--- a/frontend/src/hooks/useQuoteActions.ts
+++ b/frontend/src/hooks/useQuoteActions.ts
@@ -1,0 +1,50 @@
+import type { BookingStatus, Message, QuoteV2Create } from '@/types';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_V1 = `${API_URL}/api/v1`;
+
+interface StatusMessage extends Message {
+  booking_status: BookingStatus;
+}
+
+async function jsonFetch<T>(url: string, options: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function useSendQuote() {
+  return async (data: QuoteV2Create): Promise<Message> =>
+    jsonFetch<Message>(`${API_V1}/quotes`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+}
+
+export function useAcceptQuote() {
+  return async (
+    quoteId: number,
+    serviceId?: number,
+  ): Promise<StatusMessage> => {
+    const url = serviceId
+      ? `${API_V1}/quotes/${quoteId}/accept?service_id=${serviceId}`
+      : `${API_V1}/quotes/${quoteId}/accept`;
+    return jsonFetch<StatusMessage>(url, {
+      method: 'POST',
+      body: '{}',
+    });
+  };
+}
+
+export function useDeclineQuote() {
+  return async (quoteId: number): Promise<StatusMessage> =>
+    jsonFetch<StatusMessage>(`${API_V1}/quotes/${quoteId}/decline`, {
+      method: 'POST',
+      body: '{}',
+    });
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,6 +70,21 @@ export interface Service {
   artist: ArtistProfile;
 }
 
+export type BookingStatus =
+  | 'pending'
+  | 'confirmed'
+  | 'completed'
+  | 'cancelled'
+  | 'draft'
+  | 'pending_quote'
+  | 'quote_provided'
+  | 'pending_artist_confirmation'
+  | 'request_confirmed'
+  | 'request_completed'
+  | 'request_declined'
+  | 'request_withdrawn'
+  | 'quote_rejected';
+
 export interface Booking {
   id: number;
   artist_id: number;
@@ -77,7 +92,7 @@ export interface Booking {
   service_id: number;
   start_time: string;
   end_time: string;
-  status: "pending" | "confirmed" | "completed" | "cancelled";
+  status: BookingStatus;
   total_price: number;
   notes: string;
   /** Amount paid as a deposit toward this booking */
@@ -116,7 +131,7 @@ export interface BookingRequestCreate {
   attachment_url?: string;
   proposed_datetime_1?: string; // ISO‐formatted date‐time string
   proposed_datetime_2?: string;
-  status?: string;
+  status?: BookingStatus;
   travel_mode?: 'fly' | 'drive';
   travel_cost?: number;
   travel_breakdown?: Record<string, unknown>;
@@ -128,7 +143,7 @@ export interface ParsedBookingDetails {
   guests?: number;
 
   event_type?: string;
-
+}
 
 // This is what the backend returns when you GET a booking request:
 export interface BookingRequest {
@@ -147,7 +162,7 @@ export interface BookingRequest {
   travel_mode?: 'fly' | 'drive' | null;
   travel_cost?: number | null;
   travel_breakdown?: Record<string, unknown> | null;
-  status: string; // e.g. "pending_quote", "quote_provided", etc.
+  status: BookingStatus;
   created_at: string;
   updated_at: string;
   // Optional expanded relations returned by the API


### PR DESCRIPTION
## Summary
- add hooks for sending, accepting, and declining quotes
- expose BookingStatus type and update related interfaces
- document quote action hooks

## Testing
- `pytest`
- `npm test src/hooks/__tests__/useQuoteActions.test.ts`
- `npm test src/lib/__tests__/travel.test.ts` *(fails: Expected: "fly", Received: "drive")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68932955ba98832e971db5f199544d4f