### PR TITLE
feat: remove clear all notification action

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,7 +957,6 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Notification cards keep softly rounded corners and a gentle shadow. Unread items show a thin brand-colored strip on the left.
 * Each card displays a circular avatar, bold title, one-line subtitle, relative timestamp and a small status icon on the right. Icons are color-coded (green for confirmed, indigo for reminders, amber for due alerts).
 * The header now just shows the “Notifications” title, an **Unread** toggle and a close **X** button.
-* A full-width rounded **Clear All** button stays pinned to the bottom of the panel.
 * Deposit due alerts now display "Booking confirmed – deposit R{amount} due by {date}" only the first time a booking is confirmed. Subsequent reminders omit the greeting. The drawer parses this format to show `R50.00 due by Jan 1, 2025` as the subtitle and links directly to the booking.
 * Booking confirmed and deposit due notifications now show the artist's avatar so users can immediately recognize who the alert is from. When the artist hasn't uploaded a photo, the default avatar is used.
 * Quote acceptance and booking confirmation notifications now render dynamic titles such as **"Quote accepted by Jane Doe"** instead of a generic label.
@@ -978,7 +977,6 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * `NotificationCard` in `components/ui/` displays a single alert with the same soft shadowed style used in the drawer.
 * `getNotificationDisplayProps` converts a `Notification` or unified feed item into the props required by `NotificationCard`.
 * API responses include `sender_name` and `link` fields used by the UI for titles and navigation. See [docs/notifications.md](docs/notifications.md).
-* A rounded **Clear All** button is fixed at the bottom so users can dismiss everything at once.
 
 ### Artist Profile Enhancements
 

--- a/frontend/src/components/layout/NotificationDrawer.tsx
+++ b/frontend/src/components/layout/NotificationDrawer.tsx
@@ -194,13 +194,6 @@ export default function NotificationDrawer({
                     >
                       Mark All Read
                     </button>
-                    <button
-                      type="button"
-                      onClick={markAllRead}
-                      className="w-full rounded-full bg-indigo-500 hover:bg-indigo-600 active:scale-95 transition-transform py-1 text-xs font-medium text-white shadow-lg"
-                    >
-                      Clear All
-                    </button>
                   </footer>
                 </Dialog.Panel>
               </Transition.Child>

--- a/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/NotificationDrawer.test.tsx
@@ -219,4 +219,24 @@ describe('NotificationDrawer component', () => {
       expect(markAllRead).toHaveBeenCalled();
     }
   });
+
+  it('does not render Clear All button', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(NotificationDrawer, {
+          open: true,
+          onClose: () => {},
+          items: [],
+          onItemClick: jest.fn(),
+          markAllRead: jest.fn(),
+        }),
+      );
+      await flushPromises();
+    });
+
+    const clearBtn = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Clear All',
+    );
+    expect(clearBtn).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- remove unused Clear All action from notification drawer
- document absence of Clear All button in notifications section
- test notification drawer for presence of Mark All Read and absence of Clear All

## Testing
- `npm --prefix frontend run lint` *(fails: Component definition is missing display name, Unexpected any, etc.)*
- `FAST=1 ./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894b39bc8d0832eb27c4b3b79bd8b51