### PR TITLE
chore: remove maximum-scale from viewport

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,13 +14,12 @@ const inter = Inter({
 export const metadata = {
   title: 'Artist Booking App',
   description: 'Book your favorite artists for services',
-  viewport: 'width=device-width, initial-scale=1, maximum-scale=1',
+  viewport: 'width=device-width, initial-scale=1',
 };
 
 export const viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- drop `maximum-scale=1` from default viewport meta

## Testing
- `curl -s http://localhost:3000 | grep -o '<meta[^>]*viewport[^>]*>'`
- `./scripts/test-all.sh` *(fails: MessageThread.test.tsx, Stepper.test.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894e39782dc832ebe45aea109605142