### PR TITLE
feat: refine artist profile layout

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -172,9 +172,9 @@ export default function ArtistProfilePage() {
       <MainLayout hideFooter>
         <div className="md:flex md:h-[calc(100vh-4rem)] md:overflow-hidden bg-white">
           {/* Left Panel: image and host details */}
-          <aside className="md:w-2/5 md:flex md:flex-col bg-white">
+          <aside className="md:w-2/5 md:flex md:flex-col bg-white md:pt-6">
             <div
-              className="relative h-40 md:flex-grow overflow-hidden rounded-3xl"
+              className="relative h-32 md:h-48 overflow-hidden rounded-3xl"
               role="img"
               aria-label="Cover photo"
             >

--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -39,7 +39,7 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
   };
 
   return (
-    <Card role="listitem" className="p-4">
+    <Card role="listitem" className="p-4 border-none shadow-sm hover:shadow-sm">
       <div className="flex gap-4">
         {currentService.media_url && (
           <div className="relative w-24 h-24 flex-shrink-0">


### PR DESCRIPTION
## Summary
- align artist profile sections and shrink cover photo
- remove card borders and hover effects for artist services

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 31 failed, 52 failed tests)*
- `./scripts/test-all.sh` *(fails: frontend tests 31 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6895fce16fa4832eaea578cfe592cfc4