### PR TITLE
feat(quote): add decline request button

### DIFF
--- a/frontend/src/components/booking/InlineQuoteForm.tsx
+++ b/frontend/src/components/booking/InlineQuoteForm.tsx
@@ -122,15 +122,6 @@ const InlineQuoteForm: React.FC<Props> = ({
         <div className="flex flex-col text-xs">
           <div className="flex items-center justify-between flex-wrap gap-2 mb-2">
             <h4 className="text-sm font-semibold">Review &amp; Adjust Quote</h4>
-            {onDecline && (
-              <button
-                type="button"
-                onClick={onDecline}
-                className="text-sm text-red-600 hover:underline"
-              >
-                Decline request
-              </button>
-            )}
           </div>
           <div className="mb-4 text-xs font-medium opacity-90">
             <span>Quote No: {quoteNumber}</span>
@@ -298,6 +289,15 @@ const InlineQuoteForm: React.FC<Props> = ({
         </div>
 
         <div className="flex justify-end space-x-3 pt-6 border-t border-gray-100">
+          {onDecline && (
+            <button
+              type="button"
+              onClick={onDecline}
+              className="bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700 transition-colors"
+            >
+              Decline Request
+            </button>
+          )}
           <button
             type="button"
             onClick={handleSubmit}

--- a/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
+++ b/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
@@ -49,5 +49,34 @@ describe('InlineQuoteForm', () => {
     root.unmount();
     div.remove();
   });
+
+  it('triggers onDecline when decline button is clicked', async () => {
+    const onDecline = jest.fn();
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <InlineQuoteForm
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          onSubmit={jest.fn()}
+          onDecline={onDecline}
+        />,
+      );
+    });
+
+    const declineBtn = Array.from(div.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Decline Request',
+    ) as HTMLButtonElement | undefined;
+    await act(async () => {
+      declineBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onDecline).toHaveBeenCalledTimes(1);
+
+    root.unmount();
+    div.remove();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add red 'Decline Request' button beside 'Send Quote'
- test decline button action

## Testing
- `npx eslint src/components/booking/InlineQuoteForm.tsx src/components/booking/__tests__/InlineQuoteForm.test.tsx`
- `npm test -- src/components/booking/__tests__/InlineQuoteForm.test.tsx`
- `npm test src/lib/__tests__/travel.test.ts` *(fails: travel.calculateTravelMode)*

------
https://chatgpt.com/codex/tasks/task_e_6894586c9938832e8ef3c6c5885a7754