### PR TITLE
Make search suggestions responsive on small screens

### DIFF
--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -108,7 +108,8 @@ export default function SearchPopupContent({
             Suggested destinations
           </h3>
           {/* Enable vertical scrolling when suggestions exceed container height */}
-          <ul className="grid grid-cols-2 gap-4 max-h-[300px] overflow-y-auto scrollbar-thin">
+          {/* Use a single column on small screens and limit height to half the viewport */}
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-[50vh] overflow-y-auto scrollbar-thin">
             {MOCK_LOCATION_SUGGESTIONS.map((s) => (
               <li
                 key={s.name}
@@ -270,7 +271,8 @@ export default function SearchPopupContent({
       <p className="text-sm">Click &quot;Where&quot;, &quot;When&quot;, or &quot;Category&quot; to start.</p>
       <div className="mt-6">
         <h4 className="text-md font-semibold text-gray-700 mb-3">Popular Artist Locations</h4>
-        <ul className="grid grid-cols-2 gap-4">
+        {/* Responsive grid: stack suggestions on small screens */}
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {MOCK_LOCATION_SUGGESTIONS.slice(0, 4).map((s) => (
             <li
               key={`default-${s.name}`}


### PR DESCRIPTION
## Summary
- render search suggestions in a single column on small screens
- cap suggestion list height to half the viewport for better fit

## Testing
- `npm --prefix frontend run lint` *(fails: React/TS lint errors across unrelated files)*
- `npm --prefix frontend test` *(fails: multiple existing frontend test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6894b3bb1cf8832e8a64af6a9378d358