### PR TITLE
Handle data URLs in image helper

### DIFF
--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -117,6 +117,11 @@ describe('getFullImageUrl', () => {
     const url = 'https://cdn.example.com/img.png';
     expect(getFullImageUrl(url)).toBe(url);
   });
+
+  it('returns data URLs unchanged', () => {
+    const url = 'data:image/png;base64,abc';
+    expect(getFullImageUrl(url)).toBe(url);
+  });
 });
 
 describe('formatCurrency', () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -8,7 +8,11 @@ export const getFullImageUrl = (
   relativePath: string | undefined | null,
 ): string | null => {
   if (!relativePath) return null;
-  if (relativePath.startsWith('http://') || relativePath.startsWith('https://')) {
+  if (
+    relativePath.startsWith('http://') ||
+    relativePath.startsWith('https://') ||
+    relativePath.startsWith('data:')
+  ) {
     return relativePath;
   }
 


### PR DESCRIPTION
## Summary
- Allow `getFullImageUrl` to return data URIs without prefixing `/static`
- Test that `getFullImageUrl` leaves data URLs untouched

## Testing
- `npx jest src/lib/__tests__/utils.test.ts`
- `npm test` *(fails: 29 failed, 1 skipped, 84 passed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895dc7ad22c832eaa59fcf3e645da14