### PR TITLE
feat: add safe-area padding to mobile menu

### DIFF
--- a/frontend/STYLE_GUIDE.md
+++ b/frontend/STYLE_GUIDE.md
@@ -54,6 +54,22 @@ Provide a `title` prop to render an accessible heading inside `Dialog.Title`. Th
 
 Mobile navigation uses the `MobileBottomNav` component. It appears only below the `sm` breakpoint, hides on downward scroll, and supports unread message badges. Keep route names and icons consistent across the app.
 
+### Safe-area Utilities
+
+Use the `pt-safe` and `pb-safe` Tailwind classes to apply `env(safe-area-inset-*)` padding so content avoids notches and other device insets. When an element also needs space for the mobile navigation bar, combine these utilities with the `--mobile-bottom-nav-height` variable:
+
+```jsx
+<div
+  className="pt-safe pb-safe"
+  style={{
+    paddingBottom:
+      'calc(var(--mobile-bottom-nav-height, 0px) + env(safe-area-inset-bottom))',
+  }}
+>
+  ...
+</div>
+```
+
 ### Navigation Guidelines
 
 - All navigation links and buttons should use the shared `NavLink` component or the `navItemClasses` utility to ensure consistent typography and spacing.

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -64,7 +64,13 @@ export default function MobileMenuDrawer({
             leaveFrom="translate-x-0"
             leaveTo="-translate-x-full"
           >
-            <Dialog.Panel className="relative flex w-full max-w-xs flex-col bg-background pb-4 shadow-xl">
+            <Dialog.Panel
+              className="relative flex w-full max-w-xs flex-col overflow-y-auto bg-background pt-safe pb-safe shadow-xl"
+              style={{
+                paddingBottom:
+                  'calc(var(--mobile-bottom-nav-height, 0px) + env(safe-area-inset-bottom))',
+              }}
+            >
               <div className="flex items-center justify-between px-4 pt-4">
                 <Dialog.Title className="text-lg font-medium">Menu</Dialog.Title>
                 <button

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -97,6 +97,29 @@ describe('MobileMenuDrawer', () => {
     expect(link?.className).toContain('min-h-[44px]');
   });
 
+  it('Dialog.Panel includes overflow and safe-area classes', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          user: null,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await flushPromises();
+    const panel = document.querySelector(
+      'div[class*="overflow-y-auto"][class*="pt-safe"][class*="pb-safe"]',
+    ) as HTMLDivElement | null;
+    expect(panel).not.toBeNull();
+    expect(panel?.style.paddingBottom).toContain(
+      'var(--mobile-bottom-nav-height',
+    );
+  });
+
   it('uses Dialog.Title and nav lists for structure', async () => {
     await act(async () => {
       root.render(


### PR DESCRIPTION
## Summary
- ensure mobile menu drawer scrolls and respects device safe areas
- document safe-area utilities for consistent mobile layouts
- verify drawer panel uses safe-area and overflow classes

## Testing
- `./scripts/test-all.sh` *(fails: AssertionError in backend/tests/test_notifications.py::test_status_update_creates_notification_for_client)*

------
https://chatgpt.com/codex/tasks/task_e_6894c2550a28832e9e35c56dbb7a3915