### PR TITLE
feat: include travel extras in service and booking estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * New **Review** step showing cost breakdown and selections.
 * The review page now displays a single optimized summary with event type and
   details and calculates a price estimate based on distance.
+* Travel estimates now include artist-specified car rental and flight prices when provided.
 * Success toasts when saving a draft or submitting a request.
 * Simplified buttons sit below each step in a responsive button group. On phones
   the order is **Next**, **Save Draft**, **Back** but remains **Back**, **Save Draft**,

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -184,6 +184,18 @@ def ensure_service_travel_columns(engine: Engine) -> None:
         "travel_members",
         "travel_members INTEGER",
     )
+    add_column_if_missing(
+        engine,
+        "services",
+        "car_rental_price",
+        "car_rental_price NUMERIC(10, 2)",
+    )
+    add_column_if_missing(
+        engine,
+        "services",
+        "flight_price",
+        "flight_price NUMERIC(10, 2)",
+    )
 
 
 def ensure_booking_simple_columns(engine: Engine) -> None:

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -51,6 +51,9 @@ class Service(BaseModel):
     # New travel fields so quotes can accurately reflect costs
     travel_rate = Column(Numeric(10, 2), nullable=True, default=2.5)
     travel_members = Column(Integer, nullable=True, default=1)
+    # Additional optional travel cost inputs provided by artists
+    car_rental_price = Column(Numeric(10, 2), nullable=True)
+    flight_price = Column(Numeric(10, 2), nullable=True)
 
     # Link back to the ArtistProfileV2
     artist = relationship("ArtistProfileV2", back_populates="services")

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -17,6 +17,8 @@ class ServiceBase(BaseModel):
     service_type: Optional[ServiceType] = None
     travel_rate: Optional[Decimal] = None
     travel_members: Optional[int] = None
+    car_rental_price: Optional[Decimal] = None
+    flight_price: Optional[Decimal] = None
 
 
 # Properties to receive on item creation

--- a/backend/tests/test_db_utils.py
+++ b/backend/tests/test_db_utils.py
@@ -186,6 +186,8 @@ def test_service_travel_columns():
     cols = [c["name"] for c in inspector.get_columns("services")]
     assert "travel_rate" in cols
     assert "travel_members" in cols
+    assert "car_rental_price" in cols
+    assert "flight_price" in cols
 
 
 def test_booking_simple_columns():

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -210,6 +210,8 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
       const travelRate = svcRes.data.travel_rate || 2.5;
       const numTravelMembers = svcRes.data.travel_members || 1;
+      const carRentalPrice = svcRes.data.car_rental_price;
+      const flightPrice = svcRes.data.flight_price;
 
       const metrics = await getDrivingMetrics(artistLocation, details.location);
       if (!metrics.distanceKm) {
@@ -232,6 +234,8 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
         drivingEstimate: drivingEstimateCost,
         travelRate,
         travelDate: details.date,
+        carRentalPrice,
+        flightPricePerPerson: flightPrice,
       });
       setTravelResult(travelModeResult);
 

--- a/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
@@ -20,7 +20,7 @@ describe('ReviewStep summary', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
-    (getService as jest.Mock).mockResolvedValue({ data: { price: 100 } });
+    (getService as jest.Mock).mockResolvedValue({ data: { price: 100, car_rental_price: 1000, flight_price: 2780 } });
     (calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 150 } });
     (geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
     (getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
@@ -75,7 +75,12 @@ describe('ReviewStep summary', () => {
     expect(container.textContent).toContain('Estimated Price');
     expect(container.textContent).toContain('Travel Mode');
     expect(calculateTravelMode).toHaveBeenCalledWith(
-      expect.objectContaining({ drivingEstimate: 50, travelRate: 2.5 })
+      expect.objectContaining({
+        drivingEstimate: 50,
+        travelRate: 2.5,
+        carRentalPrice: 1000,
+        flightPricePerPerson: 2780,
+      })
     );
   });
 });

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -80,6 +80,8 @@ interface ServiceFormData {
   is_remote: boolean;
   travel_rate?: number | "";
   travel_members?: number | "";
+  car_rental_price?: number | "";
+  flight_price?: number | "";
 }
 
 export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: AddServiceModalProps) {
@@ -113,6 +115,8 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
       is_remote: false,
       travel_rate: 2.5,
       travel_members: 1,
+      car_rental_price: 1000,
+      flight_price: 2780,
     },
   });
 
@@ -250,6 +254,12 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
         travel_rate: data.travel_rate ? Number(data.travel_rate) : undefined,
         travel_members: data.travel_members
           ? Number(data.travel_members)
+          : undefined,
+        car_rental_price: data.car_rental_price
+          ? Number(data.car_rental_price)
+          : undefined,
+        flight_price: data.flight_price
+          ? Number(data.flight_price)
           : undefined,
       };
       const res = await apiCreateService(serviceData);
@@ -456,6 +466,22 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                                 valueAsNumber: true,
                               })}
                             />
+                            <TextInput
+                              label="Car rental price"
+                              type="number"
+                              step="0.01"
+                              {...register("car_rental_price", {
+                                valueAsNumber: true,
+                              })}
+                            />
+                            <TextInput
+                              label="Flight price (per person)"
+                              type="number"
+                              step="0.01"
+                              {...register("flight_price", {
+                                valueAsNumber: true,
+                              })}
+                            />
                           </>
                         )}
                         <div className="flex items-center gap-2">
@@ -591,6 +617,14 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                               <div className="border rounded-md p-4">
                                 <h3 className="font-medium">Members travelling</h3>
                                 <p>{watch("travel_members") || 1}</p>
+                              </div>
+                              <div className="border rounded-md p-4">
+                                <h3 className="font-medium">Car rental price</h3>
+                                <p>{watch("car_rental_price") || 0}</p>
+                              </div>
+                              <div className="border rounded-md p-4">
+                                <h3 className="font-medium">Flight price (per person)</h3>
+                                <p>{watch("flight_price") || 0}</p>
                               </div>
                             </>
                           )}

--- a/frontend/src/components/dashboard/EditServiceModal.tsx
+++ b/frontend/src/components/dashboard/EditServiceModal.tsx
@@ -23,6 +23,8 @@ type ServiceFormData = Pick<
   | "service_type"
   | "travel_rate"
   | "travel_members"
+  | "car_rental_price"
+  | "flight_price"
 >;
 
 export default function EditServiceModal({
@@ -47,6 +49,8 @@ export default function EditServiceModal({
       service_type: service.service_type,
       travel_rate: service.travel_rate ?? 2.5,
       travel_members: service.travel_members ?? 1,
+      car_rental_price: service.car_rental_price ?? 1000,
+      flight_price: service.flight_price ?? 2780,
     },
   });
   const watchServiceType = watch('service_type');
@@ -66,6 +70,14 @@ export default function EditServiceModal({
         travel_members:
           data.travel_members !== undefined
             ? parseInt(String(data.travel_members), 10)
+            : undefined,
+        car_rental_price:
+          data.car_rental_price !== undefined
+            ? parseFloat(String(data.car_rental_price))
+            : undefined,
+        flight_price:
+          data.flight_price !== undefined
+            ? parseFloat(String(data.flight_price))
             : undefined,
       };
       const response = await apiUpdateService(service.id, serviceData);
@@ -250,6 +262,36 @@ export default function EditServiceModal({
                     id="travel_members"
                     step="1"
                     {...register('travel_members', { valueAsNumber: true })}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand focus:border-brand sm:text-sm"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="car_rental_price"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    Car rental price
+                  </label>
+                  <input
+                    type="number"
+                    id="car_rental_price"
+                    step="0.01"
+                    {...register('car_rental_price', { valueAsNumber: true })}
+                    className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand focus:border-brand sm:text-sm"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="flight_price"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    Flight price (per person)
+                  </label>
+                  <input
+                    type="number"
+                    id="flight_price"
+                    step="0.01"
+                    {...register('flight_price', { valueAsNumber: true })}
                     className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand focus:border-brand sm:text-sm"
                   />
                 </div>

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -116,6 +116,8 @@ describe("AddServiceModal wizard", () => {
     // Review step should show travel details before publishing
     expect(container.textContent).toContain("Travelling (Rand per km)");
     expect(container.textContent).toContain("Members travelling");
+    expect(container.textContent).toContain("Car rental price");
+    expect(container.textContent).toContain("Flight price (per person)");
 
     const publish = container.querySelector(
       'button[type="submit"]',
@@ -134,6 +136,8 @@ describe("AddServiceModal wizard", () => {
         price: 100,
         travel_rate: 2.5,
         travel_members: 1,
+        car_rental_price: 1000,
+        flight_price: 2780,
       }),
     );
   });

--- a/frontend/src/components/dashboard/__tests__/EditServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EditServiceModal.test.tsx
@@ -19,6 +19,8 @@ describe('EditServiceModal', () => {
     service_type: 'Live Performance',
     travel_rate: 3,
     travel_members: 2,
+    car_rental_price: 1000,
+    flight_price: 2780,
     display_order: 0,
     artist: {} as any,
   };
@@ -53,6 +55,8 @@ describe('EditServiceModal', () => {
     const titleInput = container.querySelector('#title') as HTMLInputElement;
     const travelRateInput = container.querySelector('#travel_rate') as HTMLInputElement;
     const membersInput = container.querySelector('#travel_members') as HTMLInputElement;
+    const carRentalInput = container.querySelector('#car_rental_price') as HTMLInputElement;
+    const flightInput = container.querySelector('#flight_price') as HTMLInputElement;
 
     act(() => {
       titleInput.value = 'New Title';
@@ -61,6 +65,10 @@ describe('EditServiceModal', () => {
       travelRateInput.dispatchEvent(new Event('input', { bubbles: true }));
       membersInput.value = '3';
       membersInput.dispatchEvent(new Event('input', { bubbles: true }));
+      carRentalInput.value = '1500';
+      carRentalInput.dispatchEvent(new Event('input', { bubbles: true }));
+      flightInput.value = '3000';
+      flightInput.dispatchEvent(new Event('input', { bubbles: true }));
     });
 
     const saveBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
@@ -75,6 +83,8 @@ describe('EditServiceModal', () => {
         title: 'New Title',
         travel_rate: 4,
         travel_members: 3,
+        car_rental_price: 1500,
+        flight_price: 3000,
       }),
     );
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,8 @@ export interface Service {
   duration_minutes: number;
   travel_rate?: number;
   travel_members?: number;
+  car_rental_price?: number;
+  flight_price?: number;
   display_order: number;
   price: number;
   artist: ArtistProfile;


### PR DESCRIPTION
## Summary
- allow artists to record car rental and flight prices on live performance services
- feed car rental and flight prices into travel calculations for booking estimates
- document new travel estimate inputs in README

## Testing
- `./scripts/test-backend.sh`
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: (0 , _navigation.useRouter) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68945fdf2a1c832e9668ecb75bc776c7