### PR TITLE
feat: clarify return flight cost label

### DIFF
--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -422,7 +422,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                               })}
                             />
                             <TextInput
-                              label="Flight price (per person)"
+                              label="Return flight price (per person)"
                               type="number"
                               step="0.01"
                               {...register("flight_price", {
@@ -533,7 +533,7 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
                                 <p>{watch("car_rental_price") || 0}</p>
                               </div>
                               <div className="border rounded-md p-4">
-                                <h3 className="font-medium">Flight price (per person)</h3>
+                                <h3 className="font-medium">Return flight price (per person)</h3>
                                 <p>{watch("flight_price") || 0}</p>
                               </div>
                             </>

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -109,7 +109,7 @@ describe("AddServiceModal wizard", () => {
     expect(document.body.textContent).toContain("Travelling (Rand per km)");
     expect(document.body.textContent).toContain("Members travelling");
     expect(document.body.textContent).toContain("Car rental price");
-    expect(document.body.textContent).toContain("Flight price (per person)");
+    expect(document.body.textContent).toContain("Return flight price (per person)");
 
     const publish = document.querySelector(
       'button[type="submit"]',


### PR DESCRIPTION
## Summary
- clarify Add Service modal to specify "Return flight price (per person)"
- update AddServiceModal tests

## Testing
- `npx jest src/components/dashboard/__tests__/AddServiceModal.test.tsx src/lib/__tests__/travel.test.ts --maxWorkers=50%` *(fails: travel.calculateTravelMode)*

------
https://chatgpt.com/codex/tasks/task_e_68947e0b41dc832eb15e34d12e25acf4