### PR TITLE
docs: document message action column

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The `/api/v1/quotes/calculate` endpoint now uses a regression-based travel estim
 
 ### Database migrations
 
-Run `alembic upgrade head` whenever you pull changes that modify the database schema. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read` (added in revision `1e5c92e1a7de`), `messages.action` (added in revision `e0069045b94f`), and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
+After pulling schema changes, run `alembic upgrade head` to apply the new migrations. The API will attempt to add missing columns such as `artist_profiles.price_visible`, `services.currency`, `bookings_simple.date`/`location`, `bookings_simple.payment_status`, `users.mfa_secret`/`mfa_enabled`, `calendar_accounts.email`, `messages.is_read` (added in revision `1e5c92e1a7de`), `messages.action` (added in revision `e0069045b94f`), and `booking_requests.travel_mode`/`travel_cost`/`travel_breakdown` automatically for SQLite setups. Non-SQLite deployments should run the new Alembic migration after pulling this update. Simply starting the API will also add the new `calendar_accounts.email` column if it is missing.
 
 ### Service type enum
 
@@ -1186,6 +1186,8 @@ POST /api/v1/booking-requests/
 Validation errors are now logged server-side and returned as structured JSON so you can quickly debug bad requests. When a specific field causes a problem the API includes a `field_errors` object mapping field names to messages.
 
 Upon successful creation, the API saves the booking request with a `pending_quote` status and immediately posts a system message visible only to the artist with `action="review_quote"` so they can review details and send a quote.
+
+The `messages` table includes an `action` column that stores these call-to-action tokens (for example, `review_quote` or `view_booking_details`). The frontend renders contextual buttons based on this value to guide users through next steps.
 
 ### Booking Request Parsing
 

--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -17,7 +17,9 @@ Clients and artists communicate through the **Inbox** page.
 
 Notifications for new messages link directly to the relevant conversation.
 System messages guide users when a booking request is created or a quote
-is ready.
+is ready. These messages can include an `action` field such as
+`review_quote` that tells the frontend to display a matching
+call-to-action button in the thread.
 
 The conversation list merges booking requests created by the user with
 those where they are the artist. Non-artist users only fetch their client

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6420,7 +6420,9 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Action",
+            "description": "Optional call-to-action token such as 'review_quote' that the frontend uses to display contextual buttons."
           },
           "expires_at": {
             "anyOf": [
@@ -6498,7 +6500,9 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Action",
+            "description": "Optional call-to-action token such as 'review_quote' that the frontend uses to display contextual buttons."
           },
           "is_read": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
- document messages.action column and CTA tokens like `review_quote`
- note to run `alembic upgrade head` after pulling schema changes
- describe message `action` property in API spec and inbox docs

## Testing
- No tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_689351bfcf94832ea2ce314f257bfcc4