### PR TITLE
feat: add event details to inline quote form

### DIFF
--- a/docs/inbox_page.md
+++ b/docs/inbox_page.md
@@ -9,9 +9,10 @@ Clients and artists communicate through the **Inbox** page.
 1. Conversation list shows all booking requests.  
    Unread threads display a red dot and are sorted by `last_message_timestamp`.
 2. Selecting a conversation opens the chat area. Artists compose quotes
-   using an inline form directly in the thread. Quotes then render as
-   full-width cards showing booking details, an itemized cost breakdown,
-   and **Accept**/**Decline** actions.
+   using an inline form directly in the thread. The form displays key
+   event details and lets artists edit amounts or add custom line items.
+   Quotes then render as full-width cards showing booking details, an
+   itemized cost breakdown, and **Accept**/**Decline** actions.
 3. **Show Details** toggles a side panel with booking information and quick
    links for deposit payments and calendar events.
 

--- a/frontend/src/components/booking/InlineQuoteForm.tsx
+++ b/frontend/src/components/booking/InlineQuoteForm.tsx
@@ -5,6 +5,16 @@ import { getQuoteTemplates } from '@/lib/api';
 import { formatCurrency, generateQuoteNumber } from '@/lib/utils';
 import { trackEvent } from '@/lib/analytics';
 
+interface EventDetails {
+  from: string;
+  receivedAt: string;
+  event?: string;
+  date?: string;
+  guests?: number;
+  venue?: string;
+  notes?: string;
+}
+
 interface Props {
   onSubmit: (data: QuoteV2Create) => Promise<void> | void;
   artistId: number;
@@ -15,6 +25,7 @@ interface Props {
   initialTravelCost?: number;
   initialSoundNeeded?: boolean;
   onDecline?: () => void;
+  eventDetails: EventDetails;
 }
 
 const expiryOptions = [
@@ -33,6 +44,7 @@ const InlineQuoteForm: React.FC<Props> = ({
   initialTravelCost,
   initialSoundNeeded,
   onDecline,
+  eventDetails,
 }) => {
   const [services, setServices] = useState<ServiceItem[]>([]);
   const [serviceFee, setServiceFee] = useState(initialBaseFee ?? 0);
@@ -126,10 +138,10 @@ const InlineQuoteForm: React.FC<Props> = ({
     <div className="bg-white rounded-2xl shadow w-full border border-gray-100 p-6 space-y-6">
       <div className="flex justify-between items-center flex-wrap gap-2">
         <div>
-          <h2 className="text-xl font-bold tracking-tight">Send Quote</h2>
+          <h2 className="text-xl font-bold tracking-tight">New Booking Request</h2>
           <div className="text-sm font-medium opacity-90 mt-1">
-            <span>Quote No: {quoteNumber}</span>
-            <span className="ml-4">Date: {currentDate}</span>
+            <span>From: {eventDetails.from}</span>
+            <span className="ml-4">Received: {eventDetails.receivedAt}</span>
           </div>
         </div>
         {onDecline && (
@@ -143,7 +155,51 @@ const InlineQuoteForm: React.FC<Props> = ({
         )}
       </div>
 
+      <div>
+        <h3 className="font-medium text-gray-900">Event Details</h3>
+        <dl className="mt-2 text-sm text-gray-700 space-y-1">
+          {eventDetails.event && (
+            <div className="flex justify-between">
+              <dt>Event</dt>
+              <dd>{eventDetails.event}</dd>
+            </div>
+          )}
+          {eventDetails.date && (
+            <div className="flex justify-between">
+              <dt>Date</dt>
+              <dd>{eventDetails.date}</dd>
+            </div>
+          )}
+          {eventDetails.guests !== undefined && (
+            <div className="flex justify-between">
+              <dt>Guests</dt>
+              <dd>{eventDetails.guests}</dd>
+            </div>
+          )}
+          {eventDetails.venue && (
+            <div className="flex justify-between">
+              <dt>Venue</dt>
+              <dd>{eventDetails.venue}</dd>
+            </div>
+          )}
+          {eventDetails.notes && (
+            <div className="flex justify-between">
+              <dt>Notes</dt>
+              <dd>{eventDetails.notes}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
       <div className="space-y-6">
+        <div className="flex justify-between items-end">
+          <h3 className="text-xl font-bold text-gray-900">Review & Adjust Quote</h3>
+          <div className="text-sm font-medium opacity-90">
+            <span>Quote No: {quoteNumber}</span>
+            <span className="ml-4">Date: {currentDate}</span>
+          </div>
+        </div>
+
         <div>
           <label htmlFor="template-select" className="block text-sm font-medium text-gray-700 mb-1">
             Choose a template
@@ -181,7 +237,6 @@ const InlineQuoteForm: React.FC<Props> = ({
           </p>
         </div>
 
-        <h3 className="text-xl font-bold text-gray-900">Estimated Cost</h3>
         <div className="space-y-2 text-gray-700">
           <div className="flex justify-between items-center py-2">
             <span className="font-medium">Artist Base Fee</span>
@@ -201,7 +256,7 @@ const InlineQuoteForm: React.FC<Props> = ({
               <span className="has-tooltip relative ml-1.5 text-blue-500 cursor-pointer">
                 ⓘ
                 <div className="tooltip absolute bottom-full mb-2 w-48 bg-gray-800 text-white text-xs rounded-md p-2 text-center z-10 hidden group-hover:block">
-                  Calculated based on artist's location and event venue distance.
+                    Calculated based on artist&apos;s location and event venue distance.
                 </div>
               </span>
             </span>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -718,6 +718,7 @@ useEffect(() => {
                 initialSoundNeeded={initialSoundNeeded}
                 onSubmit={handleSendQuote}
                 onDecline={handleDeclineRequest}
+                eventDetails={eventDetails}
               />
             </div>
           )}

--- a/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
+++ b/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
@@ -22,6 +22,11 @@ describe('InlineQuoteForm', () => {
           serviceName="Test Service"
           initialBaseFee={100}
           initialTravelCost={50}
+          eventDetails={{
+            from: 'Client',
+            receivedAt: 'Aug 6, 2025',
+            event: 'Birthday',
+          }}
           onSubmit={onSubmit}
         />,
       );
@@ -37,6 +42,34 @@ describe('InlineQuoteForm', () => {
     expect(data.services[0]).toEqual({ description: 'Test Service', price: 100 });
     expect(data.travel_fee).toBe(50);
     expect(data.sound_fee).toBe(0);
+
+    root.unmount();
+    div.remove();
+  });
+
+  it('shows event details', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <InlineQuoteForm
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          eventDetails={{
+            from: 'Client',
+            receivedAt: 'Aug 6, 2025',
+            event: 'Wedding',
+            guests: 50,
+          }}
+          onSubmit={() => {}}
+        />,
+      );
+    });
+
+    expect(div.textContent).toContain('Aug 6, 2025');
+    expect(div.textContent).toContain('Wedding');
+    expect(div.textContent).toContain('50');
 
     root.unmount();
     div.remove();


### PR DESCRIPTION
## Summary
- show booking request info within inline quote form
- allow artists to review & adjust quote with editable line items
- document inline quoting with editable event details

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm --prefix frontend test --silent` *(fails: 39 failed, 70 failed tests)
- `pytest`
- `npm --prefix frontend run lint` *(fails: ESLint found issues)*

------
https://chatgpt.com/codex/tasks/task_e_6893b495ec50832ead83277a402def0f