### PR TITLE
feat: add logging and CTA analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ The July 2025 update bumps key dependencies and Docker base images:
 
 For a map of all booking agents, see [AGENTS.md](AGENTS.md).
 
+### Logging & Monitoring
+
+- SQLAlchemy listeners in [`backend/app/utils/status_logger.py`](backend/app/utils/status_logger.py)
+  emit INFO logs whenever a booking, booking request, or quote changes status.
+- Background scheduler failures invoke
+  [`alert_scheduler_failure`](backend/app/utils/notifications.py) which logs an
+  error so alerts surface in monitoring systems.
+- The booking wizard records CTA clicks using `trackEvent` for centralized analytics.
+
 ### Home Page Carousels
 
 The homepage now showcases musicians in horizontally scrollable carousels. Sections such as **Popular**, **Top Rated**, **New on Booka**, and **Recently Booked** let visitors swipe or drag to browse profiles. Each musician card links to `/artists/[id]`.

--- a/backend/app/utils/status_logger.py
+++ b/backend/app/utils/status_logger.py
@@ -1,36 +1,43 @@
 import logging
-from sqlalchemy import event, inspect
+from sqlalchemy import event
+from sqlalchemy.orm.attributes import NO_VALUE
 
 from .. import models
 
 logger = logging.getLogger(__name__)
 
 
-def _log_status_change(mapper, connection, target):
-    """Log status transitions for tracked models."""
-    try:
-        state = inspect(target)
-        history = state.attrs.status.history
-        if history.has_changes():
-            previous = history.deleted[0] if history.deleted else None
-            current = history.added[0] if history.added else getattr(target, "status", None)
-            logger.info(
-                "%s id=%s status changed from %s to %s",
-                target.__class__.__name__,
-                getattr(target, "id", "unknown"),
-                previous,
-                current,
-            )
-    except Exception as exc:  # pragma: no cover - log and continue
-        logger.exception("Failed to log status transition: %s", exc)
+def _listener_factory(model_name: str):
+    """Return a SQLAlchemy attribute listener that logs status changes."""
+
+    def _status_change(target, value, oldvalue, initiator):  # noqa: ANN001
+        if oldvalue is NO_VALUE or oldvalue == value:
+            return value
+        entity_id = getattr(target, "id", "unknown")
+        logger.info(
+            "%s id=%s status changed from %s to %s",
+            model_name,
+            entity_id,
+            oldvalue,
+            value,
+        )
+        return value
+
+    return _status_change
 
 
 def register_status_listeners() -> None:
-    """Attach SQLAlchemy listeners for status field changes."""
+    """Attach listeners for all models with a ``status`` attribute."""
     for model in (
         models.Booking,
         models.BookingRequest,
         models.Quote,
         models.QuoteV2,
     ):
-        event.listen(model, "after_update", _log_status_change)
+        event.listen(
+            model.status,  # type: ignore[arg-type]
+            "set",
+            _listener_factory(model.__name__),
+            retval=False,
+            propagate=True,
+        )

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/api';
 import { geocodeAddress } from '@/lib/geo';
 import { calculateTravelMode, getDrivingMetrics } from '@/lib/travel';
+import { trackEvent } from '@/lib/analytics';
 
 import { BookingRequestCreate } from '@/types';
 import Stepper from '../ui/Stepper';
@@ -287,6 +288,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       setStep(newStep);
       setMaxStepCompleted(Math.max(maxStepCompleted, newStep));
       setValidationError(null);
+      trackEvent('booking_wizard_next', { step: newStep });
     } else {
       setValidationError('Please fix the errors above to continue.');
     }
@@ -296,6 +298,14 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   const prev = () => {
     setStep(step - 1);
     setValidationError(null);
+  };
+
+  const handleBack = () => {
+    trackEvent(step === 0 ? 'booking_wizard_cancel' : 'booking_wizard_back', {
+      step,
+    });
+    if (step === 0) onClose();
+    else prev();
   };
 
   // Handles saving the booking request as a draft
@@ -495,7 +505,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                 {/* Back/Cancel Button */}
                 <button
                   type="button" // Ensure it's a button, not a submit
-                  onClick={step === 0 ? onClose : prev}
+                  onClick={handleBack}
                   className="bg-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 w-32 min-h-[44px] min-w-[44px]"
                 >
                   {step === 0 ? 'Cancel' : 'Back'}

--- a/frontend/src/components/booking/steps/ReviewStep.tsx
+++ b/frontend/src/components/booking/steps/ReviewStep.tsx
@@ -7,6 +7,7 @@ import { formatCurrency } from '@/lib/utils';
 import { TravelResult } from '@/lib/travel';
 import { useBooking } from '@/contexts/BookingContext';
 import { CollapsibleSection } from '../../ui';
+import { trackEvent } from '@/lib/analytics';
 
 interface ReviewStepProps {
   step: number;
@@ -163,7 +164,10 @@ export default function ReviewStep({
             </label>
           </div>
           <button
-            onClick={onNext}
+            onClick={(e) => {
+              trackEvent('booking_submit');
+              void onNext(e);
+            }}
             disabled={isButtonDisabled}
             className={`w-full bg-blue-600 text-white font-bold py-3 px-4 rounded-lg transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
               ${isButtonDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700'}`}


### PR DESCRIPTION
## Summary
- log status changes across booking, request, and quote models
- track booking wizard CTA interactions and final submission
- document monitoring hooks in README

## Testing
- `./scripts/test-backend.sh`
- `(cd frontend && npm test -- --maxWorkers=50%)` *(fails: multiple unit test errors)*


------
https://chatgpt.com/codex/tasks/task_e_689336e32f58832eb419705a613b12c6