### PR TITLE
fix: close location popup with single click

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -126,7 +126,10 @@ export default function SearchBar({
       setActiveField(null);
       if (lastActiveButtonRef.current) {
         if (activeField === "location" && locationInputRef.current) {
-          locationInputRef.current.focus();
+          // Blurring prevents the onFocus handler from immediately
+          // re-opening the location popup, which previously required a
+          // second outside click to dismiss.
+          locationInputRef.current.blur();
         } else {
           lastActiveButtonRef.current.focus();
         }

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -54,6 +54,7 @@ describe('SearchBar', () => {
   });
 
   it('dismisses popup with a single outside click and allows interactions', async () => {
+    jest.useFakeTimers();
     const onSearch = jest.fn();
     const outsideClick = jest.fn();
 
@@ -96,8 +97,14 @@ describe('SearchBar', () => {
     fireEvent.mouseDown(outside);
     fireEvent.click(outside);
 
+    // Allow the internal close timeout to elapse
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
     await waitFor(() => expect(queryByRole('dialog')).toBeNull());
     expect(outsideClick).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it('keeps popup content when switching fields quickly', () => {


### PR DESCRIPTION
## Summary
- prevent location input from immediately re-focusing after close to avoid reopening the popup
- test that a single outside click dismisses the location popup

## Testing
- `npx jest src/components/search/__tests__/SearchBar.test.tsx --runTestsByPath`
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68957cb8a6a4832e9efa84df93e071b6