### PR TITLE
fix: mock router usage in MobileBottomNav test

### DIFF
--- a/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx
@@ -70,7 +70,17 @@ describe('MobileBottomNav', () => {
   });
 
   it('sets CSS variable with nav height on the document root', () => {
-    mockUseRouter.mockReturnValue({ pathname: '/' });
+    // JSDOM does not compute layout, so mock the nav height for this test.
+    const original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetHeight',
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 56,
+    });
+
+    useRouter.mockReturnValue({ pathname: '/' });
     act(() => {
       root.render(
         React.createElement(MobileBottomNav, { user: {} as User })
@@ -80,6 +90,10 @@ describe('MobileBottomNav', () => {
       '--mobile-bottom-nav-height',
     );
     expect(value).toBe('56px');
+
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original);
+    }
   });
 
   it('shows unread message count badge', () => {


### PR DESCRIPTION
## Summary
- fix MobileBottomNav unit test to use `useRouter` mock
- ensure nav height CSS variable test passes by mocking `offsetHeight`

## Testing
- `npm test frontend/src/components/layout/__tests__/MobileBottomNav.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6894b3c138f8832e940eafc77d3a0b03