### PR TITLE
test(frontend): refresh avatar snapshot

### DIFF
--- a/frontend/src/components/ui/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -8,12 +8,8 @@ exports[`Avatar component matches snapshot for default placeholder 1`] = `
   <img
     alt="avatar"
     class="object-cover rounded-full"
-    data-nimg="1"
-    decoding="async"
     height="40"
-    loading="lazy"
     src="http://localhost:8000/static/default-avatar.svg"
-    style="color: transparent;"
     width="40"
   />
 </div>


### PR DESCRIPTION
## Summary
- refresh Avatar component snapshot after rendering changes

## Testing
- `npm test -- -u src/components/layout/__tests__/Header.test.tsx src/components/ui/__tests__/Avatar.test.tsx`
- `npm test -- src/components/layout/__tests__/Header.test.tsx src/components/ui/__tests__/Avatar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6894b0d2fcd0832eadc09be021dc1589