### PR TITLE
chore: streamline quote actions and style details panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - All booking and quote status changes now emit INFO logs, and scheduler failures
   trigger error alerts so issues surface in monitoring tools. CTA clicks on the
   frontend fire analytics events for centralized tracking.
-- Chat threads now surface contextual action buttons—**Review & Send Quote**, 
-  **Review & Accept Quote**, and **View Booking Details**—with countdown timers
-  when quotes expire, so users never miss a deadline.
+  - Chat threads now surface contextual action buttons—**View Booking Details**—with countdown timers
+    when quotes expire, so users never miss a deadline.
 - Users can download all account data via `/api/v1/users/me/export` and permanently delete their account with `DELETE /api/v1/users/me`.
 - Booking cards now show deposit and payment status with a simple progress timeline.
 - Booking request detail pages now display a step-by-step timeline from submission to quote acceptance.
@@ -842,8 +841,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * POST `/api/v1/booking-requests/{id}/quotes` now returns a Quote with
   `booking_request` set to `null` to prevent serialization cycles.
 * Sending a quote automatically transitions the booking request to
-  `quote_provided` status and posts a `SYSTEM` chat message visible to the
-  client prompting **Review & Accept Quote** with a 7-day expiration.
+  `quote_provided` status and displays the quote in the chat with a 7-day expiration.
 * `POST /api/v1/quotes` returns **404 Not Found** when the
   `booking_request_id` does not match an existing request.
 * Accepting a Quote V2 now also creates a formal booking visible on the artist dashboard.

--- a/frontend/src/components/inbox/BookingDetailsPanel.tsx
+++ b/frontend/src/components/inbox/BookingDetailsPanel.tsx
@@ -51,96 +51,81 @@ export default function BookingDetailsPanel({
     : null;
 
   return (
-    // Added bg-white and shadow-sm directly to this component's root div
-    <div className="bg-white shadow-sm flex flex-col h-full rounded-2xl overflow-hidden">
-      <dl className="flex-1 overflow-y-auto space-y-2 text-sm text-gray-800 p-4">
-            <div className="flex justify-between">
-              <dt className="font-medium">{isUserArtist ? 'Client' : 'Artist'}</dt>
-              <dd>
-                {isUserArtist
-                  ? bookingRequest.client
-                    ? `${bookingRequest.client.first_name} ${bookingRequest.client.last_name}`
-                    : 'N/A'
-                  : bookingRequest.artist_profile?.business_name || bookingRequest.artist?.first_name || 'N/A'}
-              </dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="font-medium">Email</dt>
-              <dd>
-                {isUserArtist
-                  ? bookingRequest.client?.email || 'N/A'
-                  : bookingRequest.artist?.email || 'N/A'}
-              </dd>
-            </div>
-            <div className="flex justify-between">
-              <dt className="font-medium">Service</dt>
-              <dd>{bookingRequest.service?.title || 'N/A'}</dd>
-            </div>
-            {parsedBookingDetails?.eventType && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Event Type</dt>
-                <dd>{parsedBookingDetails.eventType}</dd>
-              </div>
-            )}
-            {displayProposedDateTime && isValid(displayProposedDateTime) && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Date & Time</dt>
-                <dd>
-                  {format(displayProposedDateTime, 'PPP')}{' '}
-                  {format(displayProposedDateTime, 'p')}
-                </dd>
-              </div>
-            )}
-            {parsedBookingDetails?.location && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Location</dt>
-                <dd>{cleanLocation(parsedBookingDetails.location)}</dd>
-              </div>
-            )}
-            {parsedBookingDetails?.description && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Description</dt>
-                <dd>{parsedBookingDetails.description}</dd>
-              </div>
-            )}
-            {parsedBookingDetails?.guests && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Guests</dt>
-                <dd>{parsedBookingDetails.guests}</dd>
-              </div>
-            )}
-            {parsedBookingDetails?.venueType && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Venue Type</dt>
-                <dd>{parsedBookingDetails.venueType}</dd>
-              </div>
-            )}
-            {parsedBookingDetails?.soundNeeded && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Sound Needed</dt>
-                <dd>{parsedBookingDetails.soundNeeded === 'Yes' ? 'Yes' : 'No'}</dd>
-              </div>
-            )}
-            {parsedBookingDetails?.notes && (
-              <div className="flex justify-between">
-                <dt className="font-medium">Notes</dt>
-                <dd>{parsedBookingDetails.notes}</dd>
-              </div>
-            )}
-            {bookingConfirmed &&
-              confirmedBookingDetails?.status === 'completed' &&
-              !(confirmedBookingDetails as Booking & { review?: Review }).review && (
-                <div className="mt-4 text-center">
-                  <Button
-                    type="button"
-                    onClick={() => setShowReviewModal(true)}
-                    className="text-indigo-700 underline hover:bg-indigo-50 hover:text-indigo-800 transition-colors"
-                  >
-                    Leave Review
-                  </Button>
-                </div>
-              )}
-      </dl>
+    <div className="w-full bg-brand/10 dark:bg-brand-dark/30 rounded-xl p-4 text-xs flex flex-col h-full">
+      <h4 className="mb-2 text-sm font-semibold">Booking Details</h4>
+      <ul className="flex-1 overflow-y-auto space-y-1">
+        <li>
+          <span className="font-medium">{isUserArtist ? 'Client' : 'Artist'}:</span>{' '}
+          {isUserArtist
+            ? bookingRequest.client
+              ? `${bookingRequest.client.first_name} ${bookingRequest.client.last_name}`
+              : 'N/A'
+            : bookingRequest.artist_profile?.business_name || bookingRequest.artist?.first_name || 'N/A'}
+        </li>
+        <li>
+          <span className="font-medium">Email:</span>{' '}
+          {isUserArtist
+            ? bookingRequest.client?.email || 'N/A'
+            : bookingRequest.artist?.email || 'N/A'}
+        </li>
+        <li>
+          <span className="font-medium">Service:</span> {bookingRequest.service?.title || 'N/A'}
+        </li>
+        {parsedBookingDetails?.eventType && (
+          <li>
+            <span className="font-medium">Event Type:</span> {parsedBookingDetails.eventType}
+          </li>
+        )}
+        {displayProposedDateTime && isValid(displayProposedDateTime) && (
+          <li>
+            <span className="font-medium">Date &amp; Time:</span>{' '}
+            {format(displayProposedDateTime, 'PPP')} {format(displayProposedDateTime, 'p')}
+          </li>
+        )}
+        {parsedBookingDetails?.location && (
+          <li>
+            <span className="font-medium">Location:</span> {cleanLocation(parsedBookingDetails.location)}
+          </li>
+        )}
+        {parsedBookingDetails?.description && (
+          <li>
+            <span className="font-medium">Description:</span> {parsedBookingDetails.description}
+          </li>
+        )}
+        {parsedBookingDetails?.guests && (
+          <li>
+            <span className="font-medium">Guests:</span> {parsedBookingDetails.guests}
+          </li>
+        )}
+        {parsedBookingDetails?.venueType && (
+          <li>
+            <span className="font-medium">Venue Type:</span> {parsedBookingDetails.venueType}
+          </li>
+        )}
+        {parsedBookingDetails?.soundNeeded && (
+          <li>
+            <span className="font-medium">Sound Needed:</span> {parsedBookingDetails.soundNeeded === 'Yes' ? 'Yes' : 'No'}
+          </li>
+        )}
+        {parsedBookingDetails?.notes && (
+          <li>
+            <span className="font-medium">Notes:</span> {parsedBookingDetails.notes}
+          </li>
+        )}
+      </ul>
+      {bookingConfirmed &&
+        confirmedBookingDetails?.status === 'completed' &&
+        !(confirmedBookingDetails as Booking & { review?: Review }).review && (
+          <div className="mt-4 text-center">
+            <Button
+              type="button"
+              onClick={() => setShowReviewModal(true)}
+              className="text-indigo-700 underline hover:bg-indigo-50 hover:text-indigo-800 transition-colors"
+            >
+              Leave Review
+            </Button>
+          </div>
+        )}
       {paymentModal}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove redundant review/send quote button and unused modal logic
- restyle booking details panel to match inline quote summary
- update docs for simplified chat actions

## Testing
- `pytest` *(fails: 62 errors during collection)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: useSearchParams is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689451932f9c832e8a7844b79da2b9f0