### PR TITLE
Ensure visible_to column and await notification broadcast

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -59,6 +59,17 @@ def ensure_message_is_read_column(engine: Engine) -> None:
     )
 
 
+def ensure_visible_to_column(engine: Engine) -> None:
+    """Add the ``visible_to`` column to ``messages`` if missing."""
+
+    add_column_if_missing(
+        engine,
+        "messages",
+        "visible_to",
+        "visible_to VARCHAR NOT NULL DEFAULT 'both'",
+    )
+
+
 def ensure_request_attachment_column(engine: Engine) -> None:
     """Add the ``attachment_url`` column to ``booking_requests`` if missing."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from .db_utils import (
     ensure_message_type_column,
     ensure_attachment_url_column,
     ensure_message_is_read_column,
+    ensure_visible_to_column,
     ensure_service_type_column,
     ensure_display_order_column,
     ensure_notification_link_column,
@@ -93,6 +94,7 @@ register_status_listeners()
 ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
 ensure_message_is_read_column(engine)
+ensure_visible_to_column(engine)
 ensure_request_attachment_column(engine)
 ensure_service_type_column(engine)
 ensure_display_order_column(engine)

--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -411,10 +411,11 @@ def _create_and_broadcast(
         if v is not None and data.get(k) in [None, ""]:
             data[k] = v
     try:
-        asyncio.create_task(notifications_manager.broadcast(user_id, data))
+        loop = asyncio.get_running_loop()
+        loop.create_task(notifications_manager.broadcast(user_id, data))
     except RuntimeError:
-        # If no event loop is running (e.g., in tests), send synchronously
-        notifications_manager.broadcast(user_id, data)
+        # If no event loop is running (e.g., in tests), run synchronously
+        asyncio.run(notifications_manager.broadcast(user_id, data))
 
 
 BOOKING_DETAILS_PREFIX = "Booking details:"


### PR DESCRIPTION
## Summary
- add utility to backfill messages.visible_to column and run on startup
- await NotificationManager.broadcast to avoid unawaited coroutine warning

## Testing
- `./scripts/test-backend.sh`
- `npm test -- src/components/layout/__tests__/MainLayout.test.tsx --maxWorkers=50%` *(fails: expects 'Sound Providers' in MainLayout)*

------
https://chatgpt.com/codex/tasks/task_e_68934091d02c832ea2d12f43bda3f978