### PR TITLE
feat: enhance booking NLP with spaCy

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,3 +13,27 @@ The API adds standard security headers to every response via
 Deployment configs such as the `Dockerfile` expose matching environment
 variables so reverse proxies or additional servers can mirror these
 headers.
+
+## NLP Booking
+
+The booking request parser uses the **spaCy** `en_core_web_sm` model to
+identify dates, locations, guest counts, and event types from natural
+language descriptions. The service lives in `app/services/nlp_booking.py`
+and is accessed via `/api/v1/booking-requests/parse`.
+
+### Dependencies
+
+The following packages were added to `requirements.txt`:
+
+- `spacy` (and the `en_core_web_sm` model)
+- `dateparser`
+
+Install the model after installing dependencies:
+
+```bash
+python -m spacy download en_core_web_sm
+```
+
+If the model fails to load, the API responds with `503` and logs the
+underlying error.
+

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -52,6 +52,13 @@ def parse_booking_text(payload: schemas.BookingParseRequest):
 
     try:
         return nlp_booking.extract_booking_details(payload.text)
+    except nlp_booking.NLPModelError as exc:  # pragma: no cover - environment specific
+        logger.error("NLP model error: %s", exc)
+        raise error_response(
+            "NLP model unavailable",
+            {"text": "Model not loaded"},
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
     except Exception as exc:  # pragma: no cover - unexpected errors
         logger.exception("NLP parsing failed: %s", exc)
         raise error_response(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,7 @@ aiosmtplib==2.0.2
 itsdangerous==2.2.0
 reportlab==4.2.0
 freezegun==1.4.0
+spacy==3.7.2
+dateparser==1.2.0
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
+

--- a/backend/tests/test_nlp_booking.py
+++ b/backend/tests/test_nlp_booking.py
@@ -32,3 +32,15 @@ def test_extracts_explicit_year_and_event_type():
     assert result.event_type == "Birthday"
     assert result.guests == 20
 
+
+def test_multiple_dates_uses_first():
+    text = "Considering 5 May 2025 or 7 May 2025 in Johannesburg"
+    result = nlp_booking.extract_booking_details(text)
+    assert result.date.isoformat() == "2025-05-05"
+
+
+def test_ambiguous_location_returns_none():
+    text = "Party in Paris or London for 10 guests on 3 June 2025"
+    result = nlp_booking.extract_booking_details(text)
+    assert result.location is None
+


### PR DESCRIPTION
## Summary
- integrate spaCy-based parser for booking details with regex fallback
- handle NLP model errors in booking request API
- extend NLP booking tests for multiple dates and ambiguous locations

## Testing
- `./scripts/test-all.sh` *(fails: pytest: error: unrecognized arguments: -n --timeout=20)*
- `PYTHONPATH=backend pytest backend/tests/test_nlp_booking.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68948ac73210832ea0818a2a6037c213