### PR TITLE
Add expires_at typing improvements

### DIFF
--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -59,6 +59,7 @@ class Message(BaseModel):
     quote_id = Column(Integer, ForeignKey("quotes_v2.id"), nullable=True)
     attachment_url = Column(String, nullable=True)
     action = Column(Enum(MessageAction), nullable=True)
+    # Optional time after which this message should be considered expired
     expires_at = Column(DateTime, nullable=True)
     timestamp = Column(DateTime, default=datetime.utcnow)
     is_read = Column(Boolean, default=False)

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 from datetime import datetime
 from ..models.message import SenderType, MessageType, VisibleTo, MessageAction
@@ -10,7 +11,7 @@ class MessageCreate(BaseModel):
     quote_id: int | None = None
     attachment_url: str | None = None
     action: MessageAction | None = None
-    expires_at: datetime | None = None
+    expires_at: Optional[datetime] = None
 
 
 class MessageResponse(BaseModel):
@@ -27,7 +28,7 @@ class MessageResponse(BaseModel):
     is_read: bool = False
     timestamp: datetime
     avatar_url: str | None = None
-    expires_at: datetime | None = None
+    expires_at: Optional[datetime] = None
 
     model_config = {
         "from_attributes": True


### PR DESCRIPTION
## Summary
- document message expiry column
- standardize schema to use Optional[datetime]

## Testing
- `alembic upgrade heads` *(fails: no such table: artist_profiles)*
- `./scripts/test-backend.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935ce2e094832eaca716dc16272e1c