### PR TITLE
Require service media and display on profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The chat thread now expands or contracts horizontally as the side panel is toggled, keeping date divider lines perfectly aligned across both sections.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/artist-profiles/me/portfolio-images` to upload and `PUT /api/v1/artist-profiles/me/portfolio-images` to save the order.
 - Artists can also drag and drop service cards on the dashboard to set their display order.
+- Adding a service now requires at least one image, and the uploaded media displays on the artist profile within each service block.
 - Dashboard pages are now separated by user type: artists use `frontend/src/app/dashboard/artist/page.tsx` and clients use `frontend/src/app/dashboard/client/page.tsx`.
 - Quote modal items can now be removed even when only one item is present.
 - Clients can upload and crop a profile picture via `/api/v1/users/me/profile-picture`; chat messages and notifications will show the artist or client avatar when available.

--- a/backend/alembic/versions/60101124c3b1_add_media_url_to_services.py
+++ b/backend/alembic/versions/60101124c3b1_add_media_url_to_services.py
@@ -1,0 +1,27 @@
+"""add media_url to services
+
+Revision ID: 60101124c3b1
+Revises: f23ad0e57c1d
+Create Date: 2025-10-05 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "60101124c3b1"
+down_revision: Union[str, None] = "f23ad0e57c1d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "services",
+        sa.Column("media_url", sa.String(), nullable=False, server_default=""),
+    )
+    op.alter_column("services", "media_url", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("services", "media_url")

--- a/backend/app/models/service.py
+++ b/backend/app/models/service.py
@@ -34,6 +34,7 @@ class Service(BaseModel):
     )
     title = Column(String, index=True, nullable=False)
     description = Column(Text, nullable=True)
+    media_url = Column(String, nullable=False)
     price = Column(Numeric(10, 2), nullable=False)
     currency = Column(String(3), nullable=False, default="ZAR")
     duration_minutes = Column(Integer, nullable=False)

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -10,6 +10,7 @@ from datetime import datetime
 class ServiceBase(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
+    media_url: Optional[str] = None
     duration_minutes: Optional[int] = None
     price: Optional[Decimal] = None
     currency: Optional[str] = "ZAR"
@@ -27,6 +28,7 @@ class ServiceCreate(ServiceBase):
     duration_minutes: int
     price: Decimal
     service_type: ServiceType
+    media_url: str
     # artist_id will be set based on the authenticated artist, not in schema
 
 
@@ -43,5 +45,6 @@ class ServiceResponse(ServiceBase):
     display_order: int
     created_at: datetime
     updated_at: datetime
+    media_url: str
 
     model_config = {"from_attributes": True}

--- a/backend/tests/test_artist_filters.py
+++ b/backend/tests/test_artist_filters.py
@@ -35,6 +35,7 @@ def create_artist(db, name, location, category, rating=5, bookings=0):
         price=100,
         duration_minutes=60,
         service_type=category,
+        media_url='x',
     )
     profile.services.append(service)
     db.add(profile)

--- a/backend/tests/test_booking_deposit_fields.py
+++ b/backend/tests/test_booking_deposit_fields.py
@@ -64,6 +64,7 @@ def create_records(
         price=Decimal("100"),
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_booking_request_service_update.py
+++ b/backend/tests/test_booking_request_service_update.py
@@ -27,8 +27,22 @@ def test_client_can_update_service_id():
     db.refresh(artist)
 
     profile = ArtistProfileV2(user_id=artist.id)
-    svc1 = Service(artist_id=artist.id, title='One', price=10, duration_minutes=30, service_type=ServiceType.OTHER)
-    svc2 = Service(artist_id=artist.id, title='Two', price=20, duration_minutes=45, service_type=ServiceType.OTHER)
+    svc1 = Service(
+        artist_id=artist.id,
+        title='One',
+        price=10,
+        duration_minutes=30,
+        service_type=ServiceType.OTHER,
+        media_url='x',
+    )
+    svc2 = Service(
+        artist_id=artist.id,
+        title='Two',
+        price=20,
+        duration_minutes=45,
+        service_type=ServiceType.OTHER,
+        media_url='y',
+    )
     profile.services.extend([svc1, svc2])
     db.add(profile)
     db.commit()

--- a/backend/tests/test_calendar_export.py
+++ b/backend/tests/test_calendar_export.py
@@ -25,7 +25,13 @@ def test_calendar_download_returns_ics():
     db.refresh(artist_user)
 
     profile = ArtistProfileV2(user_id=artist_user.id)
-    service = Service(artist_id=artist_user.id, title='Gig', price=100, duration_minutes=60)
+    service = Service(
+        artist_id=artist_user.id,
+        title='Gig',
+        price=100,
+        duration_minutes=60,
+        media_url='x',
+    )
     db.add_all([profile, service])
     db.commit()
     db.refresh(service)

--- a/backend/tests/test_client_bookings_status.py
+++ b/backend/tests/test_client_bookings_status.py
@@ -58,6 +58,7 @@ def create_data(Session):
         price=100,
         duration_minutes=60,
         service_type='Live Performance',
+        media_url='x',
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_currency_fields.py
+++ b/backend/tests/test_currency_fields.py
@@ -25,7 +25,7 @@ def test_service_response_includes_currency():
     db.add(profile)
     db.commit()
 
-    svc_in = ServiceCreate(title='Gig', duration_minutes=60, price=100, service_type=ServiceType.OTHER)
+    svc_in = ServiceCreate(title='Gig', duration_minutes=60, price=100, service_type=ServiceType.OTHER, media_url='x')
     svc = api_service.create_service(db=db, service_in=svc_in, current_artist=artist)
     schema = ServiceResponse.model_validate(svc)
     assert schema.currency == 'ZAR'

--- a/backend/tests/test_field_errors.py
+++ b/backend/tests/test_field_errors.py
@@ -37,7 +37,14 @@ def create_users(Session):
     db.commit()
     db.refresh(artist)
     db.refresh(client)
-    svc = Service(artist_id=artist.id, title='One', price=10, duration_minutes=30, service_type='Other')
+    svc = Service(
+        artist_id=artist.id,
+        title='One',
+        price=10,
+        duration_minutes=30,
+        service_type='Other',
+        media_url='x',
+    )
     db.add(svc)
     db.commit()
     db.refresh(svc)

--- a/backend/tests/test_invoice.py
+++ b/backend/tests/test_invoice.py
@@ -56,6 +56,7 @@ def create_records(Session):
         price=Decimal("100"),
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -612,6 +612,7 @@ def test_personalized_video_notifications_suppressed_until_final():
         duration_minutes=5,
         price=100,
         display_order=1,
+        media_url="x",
     )
     db.add_all([profile, service])
     db.commit()
@@ -671,6 +672,7 @@ def test_review_request_notification():
         title="Gig",
         price=100,
         duration_minutes=60,
+        media_url="x",
     )
     db.add_all([profile, service])
     db.commit()
@@ -1069,6 +1071,7 @@ def test_booking_request_api_parses_sender_and_type():
         service_type=ServiceType.LIVE_PERFORMANCE,
         duration_minutes=60,
         price=100,
+        media_url="x",
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_quote_pdf.py
+++ b/backend/tests/test_quote_pdf.py
@@ -46,6 +46,7 @@ def create_quote(Session):
         price=Decimal("100"),
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_quote_v2.py
+++ b/backend/tests/test_quote_v2.py
@@ -62,6 +62,7 @@ def test_create_and_accept_quote():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -148,6 +149,7 @@ def test_create_quote_updates_request_status():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -208,6 +210,7 @@ def test_read_accepted_quote_has_booking_id():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -307,6 +310,7 @@ def test_accept_quote_booking_failure(monkeypatch, caplog):
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -386,6 +390,7 @@ def test_accept_quote_missing_client(caplog):
         currency="ZAR",
         duration_minutes=30,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -500,6 +505,7 @@ def test_accept_quote_creates_deposit_notification():
         currency="ZAR",
         duration_minutes=45,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -566,6 +572,7 @@ def test_accept_quote_deposit_notification_link():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -634,6 +641,7 @@ def test_accept_quote_supplies_missing_service_id():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -743,6 +751,7 @@ def test_accept_quote_without_date_for_video_service():
         currency="ZAR",
         duration_minutes=5,
         service_type="Personalized Video",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -806,6 +815,7 @@ def test_expire_pending_quotes():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -872,6 +882,7 @@ def test_scheduler_posts_system_message():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -947,6 +958,7 @@ def test_decline_quote():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()
@@ -1008,6 +1020,7 @@ def test_create_quote_notifies_client_when_ids_missing():
         currency="ZAR",
         duration_minutes=60,
         service_type="Live Performance",
+        media_url="x",
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_review.py
+++ b/backend/tests/test_review.py
@@ -27,7 +27,14 @@ def create_booking(db, status=BookingStatus.COMPLETED):
     db.refresh(client)
 
     profile = ArtistProfileV2(user_id=artist.id)
-    service = Service(artist_id=artist.id, title='Gig', price=100, duration_minutes=60)
+    service = Service(
+        artist_id=artist.id,
+        title='Gig',
+        price=100,
+        duration_minutes=60,
+        service_type='Live Performance',
+        media_url='x',
+    )
     db.add_all([profile, service])
     db.commit()
     db.refresh(service)

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -51,6 +51,7 @@ def test_process_quote_expiration(mock_expired, mock_expiring):
         currency='ZAR',
         duration_minutes=60,
         service_type='Live Performance',
+        media_url='x',
     )
     db.add(service)
     db.commit()

--- a/backend/tests/test_service_delete.py
+++ b/backend/tests/test_service_delete.py
@@ -42,6 +42,7 @@ def test_delete_service_cascades_messages():
         price=100,
         duration_minutes=60,
         service_type=ServiceType.OTHER,
+        media_url='x',
     )
     profile.services.append(service)
     db.add(profile)

--- a/backend/tests/test_service_schema.py
+++ b/backend/tests/test_service_schema.py
@@ -4,12 +4,13 @@ from app.schemas.service import ServiceCreate, ServiceUpdate, ServiceType
 
 def test_service_create_requires_type():
     with pytest.raises(Exception):
-        ServiceCreate(title="Test", duration_minutes=10, price=5.0)
+        ServiceCreate(title="Test", duration_minutes=10, price=5.0, media_url="x")
     s = ServiceCreate(
         title="Test",
         duration_minutes=10,
         price=5.0,
         service_type=ServiceType.OTHER,
+        media_url="x",
     )
     assert s.service_type == ServiceType.OTHER
     assert s.display_order is None

--- a/backend/tests/test_update_booking_status.py
+++ b/backend/tests/test_update_booking_status.py
@@ -25,7 +25,14 @@ def test_artist_can_update_booking_status():
     db.refresh(client)
 
     profile = ArtistProfileV2(user_id=artist.id)
-    service = Service(artist_id=artist.id, title='Gig', price=100, duration_minutes=60)
+    service = Service(
+        artist_id=artist.id,
+        title='Gig',
+        price=100,
+        duration_minutes=60,
+        service_type='Live Performance',
+        media_url='x',
+    )
     db.add_all([profile, service])
     db.commit()
     db.refresh(service)

--- a/backend/tests/test_user_export_delete.py
+++ b/backend/tests/test_user_export_delete.py
@@ -74,6 +74,7 @@ def create_data(Session):
         price=Decimal('100'),
         duration_minutes=60,
         service_type='Live Performance',
+        media_url='x',
     )
     db.add(service)
     db.commit()

--- a/frontend/src/app/dashboard/artist/__tests__/ServiceDeleteConfirmation.test.tsx
+++ b/frontend/src/app/dashboard/artist/__tests__/ServiceDeleteConfirmation.test.tsx
@@ -23,6 +23,7 @@ describe('Service deletion confirmation', () => {
     artist_id: 2,
     title: 'Gig',
     description: 'desc',
+    media_url: 'img.jpg',
     service_type: 'Live Performance',
     duration_minutes: 60,
     display_order: 1,

--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import type { Service } from '@/types';
 import { Button, Card } from '@/components/ui';
 import { getService } from '@/lib/api';
-import { formatCurrency } from '@/lib/utils';
+import { formatCurrency, getFullImageUrl } from '@/lib/utils';
 
 // This component was updated to fetch the latest service data whenever the card
 // is expanded. It ensures pricing or descriptions changed on the server are
@@ -43,6 +44,16 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
       role="listitem"
       className="p-4 cursor-pointer"
     >
+      {service.media_url && (
+        <div className="relative w-full h-48 mb-3">
+          <Image
+            src={getFullImageUrl(service.media_url) || service.media_url}
+            alt={service.title}
+            fill
+            className="object-cover rounded-md"
+          />
+        </div>
+      )}
       <div className="flex justify-between items-center" aria-expanded={expanded}>
         <h3 className="text-lg font-semibold text-gray-900 pr-2">{service.title}</h3>
         <Button

--- a/frontend/src/components/dashboard/AddServiceModal.tsx
+++ b/frontend/src/components/dashboard/AddServiceModal.tsx
@@ -203,7 +203,16 @@ export default function AddServiceModal({ isOpen, onClose, onServiceAdded }: Add
           ? Number(data.flight_price)
           : undefined,
       };
-      const res = await apiCreateService(serviceData);
+      let media_url = '';
+      if (mediaFiles[0]) {
+        media_url = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(new Error('Failed to read file'));
+          reader.readAsDataURL(mediaFiles[0]);
+        });
+      }
+      const res = await apiCreateService({ ...serviceData, media_url });
       onServiceAdded(res.data);
       reset();
       setMediaFiles([]);

--- a/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceModal.test.tsx
@@ -130,6 +130,7 @@ describe("AddServiceModal wizard", () => {
         travel_members: 1,
         car_rental_price: 1000,
         flight_price: 2780,
+        media_url: expect.any(String),
       }),
     );
   });

--- a/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/BookingRequestCard.test.tsx
@@ -46,6 +46,7 @@ const service: Service = {
   artist_id: 3,
   title: 'Live Musiek',
   description: '',
+  media_url: 'img.jpg',
   service_type: 'Other',
   duration_minutes: 0,
   travel_rate: undefined,

--- a/frontend/src/components/dashboard/__tests__/EditServiceModal.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EditServiceModal.test.tsx
@@ -37,6 +37,7 @@ describe('EditServiceModal', () => {
     artist_id: 1,
     title: 'Old Title',
     description: 'Desc',
+    media_url: 'img.jpg',
     price: 100,
     duration_minutes: 60,
     service_type: 'Live Performance',

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -43,6 +43,7 @@ describe('normalizeService', () => {
       artist_id: 1,
       title: 'Foo',
       description: 'Bar',
+      media_url: 'img.jpg',
       service_type: 'Other',
       price: '12.5' as unknown as number,
       duration_minutes: '30' as unknown as number,
@@ -60,8 +61,8 @@ describe('normalizeService', () => {
 describe('applyDisplayOrder', () => {
   it('increments display_order sequentially', () => {
     const services: Service[] = [
-      { id: 1, artist_id: 1, title: 'A', description: '', service_type: 'Other', duration_minutes: 10, display_order: 5, price: 1, artist: {} as ArtistProfile },
-      { id: 2, artist_id: 1, title: 'B', description: '', service_type: 'Other', duration_minutes: 10, display_order: 2, price: 1, artist: {} as ArtistProfile },
+      { id: 1, artist_id: 1, title: 'A', description: '', media_url: 'img.jpg', service_type: 'Other', duration_minutes: 10, display_order: 5, price: 1, artist: {} as ArtistProfile },
+      { id: 2, artist_id: 1, title: 'B', description: '', media_url: 'img.jpg', service_type: 'Other', duration_minutes: 10, display_order: 2, price: 1, artist: {} as ArtistProfile },
     ];
     const ordered = applyDisplayOrder(services);
     expect(ordered[0].display_order).toBe(1);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,7 @@ export interface Service {
   artist_id: number;
   title: string;
   description: string;
+  media_url: string;
   service_type:
     | "Live Performance"
     | "Virtual Appearance"


### PR DESCRIPTION
## Summary
- require `media_url` for services
- display service media on artist profile cards
- document mandatory service images

## Testing
- `./scripts/test-all.sh` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6895d28401a0832ea021fa6bae65d241