### PR TITLE
feat(chat): display booking details in message thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Personalized video flows suppress chat alerts until all prompts are answered. A single notification is sent with the booking type once complete.
 * System-generated booking details messages do not create extra chat alerts; a single booking request notification is sent after the form is submitted.
 * Booking notes are visible only on the Booking details page, appearing beneath the Venue Type line in the details box, and are hidden from chat threads and booking request screens.
-* Booking details messages appear in chat threads inside a collapsible section with a **Show details** button that toggles to **Hide details** when expanded. The details are collapsed by default so the header shows **Show details** until the section is opened. Small chevron icons indicate the state.
+* Booking details messages appear in chat threads as a styled summary card, outlining event type, date, location, and notes for quick reference.
 * Notification drawer cards use a two-line layout with subtle shadows and collapse/expand previews. Titles and subtitles wrap up to two lines using the `line-clamp-2` utility so full names remain visible.
 * Avatars fall back to a default placeholder image when no profile photo is available so every notification displays a consistent picture.
 * The drawer slides in from the right on a simple white panel with a soft shadow. Badges disappear when the unread count is 0.

--- a/frontend/src/components/booking/BookingDetailsBubble.tsx
+++ b/frontend/src/components/booking/BookingDetailsBubble.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { ParsedBookingDetails } from '@/lib/bookingDetails';
+
+interface BookingDetailsBubbleProps {
+  details: ParsedBookingDetails;
+  className?: string;
+}
+
+export default function BookingDetailsBubble({ details, className }: BookingDetailsBubbleProps) {
+  return (
+    <div
+      className={clsx(
+        'bg-gray-100 rounded-xl p-4 max-w-xs sm:max-w-md text-xs shadow-sm',
+        className,
+      )}
+    >
+      <h4 className="text-sm font-semibold mb-1">Booking Details</h4>
+      <ul className="space-y-0.5">
+        {details.eventType && (
+          <li>
+            <span className="font-medium">Event Type:</span> {details.eventType}
+          </li>
+        )}
+        {details.description && (
+          <li>
+            <span className="font-medium">Description:</span> {details.description}
+          </li>
+        )}
+        {details.date && (
+          <li>
+            <span className="font-medium">Date:</span> {details.date}
+          </li>
+        )}
+        {details.location && (
+          <li>
+            <span className="font-medium">Location:</span> {details.location}
+          </li>
+        )}
+        {details.guests && (
+          <li>
+            <span className="font-medium">Guests:</span> {details.guests}
+          </li>
+        )}
+        {details.venueType && (
+          <li>
+            <span className="font-medium">Venue:</span> {details.venueType}
+          </li>
+        )}
+        {details.soundNeeded && (
+          <li>
+            <span className="font-medium">Sound:</span> {details.soundNeeded}
+          </li>
+        )}
+        {details.notes && (
+          <li>
+            <span className="font-medium">Notes:</span> {details.notes}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -47,6 +47,52 @@ describe('MessageThread basic rendering', () => {
   });
 });
 
+describe('MessageThread booking details', () => {
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' } });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+    (api.acceptQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({
+      data: { id: 1, service: { title: 'Gig' }, start_time: '2024-01-01T00:00:00Z' },
+    });
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 1,
+          sender_type: 'client',
+          content:
+            'Booking details:\nEvent Type: Wedding\nDate: 2024-01-01\nLocation: Cape Town',
+          message_type: 'system',
+          is_read: true,
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('renders booking details bubble', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <MessageThread
+          bookingRequestId={1}
+          showQuoteModal={false}
+          setShowQuoteModal={jest.fn()}
+        />,
+      );
+    });
+    await act(async () => { await flushPromises(); });
+    expect(container.textContent).toContain('Booking Details');
+    expect(container.textContent).toContain('Event Type: Wedding');
+    expect(container.textContent).toContain('Location: Cape Town');
+    act(() => root.unmount());
+    container.remove();
+  });
+});
+
 describe('MessageThread system CTAs', () => {
   beforeEach(() => {
     (api.getQuoteV2 as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Summary
- show booking request details as a summary card in chat threads
- keep booking details system messages and render with new `BookingDetailsBubble`
- document booking details card and add coverage for message thread

## Testing
- `./scripts/test-all.sh` (backend tests passed)
- `npm test` (frontend tests failed: TypeError: useSearchParams is not a function)


------
https://chatgpt.com/codex/tasks/task_e_689371ddf580832eae784a6a7f7b96b5