### PR TITLE
test: mock router in BookingDetailsPage tests

### DIFF
--- a/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
+++ b/frontend/src/app/dashboard/client/bookings/__tests__/BookingDetailsPage.test.tsx
@@ -13,6 +13,14 @@ jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useSearchParams: jest.fn(),
   usePathname: jest.fn(() => "/dashboard/client/bookings/1"),
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    prefetch: jest.fn(),
+  })),
 }));
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 jest.mock("next/link", () => {


### PR DESCRIPTION
## Summary
- mock next/navigation's useRouter in BookingDetailsPage tests to provide navigation stubs

## Testing
- `npm test -- BookingDetailsPage.test.tsx`
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a4abea7c832eadef7bd5d6fc4480