### PR TITLE
fix: prevent left panel scroll on artist page

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -135,6 +135,9 @@ export default function ArtistProfilePage() {
 
   // Scroll the right panel when the user scrolls over the left section
   const handleLeftScroll = (e: WheelEvent) => {
+    // Prevent default scrolling on the left panel to avoid page jumps
+    e.preventDefault();
+    e.stopPropagation();
     if (rightPanelRef.current) {
       rightPanelRef.current.scrollBy({ top: e.deltaY });
     }
@@ -180,7 +183,7 @@ export default function ArtistProfilePage() {
       <MainLayout hideFooter>
         <div className="md:flex md:h-[calc(100vh-4rem)] md:overflow-hidden bg-white">
           {/* Left Panel: image and host details */}
-          <aside className="md:w-2/5 md:flex md:flex-col bg-white md:pt-6" onWheel={handleLeftScroll}>
+          <aside className="md:w-2/5 md:flex md:flex-col bg-white md:pt-6 md:overflow-hidden" onWheel={handleLeftScroll}>
             <div
               className="relative h-32 md:h-48 overflow-hidden rounded-3xl mx-6"
               role="img"


### PR DESCRIPTION
## Summary
- stop left-side scroll from triggering page jumps on artist profile

## Testing
- `SKIP_BACKEND=1 ./scripts/test-all.sh` *(fails: 30 failed, 1 skipped, 84 passed, 114 of 115 total)*

------
https://chatgpt.com/codex/tasks/task_e_6896059a6ff4832eaac487c257629cc7