### PR TITLE
Adjust CategoriesCarousel spacing and dimensions

### DIFF
--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -13,8 +13,8 @@ import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
 export default function CategoriesCarousel() {
   return (
     <section className="mt-4">
-      <h2 className="text-xl font-semibold px-4">Services Near You</h2>
-      <div className="mt-2 flex overflow-x-auto gap-4 px-4 pb-2">
+      <h2 className="text-xl font-semibold px-8">Services Near You</h2>
+      <div className="mt-2 flex overflow-x-auto gap-4 px-8 pb-2">
         {UI_CATEGORIES.map((cat) => (
           <Link
             key={cat.value}
@@ -23,12 +23,12 @@ export default function CategoriesCarousel() {
             )}`}
             className="flex-shrink-0 text-center"
           >
-            <div className="relative w-40 h-40 rounded-lg overflow-hidden bg-gray-100">
+            <div className="relative w-30 h-30 rounded-lg overflow-hidden bg-gray-100">
               <Image
                 src={cat.image || '/default-avatar.svg'}
                 alt={cat.label}
                 fill
-                sizes="160px"
+                sizes="120px"
                 className="object-cover"
               />
             </div>

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -26,4 +26,26 @@ describe('CategoriesCarousel', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('applies correct spacing and dimensions', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(React.createElement(CategoriesCarousel));
+    });
+
+    const heading = container.querySelector('h2');
+    expect(heading?.className).toContain('px-8');
+
+    const outer = container.querySelector('section > div');
+    expect(outer?.className).toContain('px-8');
+
+    const wrapper = container.querySelector('div.relative');
+    expect(wrapper?.className).toContain('w-30');
+    expect(wrapper?.className).toContain('h-30');
+
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- Increase CategoriesCarousel padding to `px-8`
- Reduce category image wrapper to `w-30 h-30`
- Add unit test to verify new spacing and sizing

## Testing
- `npm test` (fails: MobileMenuDrawer test failing and others)
- `pytest`
- `npm --prefix frontend run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_6895b8d910a8832ebdc74fa8ef0fbd05