### PR TITLE
test: stub additional next router methods

### DIFF
--- a/frontend/tests/mocks/next-navigation.ts
+++ b/frontend/tests/mocks/next-navigation.ts
@@ -2,6 +2,9 @@ export const useRouter = jest.fn(() => ({
   push: jest.fn(),
   replace: jest.fn(),
   refresh: jest.fn(),
+  back: jest.fn(),
+  forward: jest.fn(),
+  prefetch: jest.fn(),
   pathname: '/',
 }));
 


### PR DESCRIPTION
## Summary
- expand next/navigation test mock with back, forward, and prefetch stubs

## Testing
- `npm --prefix frontend test` *(fails: 26 test suites failed, 1 skipped, 86 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b7d0a0f8832eaac1f807b56c9204