### PR TITLE
feat: add services carousel to homepage

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -52,6 +52,10 @@ sync, ensuring responsive behavior matches the design system.
 
 Focusing the category chooser opens a popup that spans half of the search bar from the left. The location input opens a suggested-destinations popup on the right half, and selecting dates launches a full-screen calendar overlay. If the suggested destinations exceed the popup height, the list now scrolls so all options remain accessible. Once the user types in a location, the suggestions popup closes and will not reappear, while Google Places autocomplete suggestions show directly beneath the input.
 
+### Homepage Categories Carousel
+
+The home page includes a "Services Near You" carousel that lists common service categories such as Musicians and DJs. Items use a square image placeholder with the label below and link to the artists page filtered by the selected category.
+
 ### Loading Indicators
 
 `Spinner` and `SkeletonList` components in `src/components/ui` provide

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,11 @@
 import MainLayout from '@/components/layout/MainLayout'
 import ArtistsSection from '@/components/home/ArtistsSection'
+import CategoriesCarousel from '@/components/home/CategoriesCarousel'
 
 export default function HomePage() {
   return (
     <MainLayout>
+      <CategoriesCarousel />
       <ArtistsSection
         title="Popular Musicians"
         query={{ sort: 'most_booked' }}

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
+
+/**
+ * Displays a horizontally scrollable list of service categories.
+ * Each item shows a square image placeholder and a label below.
+ * Clicking an item navigates to the artists listing with the
+ * category pre-selected.
+ */
+export default function CategoriesCarousel() {
+  return (
+    <section className="mt-4">
+      <h2 className="text-xl font-semibold px-4">Services Near You</h2>
+      <div className="mt-2 flex overflow-x-auto gap-4 px-4 pb-2">
+        {UI_CATEGORIES.map((cat) => (
+          <Link
+            key={cat.value}
+            href={`/artists?category=${encodeURIComponent(
+              UI_CATEGORY_TO_SERVICE[cat.value] || cat.value,
+            )}`}
+            className="flex-shrink-0 text-center"
+          >
+            <div className="relative w-20 h-20 rounded-lg overflow-hidden bg-gray-100">
+              <Image
+                src="/default-avatar.svg"
+                alt={cat.label}
+                fill
+                sizes="80px"
+                className="object-cover"
+              />
+            </div>
+            <p className="mt-1 text-sm">{cat.label}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -1,0 +1,25 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import CategoriesCarousel from '../CategoriesCarousel';
+import { UI_CATEGORIES } from '@/lib/categoryMap';
+
+describe('CategoriesCarousel', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders all category labels', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(React.createElement(CategoriesCarousel));
+    });
+    UI_CATEGORIES.forEach((cat) => {
+      expect(container.textContent).toContain(cat.label);
+    });
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -2,18 +2,30 @@
 
 // Define the shape of a UI category item
 export const UI_CATEGORIES = [
-  { value: 'musician', label: 'Musician / Band' },
-  { value: 'photographer', label: 'Photographer' },
-  { value: 'dj', label: 'DJ' },
-  { value: 'venue', label: 'Venue' },
+  { value: 'musician', label: 'Musicians' },
+  { value: 'dj', label: 'DJs' },
+  { value: 'photographer', label: 'Photographers' },
+  { value: 'videographer', label: 'Videographers' },
+  { value: 'speaker', label: 'Speakers' },
+  { value: 'event_service', label: 'Event Services' },
+  { value: 'wedding_venue', label: 'Wedding Venues' },
+  { value: 'caterer', label: 'Caterers' },
+  { value: 'bartender', label: 'Bartenders' },
+  { value: 'mc_host', label: 'MCs & Hosts' },
 ] as const; // `as const` ensures TypeScript infers literal types, which is good practice
 
 // Map UI categories (keys are UI values) to backend service categories (values are backend values)
 export const UI_CATEGORY_TO_SERVICE: Record<string, string> = {
-  musician: 'Live Performance',
-  photographer: 'Photography',
+  musician: 'Musician',
   dj: 'DJ',
-  venue: 'Venue',
+  photographer: 'Photographer',
+  videographer: 'Videographer',
+  speaker: 'Speaker',
+  event_service: 'Event Service',
+  wedding_venue: 'Wedding Venue',
+  caterer: 'Caterer',
+  bartender: 'Bartender',
+  mc_host: 'MC & Host',
 };
 
 // Create a reverse map from backend service categories to UI categories (for display purposes)
@@ -22,4 +34,4 @@ export const SERVICE_TO_UI_CATEGORY: Record<string, string> = Object.fromEntries
 );
 
 // You can optionally export a type for clarity across components
-export type Category = typeof UI_CATEGORIES[number]; // Infers { value: 'musician' | 'photographer' | 'dj' | 'venue', label: 'Musician / Band' | 'Photographer' | 'DJ' | 'Venue' }
+export type Category = typeof UI_CATEGORIES[number]; // Infers union of all UI category items


### PR DESCRIPTION
## Summary
- add "Services Near You" carousel with 10 service categories
- expand category mapping to cover musicians, DJs, venues, and more
- document new carousel in frontend README

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 28 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6895b3a82368832e865154857eccf5d3