### PR TITLE
feat(frontend): expose safe-area-aware header height

### DIFF
--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -8,14 +8,21 @@
 - `headerFilter?: React.ReactNode` – optional filter control rendered to the right of the full search bar.
 - `fullWidthContent?: boolean` – allow content to span the full width.
 
-`MainLayout` uses the CSS custom property `--mobile-bottom-nav-height` to
-automatically pad the bottom of the page so content is never hidden behind the
-mobile navigation bar. This variable is set by `MobileBottomNav` and includes
-any safe‑area inset.
+`MainLayout` uses CSS custom properties to ensure content isn't obscured by
+fixed navigation elements:
+
+- `--mobile-bottom-nav-height` pads the bottom of the page so content is never
+  hidden behind the mobile navigation bar. This variable is set by
+  `MobileBottomNav` and includes any safe‑area inset.
+- `--header-height` exposes the sticky header's height (including safe‑area
+  inset) so pages can offset anchored content or scroll targets. It is set by
+  `Header`.
 
 ## Header
 
-`Header` powers the sticky top navigation and search experience.
+`Header` powers the sticky top navigation and search experience. It applies
+`pt-safe` to account for device notches and sets the `--header-height` variable
+on the document root for layout offsetting.
 
 - `filterControl?: React.ReactNode` – component rendered to the right of the full search bar. It is hidden when the header is compacted.
 

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react';
 import Header from '../Header';
-import { useRouter, usePathname, useSearchParams } from '@/tests/mocks/next-navigation';
+import { useSearchParams } from '@/tests/mocks/next-navigation';
 
 jest.mock('next/link', () => ({ __esModule: true, default: (props: Record<string, unknown>) => <a {...props} /> }));
 jest.mock('@/contexts/AuthContext', () => ({ useAuth: jest.fn(() => ({ user: null, logout: jest.fn() })) }));
@@ -125,5 +125,32 @@ describe('Header', () => {
     act(() => root.unmount());
     div.remove();
     useSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
+  it('sets CSS variable with header height on the document root', async () => {
+    const original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetHeight',
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 80,
+    });
+    const { div, root } = render();
+    await act(async () => {
+      root.render(
+        <Header headerState="initial" onForceHeaderState={jest.fn()} />,
+      );
+    });
+    await flushPromises();
+    const value = document.documentElement.style.getPropertyValue(
+      '--header-height',
+    );
+    expect(value).toBe('80px');
+    act(() => root.unmount());
+    div.remove();
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original);
+    }
   });
 });

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Header hides search bar when disabled 1`] = `
 <header
-  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out"
+  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out pt-safe"
   data-header-state="initial"
   id="app-header"
 >
@@ -108,7 +108,7 @@ exports[`Header hides search bar when disabled 1`] = `
 
 exports[`Header matches compact snapshot with filter control 1`] = `
 <header
-  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out compacted"
+  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out pt-safe compacted"
   data-header-state="compacted"
   id="app-header"
 >
@@ -381,7 +381,7 @@ exports[`Header matches compact snapshot with filter control 1`] = `
 
 exports[`Header renders extraBar when provided 1`] = `
 <header
-  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out"
+  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out pt-safe"
   data-header-state="initial"
   id="app-header"
 >
@@ -494,7 +494,7 @@ exports[`Header renders extraBar when provided 1`] = `
 
 exports[`Header renders search bar when enabled 1`] = `
 <header
-  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out"
+  class="app-header sticky top-0 z-50 bg-white transition-all duration-300 ease-in-out pt-safe"
   data-header-state="initial"
   id="app-header"
 >


### PR DESCRIPTION
## Summary
- pad header for device notches and compute `--header-height` CSS variable
- document header height variable for layout offsetting
- test header height CSS variable in unit tests

## Testing
- `npx next lint --file src/components/layout/Header.tsx src/components/layout/__tests__/Header.test.tsx`
- `npm test -- src/components/layout/__tests__/Header.test.tsx`
- `./scripts/test-all.sh` *(fails: 26 failed, 86 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b7ffeb54832ea71c2e0d6eb8381b