### PR TITLE
Align categories carousel with artist layout and hide scrollbar

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -303,3 +303,13 @@
 body.no-scroll {
   overflow: hidden;
 }
+
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid';
+import { ChevronRightIcon } from '@heroicons/react/24/solid';
 import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
 
 /**
@@ -41,17 +41,18 @@ export default function CategoriesCarousel() {
   };
 
   return (
-
-    <section className="mt-4" aria-labelledby="categories-heading">
-      <h2 id="categories-heading" className="px-8 text-xl font-semibold">
+    <section
+      className="full-width mx-auto mt-4 px-4 sm:px-6 lg:px-8"
+      aria-labelledby="categories-heading"
+    >
+      <h2 id="categories-heading" className="text-xl font-semibold">
         Services Near You
       </h2>
       <div className="relative mt-2">
-       
         <div
           ref={scrollRef}
           data-testid="categories-scroll"
-          className="flex overflow-x-auto scroll-smooth gap-4 px-8 pb-2"
+          className="flex gap-4 overflow-x-auto scroll-smooth pb-2 scrollbar-hide"
         >
           {UI_CATEGORIES.map((cat) => (
             <Link
@@ -59,7 +60,7 @@ export default function CategoriesCarousel() {
               href={`/artists?category=${encodeURIComponent(
                 UI_CATEGORY_TO_SERVICE[cat.value] || cat.value,
               )}`}
-              className="flex-shrink-0 text-center"
+              className="flex-shrink-0"
             >
               <div className="relative h-40 w-40 overflow-hidden rounded-lg bg-gray-100">
                 <Image
@@ -69,8 +70,10 @@ export default function CategoriesCarousel() {
                   sizes="160px"
                   className="object-cover"
                 />
+                <p className="absolute bottom-2 left-2 text-sm font-medium text-white drop-shadow">
+                  {cat.label}
+                </p>
               </div>
-              <p className="mt-1 text-sm">{cat.label}</p>
             </Link>
           ))}
         </div>

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -23,11 +23,8 @@ describe('CategoriesCarousel', () => {
     UI_CATEGORIES.forEach((cat, index) => {
       expect(imgs[index].getAttribute('src')).toBe(cat.image);
     });
-    const prev = container.querySelector('button[aria-label="Previous"]');
     const next = container.querySelector('button[aria-label="Next"]');
-    expect(prev).not.toBeNull();
     expect(next).not.toBeNull();
-    expect((prev as HTMLButtonElement).disabled).toBe(true);
     act(() => root.unmount());
     container.remove();
   });
@@ -75,15 +72,22 @@ describe('CategoriesCarousel', () => {
       root.render(React.createElement(CategoriesCarousel));
     });
 
-    const heading = container.querySelector('h2');
-    expect(heading?.className).toContain('px-8');
+    const section = container.querySelector('section');
+    expect(section?.className).toContain('px-4');
+    expect(section?.className).toContain('sm:px-6');
+    expect(section?.className).toContain('lg:px-8');
 
-    const outer = container.querySelector('section > div');
-    expect(outer?.className).toContain('px-8');
+    const scroller = container.querySelector('[data-testid="categories-scroll"]');
+    expect(scroller?.className).toContain('scrollbar-hide');
 
-    const wrapper = container.querySelector('div.relative');
-    expect(wrapper?.className).toContain('w-30');
-    expect(wrapper?.className).toContain('h-30');
+    const wrapper = container.querySelector('a div.relative');
+    expect(wrapper?.className).toContain('w-40');
+    expect(wrapper?.className).toContain('h-40');
+
+    const label = container.querySelector('a p');
+    expect(label?.className).toContain('absolute');
+    expect(label?.className).toContain('left-2');
+    expect(label?.className).toContain('bottom-2');
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- Align categories carousel heading and items with artist section spacing
- Overlay category labels at the bottom-left of images to match home page style
- Hide horizontal scrollbar while keeping scroll functionality

## Testing
- `npm test` *(fails: multiple unit tests failing, 28 test suites failed)*
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c56a7534832eb9ccbea298969b81