### PR TITLE
feat: add service categories for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The July 2025 update bumps key dependencies and Docker base images:
   type so searching musicians shows available artists.
 - Category popup now includes an artist name search input for quick navigation to
   individual profiles.
+- Service providers must now choose a service category after registering;
+  categories are managed via the new `/api/v1/service-categories` endpoints.
 - An unobtrusive marketing strip replaces the old Hero section.
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_service_categories.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_service_categories.py
@@ -1,0 +1,69 @@
+"""add service_categories table and service_category_id"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'f23ad0e57c1d'
+branch_labels = None
+depends_on = None
+
+
+CATEGORIES = [
+    {"name": "Photography"},
+    {"name": "Catering"},
+    {"name": "Music"},
+    {"name": "Lighting"},
+    {"name": "Sound"},
+    {"name": "Decor"},
+    {"name": "Venue"},
+    {"name": "Transport"},
+    {"name": "Security"},
+    {"name": "Entertainment"},
+]
+
+
+def upgrade() -> None:
+    op.create_table(
+        'service_categories',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+    )
+    op.add_column(
+        'artist_profiles',
+        sa.Column('service_category_id', sa.Integer(), nullable=True)
+    )
+    op.create_index(
+        op.f('ix_artist_profiles_service_category_id'),
+        'artist_profiles',
+        ['service_category_id'],
+        unique=False,
+    )
+    op.create_foreign_key(
+        'fk_artist_profiles_service_category',
+        'artist_profiles',
+        'service_categories',
+        ['service_category_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+    service_categories_table = sa.table(
+        'service_categories', sa.column('name', sa.String())
+    )
+    op.bulk_insert(service_categories_table, CATEGORIES)
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'fk_artist_profiles_service_category',
+        'artist_profiles',
+        type_='foreignkey',
+    )
+    op.drop_index(
+        op.f('ix_artist_profiles_service_category_id'),
+        table_name='artist_profiles'
+    )
+    op.drop_column('artist_profiles', 'service_category_id')
+    op.drop_table('service_categories')

--- a/backend/app/api/api_service_category.py
+++ b/backend/app/api/api_service_category.py
@@ -1,0 +1,64 @@
+"""API endpoints for service categories."""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.schemas.service_category import (
+    ServiceCategoryResponse,
+    ServiceCategoryCreate,
+    ServiceCategoryUpdate,
+)
+from app.crud import (
+    get_service_categories,
+    get_service_category,
+    create_service_category,
+    update_service_category,
+    remove_service_category,
+)
+from .auth import get_current_user
+from app.models.user import User
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[ServiceCategoryResponse])
+def read_service_categories(db: Session = Depends(get_db)):
+    """Return all available service categories."""
+    return get_service_categories(db)
+
+
+@router.post("/", response_model=ServiceCategoryResponse)
+def create_category(
+    category_in: ServiceCategoryCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Create a new service category."""
+    return create_service_category(db, category_in)
+
+
+@router.put("/{category_id}", response_model=ServiceCategoryResponse)
+def update_category(
+    category_id: int,
+    category_in: ServiceCategoryUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Update an existing service category."""
+    category = get_service_category(db, category_id)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return update_service_category(db, category, category_in)
+
+
+@router.delete("/{category_id}", response_model=ServiceCategoryResponse)
+def delete_category(
+    category_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Delete a service category."""
+    category = remove_service_category(db, category_id)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return category

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -19,6 +19,13 @@ from .crud_quote_template import (
 )
 from . import crud_message
 from . import crud_notification
+from .crud_service_category import (
+    get as get_service_category,
+    get_multi as get_service_categories,
+    create as create_service_category,
+    update as update_service_category,
+    remove as remove_service_category,
+)
 
 # For a cleaner import, you could define __all__ or group them
 # For now, direct import is fine for usage like `crud.user.get` 

--- a/backend/app/crud/crud_service_category.py
+++ b/backend/app/crud/crud_service_category.py
@@ -1,0 +1,47 @@
+"""CRUD operations for service categories."""
+from sqlalchemy.orm import Session
+from app.models.service_category import ServiceCategory
+from app.schemas.service_category import (
+    ServiceCategoryCreate,
+    ServiceCategoryUpdate,
+)
+
+
+def get(db: Session, category_id: int) -> ServiceCategory | None:
+    return (
+        db.query(ServiceCategory)
+        .filter(ServiceCategory.id == category_id)
+        .first()
+    )
+
+
+def get_multi(db: Session) -> list[ServiceCategory]:
+    return db.query(ServiceCategory).all()
+
+
+def create(db: Session, category_in: ServiceCategoryCreate) -> ServiceCategory:
+    category = ServiceCategory(**category_in.model_dump())
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def update(
+    db: Session, db_obj: ServiceCategory, category_in: ServiceCategoryUpdate
+) -> ServiceCategory:
+    for field, value in category_in.model_dump(exclude_unset=True).items():
+        setattr(db_obj, field, value)
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def remove(db: Session, category_id: int) -> ServiceCategory | None:
+    obj = db.query(ServiceCategory).get(category_id)
+    if not obj:
+        return None
+    db.delete(obj)
+    db.commit()
+    return obj

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,6 +61,7 @@ from .api import (
     api_quote,
     api_quote_v2,
     api_sound_provider,
+    api_service_category,
     api_ws,
     api_message,
     api_notification,
@@ -301,6 +302,13 @@ app.include_router(
     api_sound_provider.router,
     prefix=f"{api_prefix}/sound-providers",
     tags=["sound-providers"],
+)
+
+# ─── SERVICE CATEGORY ROUTES (under /api/v1/service-categories) ─────────────
+app.include_router(
+    api_service_category.router,
+    prefix=f"{api_prefix}/service-categories",
+    tags=["service-categories"],
 )
 
 # ─── CALENDAR ROUTES (under /api/v1/google-calendar) ─────────────────────────

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,6 +16,7 @@ from .calendar_account import CalendarAccount, CalendarProvider
 from .email_token import EmailToken
 from .invoice import Invoice, InvoiceStatus
 from .profile_view import ArtistProfileView
+from .service_category import ServiceCategory
 
 __all__ = [
     "User",
@@ -47,4 +48,5 @@ __all__ = [
     "Invoice",
     "InvoiceStatus",
     "ArtistProfileView",
+    "ServiceCategory",
 ]

--- a/backend/app/models/artist_profile_v2.py
+++ b/backend/app/models/artist_profile_v2.py
@@ -26,6 +26,12 @@ class ArtistProfileV2(BaseModel):
     profile_picture_url= Column(String, nullable=True)
     cover_photo_url    = Column(String, nullable=True)
     price_visible      = Column(Boolean, nullable=False, default=True)
+    service_category_id = Column(
+        Integer,
+        ForeignKey("service_categories.id"),
+        nullable=True,
+        index=True,
+    )
 
     # Relationships
     user     = relationship("User", back_populates="artist_profile")
@@ -50,4 +56,9 @@ class ArtistProfileV2(BaseModel):
         "ArtistSoundPreference",
         back_populates="artist",
         cascade="all, delete-orphan",
+    )
+
+    service_category = relationship(
+        "ServiceCategory",
+        back_populates="artists",
     )

--- a/backend/app/models/service_category.py
+++ b/backend/app/models/service_category.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from .base import BaseModel
+
+
+class ServiceCategory(BaseModel):
+    """Represents a top-level category for service providers."""
+
+    __tablename__ = "service_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+
+    # Relationships
+    artists = relationship(
+        "ArtistProfileV2",
+        back_populates="service_category",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -42,6 +42,11 @@ from .notification import (
 )
 from .invoice import InvoiceRead, InvoiceMarkPaid
 from .nlp import BookingParseRequest, ParsedBookingDetails
+from .service_category import (
+    ServiceCategoryCreate,
+    ServiceCategoryUpdate,
+    ServiceCategoryResponse,
+)
 
 __all__ = [
     "UserBase",
@@ -100,4 +105,7 @@ __all__ = [
     "InvoiceMarkPaid",
     "BookingParseRequest",
     "ParsedBookingDetails",
+    "ServiceCategoryCreate",
+    "ServiceCategoryUpdate",
+    "ServiceCategoryResponse",
 ]

--- a/backend/app/schemas/artist.py
+++ b/backend/app/schemas/artist.py
@@ -27,6 +27,7 @@ class ArtistProfileBase(BaseModel):
     profile_picture_url: Optional[str] = None
     cover_photo_url: Optional[str] = None
     price_visible: Optional[bool] = True
+    service_category_id: Optional[int] = None
 
     model_config = {
         # Still needed so that Pydantic can work with ORM objects, but we override below
@@ -56,6 +57,7 @@ class ArtistProfileResponse(ArtistProfileBase):
     rating_count: int = 0
     is_available: Optional[bool] = None
     service_price: Optional[Decimal] = None
+    service_category_id: Optional[int] = None
 
     # We want to include a nested "user" object when returning an artist profile
     user: Optional[UserResponse] = None

--- a/backend/app/schemas/service_category.py
+++ b/backend/app/schemas/service_category.py
@@ -1,0 +1,21 @@
+"""Pydantic schemas for service categories."""
+from typing import Optional
+from pydantic import BaseModel
+
+
+class ServiceCategoryBase(BaseModel):
+    name: str
+
+
+class ServiceCategoryCreate(ServiceCategoryBase):
+    pass
+
+
+class ServiceCategoryUpdate(BaseModel):
+    name: Optional[str] = None
+
+
+class ServiceCategoryResponse(ServiceCategoryBase):
+    id: int
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/test_service_categories.py
+++ b/backend/tests/test_service_categories.py
@@ -1,0 +1,41 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import BaseModel
+from app.models import User, UserType
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.models.service_category import ServiceCategory
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_service_category_linking():
+    db = setup_db()
+    category = ServiceCategory(name="Test Category")
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+
+    user = User(
+        email="a@test.com",
+        password="x",
+        first_name="A",
+        last_name="Artist",
+        user_type=UserType.SERVICE_PROVIDER,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    profile = ArtistProfileV2(user_id=user.id, service_category_id=category.id)
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+
+    assert profile.service_category_id == category.id
+    assert profile.service_category.name == "Test Category"

--- a/frontend/src/app/dashboard/artist/page.tsx
+++ b/frontend/src/app/dashboard/artist/page.tsx
@@ -246,6 +246,10 @@ export default function DashboardPage() {
       router.push('/dashboard/client');
       return;
     }
+    if (!user.service_category_id) {
+      router.push('/register/category');
+      return;
+    }
 
     const fetchDashboardData = async () => {
       try {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,6 +15,13 @@ export default function DashboardRedirectPage() {
       router.replace("/login?next=/dashboard");
       return;
     }
+    if (
+      user.user_type === "service_provider" &&
+      !user.service_category_id
+    ) {
+      router.replace("/register/category");
+      return;
+    }
     if (user.user_type === "service_provider") {
       router.replace("/dashboard/artist");
     } else {

--- a/frontend/src/app/register/__tests__/CategoryPage.test.tsx
+++ b/frontend/src/app/register/__tests__/CategoryPage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SelectCategoryPage from '../category/page';
+import { getServiceCategories, updateMyArtistProfile } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+
+jest.mock('@/lib/api');
+jest.mock('@/contexts/AuthContext', () => ({ useAuth: jest.fn(() => ({ refreshUser: jest.fn() })) }));
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+const mockCategories = [{ id: 1, name: 'Photography' }];
+
+describe('SelectCategoryPage', () => {
+  beforeEach(() => {
+    (getServiceCategories as jest.Mock).mockResolvedValue({ data: mockCategories });
+  });
+
+  it('renders categories', async () => {
+    render(<SelectCategoryPage />);
+    expect(await screen.findByText('Photography')).toBeInTheDocument();
+  });
+
+  it('submits selected category', async () => {
+    (updateMyArtistProfile as jest.Mock).mockResolvedValue({});
+    render(<SelectCategoryPage />);
+    const option = await screen.findByText('Photography');
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => {
+      expect(updateMyArtistProfile).toHaveBeenCalledWith({ service_category_id: 1 });
+    });
+  });
+});

--- a/frontend/src/app/register/category/page.tsx
+++ b/frontend/src/app/register/category/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import MainLayout from '@/components/layout/MainLayout';
+import Button from '@/components/ui/Button';
+import { getServiceCategories, updateMyArtistProfile } from '@/lib/api';
+import { ServiceCategory } from '@/types';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function SelectCategoryPage() {
+  const [categories, setCategories] = useState<ServiceCategory[]>([]);
+  const [selected, setSelected] = useState<number | ''>('');
+  const router = useRouter();
+  const { refreshUser } = useAuth();
+
+  useEffect(() => {
+    getServiceCategories()
+      .then((res) => setCategories(res.data))
+      .catch((err) => console.error('Failed to fetch categories:', err));
+  }, []);
+
+  const handleSave = async () => {
+    if (!selected) return;
+    try {
+      await updateMyArtistProfile({ service_category_id: Number(selected) });
+      if (refreshUser) {
+        await refreshUser();
+      }
+      router.push('/dashboard');
+    } catch (err) {
+      console.error('Failed to update category:', err);
+    }
+  };
+
+  return (
+    <MainLayout>
+      <div className="max-w-xl mx-auto py-8">
+        <h1 className="text-2xl font-bold mb-4">Select Your Service Category</h1>
+        <select
+          className="w-full border rounded p-2 mb-4"
+          value={selected}
+          onChange={(e) => setSelected(Number(e.target.value))}
+        >
+          <option value="">Select category</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <Button onClick={handleSave} disabled={!selected}>
+          Save
+        </Button>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -63,12 +63,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (userData.user_type === 'service_provider') {
       try {
         const profile = await getArtistProfileMe();
-        if (profile.data.profile_picture_url) {
-          userData = {
-            ...userData,
-            profile_picture_url: profile.data.profile_picture_url,
-          };
-        }
+        userData = {
+          ...userData,
+          profile_picture_url: profile.data.profile_picture_url || null,
+          service_category_id: profile.data.service_category_id ?? null,
+        };
       } catch (err) {
         console.error('Failed to fetch artist profile:', err);
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,7 @@ import {
   Notification,
   ThreadNotification,
   ParsedBookingDetails,
+  ServiceCategory,
 } from '@/types';
 import { useAuth as useContextAuth } from '@/contexts/AuthContext'; // Renamed to avoid conflict with default export 'api'
 
@@ -205,6 +206,9 @@ export const getArtistProfileMe = async () => {
 
 export const updateMyArtistProfile = (data: Partial<ArtistProfile>) =>
   api.put(`${API_V1}/artist-profiles/me`, data);
+
+export const getServiceCategories = () =>
+  api.get<ServiceCategory[]>(`${API_V1}/service-categories`);
 
 export const uploadMyArtistProfilePicture = (file: File) => {
   const formData = new FormData();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,7 @@ export interface User {
   is_verified: boolean;
   mfa_enabled?: boolean;
   profile_picture_url?: string | null;
+  service_category_id?: number | null;
 }
 
 export interface ArtistProfile {
@@ -36,9 +37,15 @@ export interface ArtistProfile {
   price_visible?: boolean;
   /** Price of the selected service category when filtering */
   service_price?: number | string | null;
+  service_category_id?: number | null;
   user: User;
   created_at: string;
   updated_at: string;
+}
+
+export interface ServiceCategory {
+  id: number;
+  name: string;
 }
 
 export interface SearchParams {


### PR DESCRIPTION
## Summary
- add service_categories table with initial seed data
- expose CRUD endpoints and profile linkage for provider categories
- redirect new providers to select a service category on first login

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest` *(fails: Interrupted: 63 errors during collection)*
- `npm test` *(fails: Test Suites: 31 failed, 1 skipped, 83 passed, 114 of 115 total)*

------
https://chatgpt.com/codex/tasks/task_e_6895f8b3ac3c832ea34e417dec49208f