### PR TITLE
test: mock next image globally

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -41,6 +41,13 @@ jest.mock('next/link', () => ({
   },
 }));
 
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return require('react').createElement('img', props);
+  },
+}));
+
 jest.mock('@/contexts/AuthContext', () => {
   const mock = jest.fn(() => ({
     user: null,

--- a/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
+++ b/frontend/src/components/inbox/__tests__/MessageThreadWrapper.test.tsx
@@ -29,11 +29,6 @@ jest.mock('next/link', () => ({
   default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: any) => <img {...props} />,
-}));
-
 
 const bookingRequest = {
   id: 1,


### PR DESCRIPTION
## Summary
- mock next/image in global Jest setup
- remove redundant test-level next/image mock

## Testing
- `npm test frontend/src/components/inbox/__tests__/ConversationList.test.tsx` *(fails: Expected substring "Biz" to be present)*

------
https://chatgpt.com/codex/tasks/task_e_68949ab18314832e88f5012f0c7f3447