### PR TITLE
Normalize common booking typos

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,11 @@ identify dates, locations, guest counts, and event types from natural
 language descriptions. The service lives in `app/services/nlp_booking.py`
 and is accessed via `/api/v1/booking-requests/parse`.
 
+Common booking terms like event types and guest count labels are
+normalized with Python's `difflib` before spaCy parsing. This lightweight
+correction handles typos such as "frstival" → "Festival" or "guesds" →
+"guests" so malformed requests can still be parsed.
+
 ### Dependencies
 
 The following packages were added to `requirements.txt`:

--- a/backend/tests/test_nlp_booking.py
+++ b/backend/tests/test_nlp_booking.py
@@ -44,3 +44,10 @@ def test_ambiguous_location_returns_none():
     result = nlp_booking.extract_booking_details(text)
     assert result.location is None
 
+
+def test_typos_are_normalized():
+    text = "Planning a frstival for 100 guesds on 25 December 2025 in Cape Town"
+    result = nlp_booking.extract_booking_details(text)
+    assert result.event_type == "Festival"
+    assert result.guests == 100
+


### PR DESCRIPTION
## Summary
- normalize common booking terms via difflib before spaCy parsing
- test NLP parsing with misspelled event and guest terms
- document typo correction in backend README

## Testing
- `./scripts/test-all.sh` *(frontend tests aborted: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689493cca7d8832ea8b37debbb99397d