### PR TITLE
Fix websocket notification datetime serialization

### DIFF
--- a/backend/app/utils/notifications.py
+++ b/backend/app/utils/notifications.py
@@ -406,7 +406,7 @@ def _create_and_broadcast(
         link=link,
     )
     response = _build_response(db, notif)
-    data = response.model_dump()
+    data = response.model_dump(mode="json")
     for k, v in extra.items():
         if v is not None and data.get(k) in [None, ""]:
             data[k] = v

--- a/backend/tests/test_notifications_ws.py
+++ b/backend/tests/test_notifications_ws.py
@@ -87,6 +87,7 @@ def test_notifications_ws_broadcasts(patch_notifications_broadcast):
     args, _ = patch_notifications_broadcast.call_args
     assert args[0] == user.id
     assert args[1]["message"] == "hello"
+    assert isinstance(args[1]["timestamp"], str)
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- ensure websocket notifications dump datetimes as JSON strings
- validate websocket notification timestamps are serialized

## Testing
- `pytest tests/test_notifications_ws.py`
- `npm test -- --maxWorkers=2 --passWithNoTests` (fails: FAIL src/components/booking/steps/__tests__/ReviewStep.test.tsx and others)


------
https://chatgpt.com/codex/tasks/task_e_6893b87d7c64832eaa4c904d74a748b0