### PR TITLE
fix: remove duplicate FixedSizeList type import

### DIFF
--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -10,7 +10,6 @@ import {
   type ListChildComponentProps,
   type FixedSizeList as FixedSizeListType,
 } from 'react-window';
-import type { FixedSizeList as FixedSizeListType } from 'react-window';
 import NotificationCard from '../ui/NotificationCard';
 import getNotificationDisplayProps from '@/hooks/getNotificationDisplayProps';
 import { ToggleSwitch, IconButton } from '../ui';


### PR DESCRIPTION
## Summary
- fix duplicate `FixedSizeListType` import in `NotificationDrawer`

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 39 failed, 1 skipped, 70 passed, 109 of 110 total)*

------
https://chatgpt.com/codex/tasks/task_e_68938db2febc832e8cd4d8f22c3a852f