### PR TITLE
Align MobileMenuDrawer items to the left

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -235,7 +235,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
               type="button"
               onClick={() => setMenuOpen(true)}
               aria-label="Open menu"
-              className={clsx(navItemClasses, 'md:hidden')}
+              className={clsx(navItemClasses, 'md:hidden justify-center')}
             >
               <Bars3Icon className="h-6 w-6" />
             </button>
@@ -310,18 +310,18 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                   {user.user_type === 'artist' && (
                     <button
                       onClick={toggleArtistView}
-                      className={clsx(navItemClasses, 'text-gray-700')}
+                      className={clsx(navItemClasses, 'text-gray-700 justify-center')}
                     >
                       {artistViewActive ? 'Switch to Booking' : 'Switch to Artist View'}
                     </button>
                   )}
-                  <div className={navItemClasses}>
+                  <div className={clsx(navItemClasses, 'justify-center')}>
                     <NotificationBell />
                   </div>
                   <Menu as="div" className="relative">
                   <Menu.Button
                     aria-label="Account menu"
-                    className={clsx(navItemClasses, 'rounded-full bg-gray-100 text-sm focus:outline-none')}
+                    className={clsx(navItemClasses, 'rounded-full bg-gray-100 text-sm focus:outline-none justify-center')}
                   >
                     <Avatar
                       src={user.profile_picture_url || null}
@@ -364,12 +364,12 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
               </>
             ) : (
               <div className="flex gap-2">
-                <Link href="/login" className={clsx(navItemClasses, 'text-gray-600')}>
+                <Link href="/login" className={clsx(navItemClasses, 'text-gray-600 justify-center')}>
                   Sign in
                 </Link>
                 <Link
                   href="/register"
-                  className={clsx(navItemClasses, 'bg-brand-dark text-white rounded')}
+                  className={clsx(navItemClasses, 'bg-brand-dark text-white rounded justify-center')}
                 >
                   Sign up
                 </Link>

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -180,7 +180,7 @@ export default function MobileMenuDrawer({
                             }}
                             className={clsx(
                               navItemClasses,
-                              'w-full text-left text-base text-gray-700 hover:bg-gray-100 hover:text-red-600 px-2 py-2 rounded-md',
+                              'w-full text-left text-base text-gray-700 hover:bg-gray-100 hover:text-red-600 px-2 py-2 rounded-md justify-start',
                             )}
                           >
                             Sign out

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -50,4 +50,5 @@ technologies.
 
 Navigation items accept an optional `icon` component from
 `@heroicons/react`. When provided, the icon is rendered next to the link text
-and spaced consistently via the shared `navItemClasses` utility.
+and spaced consistently via the shared `navItemClasses` utility. Items are
+left-aligned within the drawer for faster scanning.

--- a/frontend/src/components/layout/navStyles.ts
+++ b/frontend/src/components/layout/navStyles.ts
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-export const navItemClasses = 'inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-sm font-medium no-underline hover:no-underline';
+export const navItemClasses = 'inline-flex items-center min-h-[44px] min-w-[44px] text-sm font-medium no-underline hover:no-underline';
 
 export const navLinkClasses = (isActive?: boolean) =>
   clsx(


### PR DESCRIPTION
## Summary
- remove default center justification from navigation item utility classes
- explicitly center header buttons and auth links while leaving drawer items left-aligned
- document left-aligned mobile drawer menu items for quicker scanning

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 27 failed, 1 skipped, 85 passed, 112 of 113 total)*
- `npx jest src/components/layout/__tests__/Header.test.tsx --runInBand --bail 2>&1 | tail -n 10` *(fails: Test Suites: 1 failed, 1 total)*

------
https://chatgpt.com/codex/tasks/task_e_6894d61102fc832ea833375a5534e457