### PR TITLE
Ensure services media_url column exists

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,3 +42,10 @@ python -m spacy download en_core_web_sm
 If the model fails to load, the API responds with `503` and logs the
 underlying error.
 
+## Database schema helpers
+
+Startup checks in `app/db_utils.py` backfill missing database columns. This includes
+an automatic migration that adds the `media_url` column to the `services` table when
+running against older databases, preventing runtime errors when querying services
+without this field.
+

--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -169,6 +169,17 @@ def ensure_currency_column(engine: Engine) -> None:
     )
 
 
+def ensure_media_url_column(engine: Engine) -> None:
+    """Add the ``media_url`` column to ``services`` if it's missing."""
+
+    add_column_if_missing(
+        engine,
+        "services",
+        "media_url",
+        "media_url VARCHAR NOT NULL DEFAULT ''",
+    )
+
+
 def ensure_service_travel_columns(engine: Engine) -> None:
     """Add travel-related columns to ``services`` if missing."""
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from .db_utils import (
     ensure_price_visible_column,
     ensure_portfolio_image_urls_column,
     ensure_currency_column,
+    ensure_media_url_column,
     ensure_service_travel_columns,
     ensure_mfa_columns,
     ensure_request_attachment_column,
@@ -107,6 +108,7 @@ ensure_custom_subtitle_column(engine)
 ensure_price_visible_column(engine)
 ensure_portfolio_image_urls_column(engine)
 ensure_currency_column(engine)
+ensure_media_url_column(engine)
 ensure_service_travel_columns(engine)
 ensure_mfa_columns(engine)
 ensure_booking_simple_columns(engine)


### PR DESCRIPTION
## Summary
- add db_utils.ensure_media_url_column to backfill media_url on services
- invoke media_url column check during API startup
- document schema helper in backend README

## Testing
- `./scripts/test-all.sh` (fails: 29 failed, 1 skipped, 84 passed, 113 total)


------
https://chatgpt.com/codex/tasks/task_e_6895d76fdd94832e9d58449c4d323cd6