### PR TITLE
feat: show booking details in inline quote form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ keeps the current view, e.g.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details. Message notifications open directly to this page so clients can read and respond without hunting for the correct thread.
 * URL parameters on `/inbox` include `requestId` to select a conversation. Artists receive an inline quote summary bubble instead of a modal, so the previous `sendQuote` flag has been removed.
+* The inline quote form now surfaces booking event details with the same styling as the summary bubble, keeping artists in context while composing a quote.
 * `/booking-requests` lists all requests with search and filters. Search and filter inputs now include hidden labels for screen readers.
 * `ChatThreadView` component for mobile-friendly chat threads using a modern card-style layout.
 * Tap a booking request card to open `/booking-requests/[id]`.

--- a/frontend/src/components/booking/InlineQuoteForm.tsx
+++ b/frontend/src/components/booking/InlineQuoteForm.tsx
@@ -4,6 +4,7 @@ import { ServiceItem, QuoteV2Create, QuoteTemplate } from '@/types';
 import { getQuoteTemplates } from '@/lib/api';
 import { formatCurrency, generateQuoteNumber } from '@/lib/utils';
 import { trackEvent } from '@/lib/analytics';
+import type { EventDetails } from './QuoteBubble';
 
 interface Props {
   onSubmit: (data: QuoteV2Create) => Promise<void> | void;
@@ -15,6 +16,7 @@ interface Props {
   initialTravelCost?: number;
   initialSoundNeeded?: boolean;
   onDecline?: () => void;
+  eventDetails?: EventDetails;
 }
 
 const expiryOptions = [
@@ -33,6 +35,7 @@ const InlineQuoteForm: React.FC<Props> = ({
   initialTravelCost,
   initialSoundNeeded,
   onDecline,
+  eventDetails,
 }) => {
   const [services, setServices] = useState<ServiceItem[]>([]);
   const [serviceFee, setServiceFee] = useState(initialBaseFee ?? 0);
@@ -123,10 +126,29 @@ const InlineQuoteForm: React.FC<Props> = ({
   };
 
   return (
-    <div className="bg-white rounded-2xl shadow w-full border border-gray-100 p-6 space-y-6">
+    <div className="w-full bg-brand/10 dark:bg-brand-dark/30 rounded-xl p-6 space-y-6">
+      {eventDetails && (
+        <div>
+          <h4 className="mb-2 text-sm font-semibold">New Booking Request</h4>
+          <p className="mb-2 text-xs">
+            From: {eventDetails.from ?? 'N/A'} | Received: {eventDetails.receivedAt ?? 'N/A'}
+          </p>
+          <div className="text-xs">
+            <p className="mb-1 font-semibold">Event Details</p>
+            <ul className="space-y-1">
+              {eventDetails.event && <li>Event: {eventDetails.event}</li>}
+              {eventDetails.date && <li>Date: {eventDetails.date}</li>}
+              {eventDetails.guests && <li>Guests: {eventDetails.guests}</li>}
+              {eventDetails.venue && <li>Venue: {eventDetails.venue}</li>}
+              {eventDetails.notes && <li>Notes: "{eventDetails.notes}"</li>}
+            </ul>
+          </div>
+        </div>
+      )}
+
       <div className="flex justify-between items-center flex-wrap gap-2">
         <div>
-          <h2 className="text-xl font-bold tracking-tight">Send Quote</h2>
+          <h2 className="text-xl font-bold tracking-tight">Review &amp; Adjust Quote</h2>
           <div className="text-sm font-medium opacity-90 mt-1">
             <span>Quote No: {quoteNumber}</span>
             <span className="ml-4">Date: {currentDate}</span>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -718,6 +718,7 @@ useEffect(() => {
                 initialSoundNeeded={initialSoundNeeded}
                 onSubmit={handleSendQuote}
                 onDecline={handleDeclineRequest}
+                eventDetails={eventDetails}
               />
             </div>
           )}

--- a/frontend/src/components/booking/QuoteBubble.tsx
+++ b/frontend/src/components/booking/QuoteBubble.tsx
@@ -4,7 +4,7 @@ import { format } from 'date-fns';
 import { formatCurrency } from '@/lib/utils';
 import StatusBadge from '../ui/StatusBadge';
 
-interface EventDetails {
+export interface EventDetails {
   from?: string;
   receivedAt?: string;
   event?: string;

--- a/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
+++ b/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
@@ -22,6 +22,14 @@ describe('InlineQuoteForm', () => {
           serviceName="Test Service"
           initialBaseFee={100}
           initialTravelCost={50}
+          eventDetails={{
+            from: 'Chris',
+            receivedAt: 'Aug 6, 2025',
+            event: 'Birthday',
+            guests: '100',
+            venue: 'indoor',
+            notes: 'N/A',
+          }}
           onSubmit={onSubmit}
         />,
       );
@@ -37,6 +45,8 @@ describe('InlineQuoteForm', () => {
     expect(data.services[0]).toEqual({ description: 'Test Service', price: 100 });
     expect(data.travel_fee).toBe(50);
     expect(data.sound_fee).toBe(0);
+    expect(div.textContent).toContain('Event Details');
+    expect(div.textContent).toContain('Birthday');
 
     root.unmount();
     div.remove();


### PR DESCRIPTION
## Summary
- surface booking event info inside the inline quote form with a quote bubble style
- pass booking details from message threads to inline quote form
- document inline quote form context display

## Testing
- `pytest`
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6893badc3bc8832eaa1f79178c5eaed9