### PR TITLE
fix: handle service price parsing in booking review

### DIFF
--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -205,13 +205,24 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
         throw new Error(`Could not find geographic coordinates for event location: "${details.location}".`);
       }
 
-      const basePrice = Number(svcRes.data.price);
+      // Helper to safely parse numeric fields that may arrive as formatted strings
+      const parseNumber = (val: unknown, fallback = 0): number => {
+        if (typeof val === 'number') return val;
+        if (typeof val === 'string') {
+          const cleaned = val.replace(/[^0-9.-]/g, '');
+          const parsed = parseFloat(cleaned);
+          return Number.isNaN(parsed) ? fallback : parsed;
+        }
+        return fallback;
+      };
+
+      const basePrice = parseNumber(svcRes.data.price);
       setBaseServicePrice(basePrice); // Set the base service price
 
-      const travelRate = svcRes.data.travel_rate || 2.5;
-      const numTravelMembers = svcRes.data.travel_members || 1;
-      const carRentalPrice = svcRes.data.car_rental_price;
-      const flightPrice = svcRes.data.flight_price;
+      const travelRate = parseNumber(svcRes.data.travel_rate, 2.5) || 2.5;
+      const numTravelMembers = parseNumber(svcRes.data.travel_members, 1) || 1;
+      const carRentalPrice = parseNumber(svcRes.data.car_rental_price);
+      const flightPrice = parseNumber(svcRes.data.flight_price);
 
       const metrics = await getDrivingMetrics(artistLocation, details.location);
       if (!metrics.distanceKm) {

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -1,16 +1,22 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import BookingWizard from '../BookingWizard';
 import { BookingProvider, useBooking } from '@/contexts/BookingContext';
 import { useAuth } from '@/contexts/AuthContext';
 import * as api from '@/lib/api';
+import * as geo from '@/lib/geo';
+import * as travel from '@/lib/travel';
+import { formatCurrency } from '@/lib/utils';
 
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
+jest.mock('@/lib/geo');
+jest.mock('@/lib/travel');
 
 function ExposeSetter() {
-  const { setStep } = useBooking();
+  const { setStep, setDetails } = useBooking();
   (window as unknown as { __setStep: (s: number) => void }).__setStep = setStep;
+  (window as unknown as { __setDetails: (d: any) => void }).__setDetails = setDetails as (d: any) => void;
   return null;
 }
 
@@ -18,7 +24,7 @@ function Wrapper() {
   return (
     <BookingProvider>
       <ExposeSetter />
-      <BookingWizard artistId={1} isOpen onClose={() => {}} />
+      <BookingWizard artistId={1} serviceId={1} isOpen onClose={() => {}} />
     </BookingProvider>
   );
 }
@@ -32,6 +38,23 @@ describe('BookingWizard instructions', () => {
     (api.getArtist as jest.Mock).mockResolvedValue({
       data: { location: 'NYC' },
     });
+    (api.getService as jest.Mock).mockResolvedValue({
+      data: {
+        price: 'R100',
+        travel_rate: 2.5,
+        travel_members: 1,
+        car_rental_price: 0,
+        flight_price: 0,
+      },
+    });
+    (api.calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 100 } });
+    (geo.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
+    (travel.getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
+    (travel.calculateTravelMode as jest.Mock).mockResolvedValue({
+      mode: 'drive',
+      totalCost: 0,
+      breakdown: { drive: { estimate: 0 } },
+    });
   });
 
   it('shows first step instruction', () => {
@@ -40,4 +63,30 @@ describe('BookingWizard instructions', () => {
 
   });
 
-});
+  it('displays service base price in review step', async () => {
+    render(<Wrapper />);
+
+    // Allow initial effects to run
+    await act(async () => {});
+
+    await act(async () => {
+      (window as unknown as { __setDetails: (d: any) => void }).__setDetails({
+        eventType: 'Party',
+        eventDescription: 'Fun',
+        date: new Date(),
+        time: '18:00',
+        location: 'Cape Town',
+        guests: '10',
+        venueType: 'indoor',
+        sound: 'no',
+        notes: '',
+        attachment_url: '',
+      });
+      (window as unknown as { __setStep: (s: number) => void }).__setStep(8);
+    });
+
+      expect(await screen.findByText('Artist Base Fee')).toBeTruthy();
+      expect(document.body.textContent).toContain(formatCurrency(100));
+    });
+
+  });


### PR DESCRIPTION
## Summary
- parse numeric strings from service details so review step shows artist-set base fee
- add regression test for service fee display in booking wizard

## Testing
- `./scripts/test-backend.sh`
- `(cd frontend && npm test -- --maxWorkers=50% --passWithNoTests)` *(fails: Stepper progress bar renders steps and highlights the current one)*


------
https://chatgpt.com/codex/tasks/task_e_68946ae8e890832eb74c8fcb4b31ce40