### PR TITLE
fix: normalize legacy artist user type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a FastAPI backend and a Next.js frontend.
 
 User roles include `service_provider` (formerly `artist`) and `client`.
 
+On startup the backend now upgrades any legacy `ARTIST` entries in the `users`
+table to the current `SERVICE_PROVIDER` role so existing artists can still log
+in.
+
 The July 2025 update bumps key dependencies and Docker base images:
 
 - **FastAPI** 0.115.12 (requires Starlette 0.46+)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,7 @@ from .db_utils import (
     ensure_calendar_account_email_column,
     ensure_user_profile_picture_column,
     ensure_booking_request_travel_columns,
+    ensure_legacy_artist_user_type,
 )
 from .models.user import User
 from .models.artist_profile_v2 import ArtistProfileV2 as ArtistProfile
@@ -115,6 +116,7 @@ ensure_booking_simple_columns(engine)
 ensure_calendar_account_email_column(engine)
 ensure_user_profile_picture_column(engine)
 ensure_booking_request_travel_columns(engine)
+ensure_legacy_artist_user_type(engine)
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Artist Booking API")


### PR DESCRIPTION
## Summary
- convert legacy `ARTIST` user types to `SERVICE_PROVIDER` during startup
- document automatic upgrade of legacy user roles

## Testing
- `./scripts/test-backend.sh`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: router.replace is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6895f1711ec8832e884942e6cbe5d70c