### PR TITLE
Handle legacy ARTIST user type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository contains a FastAPI backend and a Next.js frontend.
 
-User roles include `service_provider` (formerly `artist`) and `client`.
+User roles include `service_provider` (formerly `artist`) and `client`. The API
+also accepts the legacy `ARTIST` user type and maps it to `service_provider`
+for backward compatibility.
 
 The July 2025 update bumps key dependencies and Docker base images:
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -11,6 +11,13 @@ class UserType(str, enum.Enum):
     SERVICE_PROVIDER = "service_provider"
     CLIENT = "client"
 
+    @classmethod
+    def _missing_(cls, value: object):
+        """Map legacy enum values to current ones."""
+        if isinstance(value, str) and value.upper() == "ARTIST":
+            return cls.SERVICE_PROVIDER
+        return None
+
 class User(BaseModel):
     __tablename__ = "users"
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -11,6 +11,13 @@ class UserType(str, Enum):
     SERVICE_PROVIDER = "service_provider"
     CLIENT = "client"
 
+    @classmethod
+    def _missing_(cls, value: object):
+        """Map legacy enum values to current ones."""
+        if isinstance(value, str) and value.upper() == "ARTIST":
+            return cls.SERVICE_PROVIDER
+        return None
+
 
 class UserBase(BaseModel):
     email: EmailStr


### PR DESCRIPTION
## Summary
- map legacy `ARTIST` user type to `service_provider` in backend models and schemas
- document that API accepts `ARTIST` as alias for `service_provider`

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6895f13c7120832ea012e964891ab955