### PR TITLE
Refine service listing layout on artist profile

### DIFF
--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -5,12 +5,8 @@ import { Button, Card } from '@/components/ui';
 import { getService } from '@/lib/api';
 import { formatCurrency, getFullImageUrl } from '@/lib/utils';
 
-// This component was updated to fetch the latest service data whenever the card
-// is expanded. It ensures pricing or descriptions changed on the server are
-// reflected immediately without a full page refresh.
-
-// Service details may change often. Fetch the latest data when expanded so
-// displayed information always reflects server values.
+// Fetch the latest service data on mount so pricing and descriptions stay
+// current without requiring a full page refresh.
 
 interface ArtistServiceCardProps {
   service: Service;
@@ -18,7 +14,6 @@ interface ArtistServiceCardProps {
 }
 
 export default function ArtistServiceCard({ service, onBook }: ArtistServiceCardProps) {
-  const [expanded, setExpanded] = useState(false);
   const [currentService, setCurrentService] = useState<Service>(service);
 
   // keep local copy in sync with parent prop
@@ -26,63 +21,67 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
     setCurrentService(service);
   }, [service]);
 
-  // fetch latest details when card is expanded
+  // fetch latest details on mount
   useEffect(() => {
-    if (!expanded) return;
     getService(service.id)
       .then((res) => setCurrentService(res.data))
       .catch((err) => {
         console.error('Failed to refresh service:', err);
       });
-  }, [expanded, service.id]);
+  }, [service.id]);
 
-  const toggle = () => setExpanded((e) => !e);
+  const formatDuration = (minutes: number) => {
+    if (minutes % 60 === 0) {
+      const hours = minutes / 60;
+      return `${hours} hr${hours > 1 ? 's' : ''}`;
+    }
+    return `${minutes} min`;
+  };
 
   return (
-    <Card
-      onClick={toggle}
-      role="listitem"
-      className="p-4 cursor-pointer"
-    >
-      {service.media_url && (
-        <div className="relative w-full h-48 mb-3">
-          <Image
-            src={getFullImageUrl(service.media_url) || service.media_url}
-            alt={service.title}
-            fill
-            className="object-cover rounded-md"
-          />
-        </div>
-      )}
-      <div className="flex justify-between items-center" aria-expanded={expanded}>
-        <h3 className="text-lg font-semibold text-gray-900 pr-2">{service.title}</h3>
-        <Button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onBook(service);
-          }}
-          className="ml-auto"
-          fullWidth={false}
-          title="The artist will respond with a quote"
-        >
-          Request Booking
-        </Button>
-      </div>
-      {expanded && (
-        <div className="mt-2 text-sm text-gray-600" role="region">
-          {currentService.description && <p className="mb-2">{currentService.description}</p>}
-          <p className="text-sm text-gray-500">Type: {currentService.service_type}</p>
-          <div className="mt-2 flex items-center space-x-2">
-            <span className="text-lg font-bold text-gray-800">
+    <Card role="listitem" className="p-4">
+      <div className="flex gap-4">
+        {currentService.media_url && (
+          <div className="relative w-24 h-24 flex-shrink-0">
+            <Image
+              src={
+                getFullImageUrl(currentService.media_url) || currentService.media_url
+              }
+              alt={currentService.title}
+              fill
+              className="object-cover rounded-md"
+            />
+          </div>
+        )}
+        <div className="flex flex-col flex-1">
+          <h3 className="text-lg font-semibold text-gray-900">
+            {currentService.title}
+          </h3>
+          <div className="mt-1 text-sm text-gray-600 flex flex-wrap items-center gap-x-2">
+            <span className="text-base font-semibold text-gray-900">
               {formatCurrency(Number(currentService.price))}
             </span>
-            <span className="text-sm text-gray-500">
-              {currentService.duration_minutes} minutes
-            </span>
+            <span>per guest</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatDuration(currentService.duration_minutes)}</span>
+          </div>
+          {currentService.description && (
+            <p className="mt-1 text-sm text-gray-600">
+              {currentService.description}
+            </p>
+          )}
+          <div className="mt-2">
+            <Button
+              type="button"
+              onClick={() => onBook(currentService)}
+              fullWidth={false}
+              title="The artist will respond with a quote"
+            >
+              Request Booking
+            </Button>
           </div>
         </div>
-      )}
+      </div>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- Display service images as square thumbnails with details and booking button
- Remove "Explore Other Artists" section from profile pages

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 29 failed, 1 skipped, 84 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6895f06d47f4832e98d554061c855b03