### PR TITLE
Refactor footer layout to 3-column grid

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -120,7 +120,7 @@ export default function Footer() {
             </div>
           </div>
 
-          <nav className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-8">
+          <nav className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-8">
             {navigation.map((section) => (
               <div key={section.title}>
                 <h3 className="text-sm font-semibold text-brand-dark">

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -18,4 +18,5 @@ The filter control is typically an icon button that opens a filtering UI, such a
 
 ## Footer
 
-`Footer` renders grouped navigation links and social icons using brand colors. It appears on every page wrapped by `MainLayout`.
+`Footer` renders grouped navigation links and social icons using brand colors. On large screens the navigation links are laid out
+in two rows and three columns, maintaining a compact grid for easier scanning. It appears on every page wrapped by `MainLayout`.

--- a/frontend/src/components/layout/__tests__/Footer.test.tsx
+++ b/frontend/src/components/layout/__tests__/Footer.test.tsx
@@ -6,4 +6,10 @@ describe('Footer', () => {
     render(<Footer />);
     expect(screen.getByText('Company')).toBeTruthy();
   });
+
+  it('displays navigation links in a 3-column grid on large screens', () => {
+    render(<Footer />);
+    const nav = screen.getByRole('navigation');
+    expect(nav.className).toContain('md:grid-cols-3');
+  });
 });


### PR DESCRIPTION
## Summary
- Keep footer navigation in three columns so links appear in two rows on wide screens
- Document new footer grid layout
- Add test verifying footer uses three-column grid on large viewports

## Testing
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: Test run aborted)*
- `npx eslint src/components/layout/Footer.tsx src/components/layout/__tests__/Footer.test.tsx`
- `npx jest src/components/layout/__tests__/Footer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6894877a44a8832ea82d7fb6cba3a0c1