### PR TITLE
fix: ensure messages action column

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -70,6 +70,17 @@ def ensure_visible_to_column(engine: Engine) -> None:
     )
 
 
+def ensure_message_action_column(engine: Engine) -> None:
+    """Add the ``action`` column to ``messages`` if missing."""
+
+    add_column_if_missing(
+        engine,
+        "messages",
+        "action",
+        "action VARCHAR",
+    )
+
+
 def ensure_request_attachment_column(engine: Engine) -> None:
     """Add the ``attachment_url`` column to ``booking_requests`` if missing."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from .db_utils import (
     ensure_attachment_url_column,
     ensure_message_is_read_column,
     ensure_visible_to_column,
+    ensure_message_action_column,
     ensure_service_type_column,
     ensure_display_order_column,
     ensure_notification_link_column,
@@ -95,6 +96,7 @@ ensure_message_type_column(engine)
 ensure_attachment_url_column(engine)
 ensure_message_is_read_column(engine)
 ensure_visible_to_column(engine)
+ensure_message_action_column(engine)
 ensure_request_attachment_column(engine)
 ensure_service_type_column(engine)
 ensure_display_order_column(engine)

--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -21,6 +21,10 @@ is ready. These messages can include an `action` field such as
 `review_quote` that tells the frontend to display a matching
 call-to-action button in the thread.
 
+> **Note:** The backend automatically adds the `action` column to the
+> `messages` table if it's missing, ensuring upgrades from older
+> deployments don't fail with missing-column errors.
+
 The conversation list merges booking requests created by the user with
 those where they are the artist. Non-artist users only fetch their client
 requests to avoid API errors.


### PR DESCRIPTION
## Summary
- ensure `messages.action` column is added automatically for older databases
- document backend safeguard for missing message `action` column

## Testing
- `./scripts/test-all.sh`
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893540b5e94832ebb856282852e54ca