### PR TITLE
Add migration for message action column

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The `/api/v1/quotes/calculate` endpoint now uses a regression-based travel estim
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read` (added in revision `1e5c92e1a7de`), and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
+Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read` (added in revision `1e5c92e1a7de`), `messages.action` (added in revision `e0069045b94f`), and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
 
 ### Service type enum
 

--- a/backend/alembic/versions/e0069045b94f_add_action_column_to_messages.py
+++ b/backend/alembic/versions/e0069045b94f_add_action_column_to_messages.py
@@ -1,0 +1,34 @@
+"""add action column to messages
+
+Revision ID: e0069045b94f
+Revises: f23ad0e57c1d
+Create Date: 2025-08-06 12:03:03.870245
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e0069045b94f'
+down_revision: Union[str, None] = 'f23ad0e57c1d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the action column to the messages table."""
+    action_enum = sa.Enum(
+        "review_quote",
+        "view_booking_details",
+        name="messageaction",
+    )
+    action_enum.create(op.get_bind(), checkfirst=True)
+    op.add_column("messages", sa.Column("action", action_enum, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "action")
+    op.execute("DROP TYPE IF EXISTS messageaction")


### PR DESCRIPTION
## Summary
- add Alembic migration to create `messages.action` enum column
- document new migration in README

## Testing
- `./scripts/test-all.sh` *(fails: frontend tests aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6893438f05f4832e9b271dd405b4385a