### PR TITLE
test: cover quote expiration scheduler and chat send flow

### DIFF
--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,110 @@
+import pytest
+from decimal import Decimal
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from unittest.mock import patch
+
+from app.main import process_quote_expiration
+from app import models
+from app.models.base import BaseModel
+from app.models import User, UserType, Service
+from app.models.request_quote import BookingRequest, BookingStatus
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+@patch('app.main.notify_quote_expiring')
+@patch('app.main.notify_quote_expired')
+def test_process_quote_expiration(mock_expired, mock_expiring):
+    db = setup_db()
+
+    artist = User(
+        email='a@test.com',
+        password='x',
+        first_name='A',
+        last_name='R',
+        user_type=UserType.ARTIST,
+    )
+    client = User(
+        email='c@test.com',
+        password='x',
+        first_name='C',
+        last_name='L',
+        user_type=UserType.CLIENT,
+    )
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+
+    service = Service(
+        artist_id=artist.id,
+        title='Show',
+        description='test',
+        price=Decimal('100'),
+        currency='ZAR',
+        duration_minutes=60,
+        service_type='Live Performance',
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+
+    br1 = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        service_id=service.id,
+        proposed_datetime_1=datetime.utcnow(),
+        status=BookingStatus.PENDING_QUOTE,
+    )
+    br2 = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        service_id=service.id,
+        proposed_datetime_1=datetime.utcnow(),
+        status=BookingStatus.PENDING_QUOTE,
+    )
+    db.add_all([br1, br2])
+    db.commit()
+    db.refresh(br1)
+    db.refresh(br2)
+
+    q1 = models.QuoteV2(
+        booking_request_id=br1.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[{'description': 'Gig', 'price': 100}],
+        sound_fee=Decimal('0'),
+        travel_fee=Decimal('0'),
+        subtotal=Decimal('100'),
+        total=Decimal('100'),
+        status=models.QuoteStatusV2.PENDING,
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+    q2 = models.QuoteV2(
+        booking_request_id=br2.id,
+        artist_id=artist.id,
+        client_id=client.id,
+        services=[{'description': 'Gig', 'price': 100}],
+        sound_fee=Decimal('0'),
+        travel_fee=Decimal('0'),
+        subtotal=Decimal('100'),
+        total=Decimal('100'),
+        status=models.QuoteStatusV2.PENDING,
+        expires_at=datetime.utcnow() - timedelta(hours=1),
+    )
+    db.add_all([q1, q2])
+    db.commit()
+
+    process_quote_expiration(db)
+
+    assert mock_expiring.call_count == 2
+    assert mock_expired.call_count == 2
+    db.refresh(q2)
+    assert q2.status == models.QuoteStatusV2.EXPIRED

--- a/frontend/src/components/booking/__tests__/MessageThreadSend.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThreadSend.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import MessageThread from '../MessageThread';
+import * as api from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext');
+
+describe('MessageThread send flow', () => {
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({ data: null });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({
+      data: { id: 1, service: { title: 'Gig' }, start_time: '2024-01-01T00:00:00Z' },
+    });
+  });
+
+  it('sends a message and clears the input', async () => {
+    (api.postMessageToBookingRequest as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+    const { getByPlaceholderText, getByLabelText } = render(
+      <MessageThread bookingRequestId={1} showQuoteModal={false} setShowQuoteModal={jest.fn()} />,
+    );
+    const textarea = getByPlaceholderText('Type your message...') as HTMLTextAreaElement;
+    const button = getByLabelText('Send message') as HTMLButtonElement;
+
+    expect(button.disabled).toBe(true);
+    fireEvent.change(textarea, { target: { value: ' Hello ' } });
+    expect(button.disabled).toBe(false);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(api.postMessageToBookingRequest).toHaveBeenCalledWith(1, {
+        content: 'Hello',
+        attachment_url: undefined,
+      });
+    });
+    expect(textarea.value).toBe('');
+  });
+
+  it('does not send empty messages', async () => {
+    const { getByPlaceholderText, getByLabelText } = render(
+      <MessageThread bookingRequestId={1} showQuoteModal={false} setShowQuoteModal={jest.fn()} />,
+    );
+    const textarea = getByPlaceholderText('Type your message...');
+    const button = getByLabelText('Send message');
+
+    fireEvent.change(textarea, { target: { value: '   ' } });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    await new Promise((res) => setTimeout(res, 0));
+    expect(api.postMessageToBookingRequest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract quote expiration logic for hourly scheduler and add unit tests
- verify chat message send UI clears input and calls API

## Testing
- `./scripts/test-all.sh` *(failed: numerous frontend test failures e.g. NotificationVirtualization.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68932de68de8832e949c6e8daa774934