### PR TITLE
feat: add nav buttons to categories carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The July 2025 update bumps key dependencies and Docker base images:
   individual profiles.
 - An unobtrusive marketing strip replaces the old Hero section.
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
+- The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ Focusing the category chooser opens a popup that spans half of the search bar fr
 
 ### Homepage Categories Carousel
 
-The home page includes a "Services Near You" carousel that lists common service categories such as Musicians and DJs. Each category now supports its own image, defined in `src/lib/categoryMap.ts` and served from `public/categories`. Items display the image with the label below and link to the artists page filtered by the selected category.
+The home page includes a "Services Near You" carousel that lists common service categories such as Musicians and DJs. Each category supports its own image, defined in `src/lib/categoryMap.ts` and served from `public/categories`. Items display the image with the label below and link to the artists page filtered by the selected category. On desktop, left and right buttons page through the list for easier navigation.
 
 ### Loading Indicators
 

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -2,6 +2,8 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid';
 import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
 
 /**
@@ -11,30 +13,83 @@ import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
  * category pre-selected.
  */
 export default function CategoriesCarousel() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollButtons = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth);
+  };
+
+  useEffect(() => {
+    updateScrollButtons();
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateScrollButtons);
+    window.addEventListener('resize', updateScrollButtons);
+    return () => {
+      el.removeEventListener('scroll', updateScrollButtons);
+      window.removeEventListener('resize', updateScrollButtons);
+    };
+  }, []);
+
+  const scrollBy = (offset: number) => {
+    scrollRef.current?.scrollBy({ left: offset, behavior: 'smooth' });
+  };
+
   return (
-    <section className="mt-4">
-      <h2 className="text-xl font-semibold px-4">Services Near You</h2>
-      <div className="mt-2 flex overflow-x-auto gap-4 px-4 pb-2">
-        {UI_CATEGORIES.map((cat) => (
-          <Link
-            key={cat.value}
-            href={`/artists?category=${encodeURIComponent(
-              UI_CATEGORY_TO_SERVICE[cat.value] || cat.value,
-            )}`}
-            className="flex-shrink-0 text-center"
-          >
-            <div className="relative w-40 h-40 rounded-lg overflow-hidden bg-gray-100">
-              <Image
-                src={cat.image || '/default-avatar.svg'}
-                alt={cat.label}
-                fill
-                sizes="160px"
-                className="object-cover"
-              />
-            </div>
-            <p className="mt-1 text-sm">{cat.label}</p>
-          </Link>
-        ))}
+    <section className="mt-4" aria-labelledby="categories-heading">
+      <h2 id="categories-heading" className="px-4 text-xl font-semibold">
+        Services Near You
+      </h2>
+      <div className="relative mt-2">
+        <button
+          type="button"
+          aria-label="Previous"
+          className="absolute left-0 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border bg-white p-2 shadow disabled:opacity-50 sm:block"
+          disabled={!canScrollLeft}
+          onClick={() => scrollBy(-200)}
+        >
+          <ChevronLeftIcon className="h-5 w-5" />
+        </button>
+        <div
+          ref={scrollRef}
+          data-testid="categories-scroll"
+          className="flex overflow-x-auto scroll-smooth gap-4 px-4 pb-2"
+        >
+          {UI_CATEGORIES.map((cat) => (
+            <Link
+              key={cat.value}
+              href={`/artists?category=${encodeURIComponent(
+                UI_CATEGORY_TO_SERVICE[cat.value] || cat.value,
+              )}`}
+              className="flex-shrink-0 text-center"
+            >
+              <div className="relative h-40 w-40 overflow-hidden rounded-lg bg-gray-100">
+                <Image
+                  src={cat.image || '/default-avatar.svg'}
+                  alt={cat.label}
+                  fill
+                  sizes="160px"
+                  className="object-cover"
+                />
+              </div>
+              <p className="mt-1 text-sm">{cat.label}</p>
+            </Link>
+          ))}
+        </div>
+        <button
+          type="button"
+          aria-label="Next"
+          className="absolute right-0 top-1/2 z-10 hidden -translate-y-1/2 rounded-full border bg-white p-2 shadow disabled:opacity-50 sm:block"
+          disabled={!canScrollRight}
+          onClick={() => scrollBy(200)}
+        >
+          <ChevronRightIcon className="h-5 w-5" />
+        </button>
       </div>
     </section>
   );

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -9,7 +9,7 @@ describe('CategoriesCarousel', () => {
     document.body.innerHTML = '';
   });
 
-  it('renders all category labels with images', () => {
+  it('renders categories with navigation buttons', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -23,6 +23,46 @@ describe('CategoriesCarousel', () => {
     UI_CATEGORIES.forEach((cat, index) => {
       expect(imgs[index].getAttribute('src')).toBe(cat.image);
     });
+    const prev = container.querySelector('button[aria-label="Previous"]');
+    const next = container.querySelector('button[aria-label="Next"]');
+    expect(prev).not.toBeNull();
+    expect(next).not.toBeNull();
+    expect((prev as HTMLButtonElement).disabled).toBe(true);
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('scrolls when clicking the next button', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(React.createElement(CategoriesCarousel));
+    });
+    const scroller = container.querySelector(
+      '[data-testid="categories-scroll"]',
+    ) as HTMLDivElement;
+    Object.defineProperty(scroller, 'scrollWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scroller, 'clientWidth', {
+      configurable: true,
+      value: 500,
+    });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    const next = container.querySelector(
+      'button[aria-label="Next"]',
+    ) as HTMLButtonElement;
+    expect(next.disabled).toBe(false);
+    const mock = jest.fn();
+    scroller.scrollBy = mock;
+    act(() => {
+      next.click();
+    });
+    expect(mock).toHaveBeenCalled();
     act(() => root.unmount());
     container.remove();
   });


### PR DESCRIPTION
## Summary
- add previous/next buttons and scroll logic to homepage categories carousel
- document carousel navigation in READMEs
- expand carousel tests for new controls

## Testing
- `./scripts/test-all.sh` *(failed: Test Suites: 28 failed, 1 skipped, 85 passed, 113 of 114 total)*

------
https://chatgpt.com/codex/tasks/task_e_6895b976d84c832eb0367b52ac4b3de3