### PR TITLE
Handle invalid booking dates in MessageThread

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -35,8 +35,7 @@ import SendQuoteModal from './SendQuoteModal';
 import usePaymentModal from '@/hooks/usePaymentModal';
 import QuoteBubble from './QuoteBubble';
 import useWebSocket from '@/hooks/useWebSocket';
-import { format } from 'date-fns';
-import { FixedSizeList as List } from 'react-window';
+import { format, isValid } from 'date-fns';
 import Countdown from './Countdown';
 import QuoteReviewModal from './QuoteReviewModal';
 import { useRouter } from 'next/navigation';
@@ -422,13 +421,6 @@ useEffect(() => {
       prevMessageCountRef.current = messages.length;
     }, [messages, showScrollButton]);
 
-    // Scroll to the quote bubble corresponding to the provided ID
-    const scrollToQuote = useCallback((id?: number | null) => {
-      if (!id) return;
-      const el = document.getElementById(`quote-${id}`);
-      el?.scrollIntoView({ behavior: 'smooth' });
-    }, []);
-
     const visibleMessages = useMemo(
       () =>
         messages.filter((msg) => {
@@ -772,9 +764,13 @@ useEffect(() => {
                               from: clientName || 'Client',
                               receivedAt: format(new Date(msg.timestamp), 'PPP'),
                               event: parsedBookingDetails?.eventType,
-                              date: parsedBookingDetails?.date
-                                ? format(new Date(parsedBookingDetails.date), 'PPP')
-                                : undefined,
+                              date: (() => {
+                                if (!parsedBookingDetails?.date) return undefined;
+                                const eventDate = new Date(parsedBookingDetails.date);
+                                return isValid(eventDate)
+                                  ? format(eventDate, 'PPP')
+                                  : undefined;
+                              })(),
                               guests: parsedBookingDetails?.guests,
                               venue: parsedBookingDetails?.venueType,
                               notes: parsedBookingDetails?.notes,

--- a/frontend/src/components/booking/__tests__/MessageThreadInvalidDate.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThreadInvalidDate.test.tsx
@@ -1,0 +1,96 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import MessageThread from '../MessageThread';
+import * as api from '@/lib/api';
+import { useRouter } from 'next/navigation';
+import { BOOKING_DETAILS_PREFIX } from '@/lib/constants';
+
+jest.mock('@/lib/api');
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
+jest.mock('@/hooks/useWebSocket', () => ({
+  __esModule: true,
+  default: () => ({ send: jest.fn(), onMessage: jest.fn() }),
+}));
+
+interface EventDetails {
+  date?: string;
+}
+
+let receivedEventDetails: EventDetails | undefined;
+jest.mock('../QuoteBubble', () => {
+  const MockQuoteBubble = ({ eventDetails }: { eventDetails: EventDetails }) => {
+    receivedEventDetails = eventDetails;
+    return <div data-testid="quote-bubble" />;
+  };
+  MockQuoteBubble.displayName = 'MockQuoteBubble';
+  return MockQuoteBubble;
+});
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollTo = jest.fn();
+});
+
+function flushPromises() {
+  return new Promise((res) => setTimeout(res, 0));
+}
+
+describe('MessageThread booking details with invalid date', () => {
+  it('renders quote bubble when booking details contain invalid date', async () => {
+    (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 7, user_type: 'client' } });
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 9,
+          sender_type: 'system',
+          content: `${BOOKING_DETAILS_PREFIX}\nDate: not-a-date`,
+          message_type: 'SYSTEM',
+          is_read: true,
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          booking_request_id: 1,
+          sender_id: 9,
+          sender_type: 'artist',
+          content: 'Quote message',
+          message_type: 'QUOTE',
+          quote_id: 42,
+          is_read: true,
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+      ],
+    });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 42,
+        services: [{ description: 'Performance', price: 100 }],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 100,
+        total: 100,
+        status: 'pending',
+      },
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MessageThread bookingRequestId={1} showQuoteModal={false} setShowQuoteModal={jest.fn()} />,
+      );
+    });
+    await act(async () => { await flushPromises(); });
+    await act(async () => { await flushPromises(); });
+    await act(async () => { await flushPromises(); });
+
+    expect(receivedEventDetails?.date).toBeUndefined();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- validate and format booking dates safely in MessageThread to avoid RangeError
- add regression test ensuring invalid booking dates don't crash quote display

## Testing
- `npx eslint src/components/booking/MessageThread.tsx src/components/booking/__tests__/MessageThreadInvalidDate.test.tsx`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(failed: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689397e47a48832ea6a12b9108508222