### PR TITLE
Render full-width quote card with actions

### DIFF
--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -8,8 +8,9 @@ Clients and artists communicate through the **Inbox** page.
 
 1. Conversation list shows all booking requests.  
    Unread threads display a red dot and are sorted by `last_message_timestamp`.
-2. Selecting a conversation opens the chat area.  
-   Quotes appear as special bubbles with **Accept** and **Decline** buttons.
+2. Selecting a conversation opens the chat area.
+   Quotes now render as full-width cards showing booking details,
+   an itemized cost breakdown, and **Accept**/**Decline** actions.
 3. **Show Details** toggles a side panel with booking information and quick
    links for deposit payments and calendar events.
 

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -85,4 +85,57 @@ describe('MessageThread quote actions', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('renders quote bubble for system review_quote messages', async () => {
+    (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 7, user_type: 'client' } });
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 9,
+          sender_type: 'artist',
+          content: 'Review & Accept Quote',
+          message_type: 'SYSTEM',
+          action: 'review_quote',
+          visible_to: 'client',
+          quote_id: 55,
+          is_read: true,
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+      ],
+    });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({
+      data: {
+        id: 55,
+        services: [{ description: 'Performance', price: 100 }],
+        sound_fee: 0,
+        travel_fee: 0,
+        subtotal: 100,
+        total: 100,
+        status: 'pending',
+      },
+    });
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <MessageThread
+          bookingRequestId={1}
+          showQuoteModal={false}
+          setShowQuoteModal={jest.fn()}
+        />,
+      );
+    });
+    await act(async () => { await flushPromises(); });
+    await act(async () => { await flushPromises(); });
+
+    const bubble = container.querySelector('#quote-55');
+    expect(bubble).not.toBeNull();
+
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- render quote details from system `review_quote` messages as full-width cards with accept/reject actions
- load and deduplicate quote data in `MessageThread`
- document that quotes display as itemized cards in the inbox

## Testing
- `pytest`
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68939cfc3694832eb892eaeb80c4a04c