### PR TITLE
feat: add icons to mobile navigation

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,7 +12,14 @@ import {
   type MutableRefObject,
 } from 'react';
 import { Menu, Transition } from '@headlessui/react';
-import { MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
+import {
+  MagnifyingGlassIcon,
+  Bars3Icon,
+  UsersIcon,
+  WrenchScrewdriverIcon,
+  QuestionMarkCircleIcon,
+  EnvelopeIcon,
+} from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext'; // Assuming AuthContext is set up
@@ -38,12 +45,17 @@ type SearchParams = {
   when?: Date | null;
 };
 
-const clientNav = [
-  { name: 'Artists', href: '/artists' },
-  { name: 'Services', href: '/services' },
-  { name: 'FAQ', href: '/faq' },
-  { name: 'Contact', href: '/contact' },
+const navigation = [
+  { name: 'Artists', href: '/artists', icon: UsersIcon },
+  { name: 'Services', href: '/services', icon: WrenchScrewdriverIcon },
 ];
+
+const secondaryNavigation = [
+  { name: 'FAQ', href: '/faq', icon: QuestionMarkCircleIcon },
+  { name: 'Contact', href: '/contact', icon: EnvelopeIcon },
+];
+
+const clientNav = [...navigation, ...secondaryNavigation];
 
 function ClientNav({ pathname }: { pathname: string }) {
   return (
@@ -402,7 +414,8 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
       <MobileMenuDrawer
         open={menuOpen}
         onClose={() => setMenuOpen(false)}
-        navigation={clientNav}
+        navigation={navigation}
+        secondaryNavigation={secondaryNavigation}
         user={user}
         logout={logout}
         pathname={pathname}

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment } from 'react';
+import { Fragment, type ComponentType, type SVGProps } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
@@ -11,6 +11,7 @@ import { navItemClasses } from './navStyles';
 interface NavItem {
   name: string;
   href: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
 interface MobileMenuDrawerProps {
@@ -94,9 +95,12 @@ export default function MobileMenuDrawer({
                         href={item.href}
                         onClick={onClose}
                         isActive={pathname === item.href}
-                        className="block border-l-4 text-base"
+                        className="w-full border-l-4 text-base justify-start gap-3"
                       >
-                        {item.name}
+                        {item.icon && (
+                          <item.icon className="h-5 w-5" aria-hidden="true" />
+                        )}
+                        <span>{item.name}</span>
                       </NavLink>
                     </li>
                   ))}
@@ -115,9 +119,12 @@ export default function MobileMenuDrawer({
                           href={item.href}
                           onClick={onClose}
                           isActive={pathname === item.href}
-                          className="block border-l-4 text-base"
+                          className="w-full border-l-4 text-base justify-start gap-3"
                         >
-                          {item.name}
+                          {item.icon && (
+                            <item.icon className="h-5 w-5" aria-hidden="true" />
+                          )}
+                          <span>{item.name}</span>
                         </NavLink>
                       </li>
                     ))}

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -47,3 +47,7 @@ Headless UI's `<Dialog.Title>` to supply an accessible name for the dialog.
 Each navigation group is wrapped in a `<nav>` with an `aria-label` and links
 are rendered inside `<ul>`/`<li>` lists to expose proper semantics to assistive
 technologies.
+
+Navigation items accept an optional `icon` component from
+`@heroicons/react`. When provided, the icon is rendered next to the link text
+and spaced consistently via the shared `navItemClasses` utility.

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -5,6 +5,14 @@ import { act } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import MobileMenuDrawer from '../MobileMenuDrawer';
 import type { User } from '@/types';
+import {
+  HomeIcon,
+  UsersIcon,
+  SpeakerWaveIcon,
+  CalculatorIcon,
+  DocumentDuplicateIcon,
+  QuestionMarkCircleIcon,
+} from '@heroicons/react/24/outline';
 
 jest.mock('next/link', () => ({
   __esModule: true,
@@ -13,11 +21,15 @@ jest.mock('next/link', () => ({
 
 
 const nav = [
-  { name: 'Home', href: '/' },
-  { name: 'Artists', href: '/artists' },
-  { name: 'Sound Providers', href: '/sound-providers' },
-  { name: 'Quote Calculator', href: '/quote-calculator' },
-  { name: 'Quote Templates', href: '/dashboard/profile/quote-templates' },
+  { name: 'Home', href: '/', icon: HomeIcon },
+  { name: 'Artists', href: '/artists', icon: UsersIcon },
+  { name: 'Sound Providers', href: '/sound-providers', icon: SpeakerWaveIcon },
+  { name: 'Quote Calculator', href: '/quote-calculator', icon: CalculatorIcon },
+  {
+    name: 'Quote Templates',
+    href: '/dashboard/profile/quote-templates',
+    icon: DocumentDuplicateIcon,
+  },
 ];
 
 describe('MobileMenuDrawer', () => {
@@ -57,6 +69,27 @@ describe('MobileMenuDrawer', () => {
     expect(bodyText).toContain('Sound Providers');
     expect(bodyText).toContain('Quote Calculator');
     expect(bodyText).toContain('Quote Templates');
+  });
+
+  it('renders an icon for each navigation link', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(MobileMenuDrawer, {
+          open: true,
+          onClose: () => {},
+          navigation: nav,
+          secondaryNavigation: [{ name: 'Help', href: '/help', icon: QuestionMarkCircleIcon }],
+          user: null,
+          logout: () => {},
+          pathname: '/',
+        }),
+      );
+    });
+    await flushPromises();
+    const exploreIcons = document.querySelectorAll('nav[aria-label="Explore"] svg');
+    expect(exploreIcons.length).toBe(nav.length);
+    const moreIcons = document.querySelectorAll('nav[aria-label="More"] svg');
+    expect(moreIcons.length).toBe(1);
   });
 
   it('close button has focus ring classes', async () => {


### PR DESCRIPTION
## Summary
- allow MobileMenuDrawer nav items to include optional icons and render them with spacing
- supply heroicon components for main and secondary links in the Header
- document icon support and test icon rendering in MobileMenuDrawer

## Testing
- `./scripts/test-all.sh` *(fails: NotificationType mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6894c68fb3a0832e81f72db8334492f9