### PR TITLE
Handle legacy message types in message API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Booking request API responses now include `last_message_content` and `last_message_timestamp` so inbox conversations sort by recent chats.
 - Messages now include a `message_type` (`USER`, `QUOTE`, `SYSTEM`) and `visible_to`
   (`artist`, `client`, `both`) field so threads render and filter correctly for
-  each participant.
+  each participant. The API also accepts the legacy values `text`, `quote`, and
+  `system` (in any case) and automatically normalizes them to the uppercase
+  values above for backward compatibility.
 - Backend now fetches these fields using a single optimized query for improved performance.
 - Booking request endpoints now embed the artist's business name so clients no longer see placeholder `user/unknown` names.
 

--- a/backend/tests/test_message_type_normalization.py
+++ b/backend/tests/test_message_type_normalization.py
@@ -1,0 +1,52 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import User, UserType, BookingRequest, BookingStatus, MessageType
+from app.models.base import BaseModel
+from app.api import api_message
+from app.schemas import MessageCreate
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_lowercase_message_type_normalized():
+    db = setup_db()
+    client = User(
+        email="client@example.com",
+        password="x",
+        first_name="Client",
+        last_name="User",
+        user_type=UserType.CLIENT,
+    )
+    artist = User(
+        email="artist@example.com",
+        password="x",
+        first_name="Artist",
+        last_name="User",
+        user_type=UserType.ARTIST,
+    )
+    db.add_all([client, artist])
+    db.commit()
+    db.refresh(client)
+    db.refresh(artist)
+
+    br = BookingRequest(
+        client_id=client.id,
+        artist_id=artist.id,
+        status=BookingStatus.PENDING_QUOTE,
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    msg_in = MessageCreate(content="hi", message_type="system")
+    result = api_message.create_message(br.id, msg_in, db, current_user=client)
+
+    assert result["message_type"] == MessageType.SYSTEM


### PR DESCRIPTION
## Summary
- normalize incoming `message_type` values so legacy lower-case types (`text`, `quote`, `system`) are accepted
- document `message_type` normalization in README
- add regression test covering lower-case `message_type`

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest`
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689365ebef60832e8f56483fde678168