### PR TITLE
feat: right-align footer navigation

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -98,8 +98,8 @@ export default function Footer() {
   return (
     <footer className="bg-gradient-to-t from-brand-light/50 to-gray-50 border-t border-gray-200">
       <div className="mx-auto max-w-7xl px-6 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <div className="space-y-4">
+        <div className="flex flex-col md:flex-row md:gap-8">
+          <div className="space-y-4 md:flex-1">
             <Link href="/" className="block text-xl font-bold text-brand-dark">
               Booka.co.za
             </Link>
@@ -120,7 +120,7 @@ export default function Footer() {
             </div>
           </div>
 
-          <nav className="md:col-span-2 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-8">
+          <nav className="mt-8 md:mt-0 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 gap-8 md:ml-auto">
             {navigation.map((section) => (
               <div key={section.title}>
                 <h3 className="text-sm font-semibold text-brand-dark">

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -18,5 +18,5 @@ The filter control is typically an icon button that opens a filtering UI, such a
 
 ## Footer
 
-`Footer` renders grouped navigation links and social icons using brand colors. On large screens the navigation links are laid out
-in two rows and three columns, maintaining a compact grid for easier scanning. It appears on every page wrapped by `MainLayout`.
+`Footer` renders grouped navigation links and social icons using brand colors. On large screens the navigation links sit on the
+right side of the page in a two-row, three-column grid for easier scanning. It appears on every page wrapped by `MainLayout`.


### PR DESCRIPTION
## Summary
- align footer link grid to the right on desktop
- document footer placement

## Testing
- `npm --prefix frontend run lint` *(fails: project has existing lint errors)*
- `npm test` *(fails: TypeError `(0 , _navigation.useSearchParams)` is not a function and other failures)*
- `pytest backend` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68948a7504c4832eba3699a0c52d9d71