### PR TITLE
feat: show booking CTA on touch

### DIFF
--- a/frontend/src/components/artist/ArtistCard.tsx
+++ b/frontend/src/components/artist/ArtistCard.tsx
@@ -2,7 +2,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { HTMLAttributes } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import {
@@ -69,6 +69,14 @@ export default function ArtistCard({
   const maxTags = 2;
   const limitedTags = tags.slice(0, maxTags);
   const [imgLoaded, setImgLoaded] = useState(false);
+  const [supportsHover, setSupportsHover] = useState(true);
+
+  // Detect touch devices so the overlay can rely on tap rather than hover
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setSupportsHover(!window.matchMedia('(hover: none)').matches);
+    }
+  }, []);
 
   return (
     <motion.div
@@ -109,11 +117,17 @@ export default function ArtistCard({
             />
           )}
           <div
-            className="absolute inset-0 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition"
+            className={clsx(
+              'absolute inset-0 flex items-center justify-center bg-black/60',
+              supportsHover
+                ? 'opacity-0 group-hover:opacity-100 transition'
+                : 'opacity-100 pointer-events-none',
+            )}
+            // On touch screens, show the CTA without relying on hover
           >
             <button
               type="button"
-              className="text-sm bg-brand text-white px-4 py-1.5 rounded-md focus:outline-none focus-visible:ring"
+              className="pointer-events-auto text-sm bg-brand text-white px-4 py-1.5 rounded-md focus:outline-none focus-visible:ring"
             >
               Book Now
             </button>

--- a/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
+++ b/frontend/src/components/artist/__tests__/ArtistCard.test.tsx
@@ -20,6 +20,23 @@ function setup(props = {}) {
 }
 
 describe('ArtistCard optional fields', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+    // Polyfill for matchMedia used in ArtistCard
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
   afterEach(() => {
     document.body.innerHTML = '';
   });
@@ -105,6 +122,34 @@ describe('ArtistCard optional fields', () => {
     expect(anchor?.getAttribute('href')).toBe('/artists/9');
     act(() => root.unmount());
     container.remove();
+  });
+
+  it('shows Book Now button by default on touch devices', () => {
+    (window.matchMedia as jest.Mock).mockImplementation((query) => ({
+      matches: query === '(hover: none)',
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+    const { container, root } = setup();
+    const overlay = container.querySelector('div.absolute.flex');
+    expect(overlay?.className).toContain('opacity-100');
+    act(() => root.unmount());
+    container.remove();
+    (window.matchMedia as jest.Mock).mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
   });
 
 


### PR DESCRIPTION
## Summary
- detect touch devices to disable hover-only overlay
- always display Book Now on touch screens
- cover touch overlay behaviour with tests

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: ChatThreadView test missing module; Snapshot Summary: 2 snapshots failed, 28 suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b103ebe0832eaa91ba0bffae8777