### PR TITLE
fix: constrain left panel scroll on artist page

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -133,13 +133,24 @@ export default function ArtistProfilePage() {
     setSelectedService(null);
   };
 
-  // Scroll the right panel when the user scrolls over the left section
+  // Scroll the right panel when the user scrolls over the left section.
+  // Only allow the main page to scroll once the right panel reaches an edge
   const handleLeftScroll = (e: WheelEvent) => {
-    // Prevent default scrolling on the left panel to avoid page jumps
-    e.preventDefault();
-    e.stopPropagation();
-    if (rightPanelRef.current) {
-      rightPanelRef.current.scrollBy({ top: e.deltaY });
+    if (!rightPanelRef.current) return;
+
+    const rightPanel = rightPanelRef.current;
+    const { scrollTop, scrollHeight, clientHeight } = rightPanel;
+    const atTop = scrollTop === 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight;
+
+    const scrollingUp = e.deltaY < 0;
+    const scrollingDown = e.deltaY > 0;
+
+    // If the right panel can scroll in the desired direction, handle it here
+    if ((scrollingUp && !atTop) || (scrollingDown && !atBottom)) {
+      e.preventDefault();
+      e.stopPropagation();
+      rightPanel.scrollBy({ top: e.deltaY });
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent artist page from scrolling when cursor is over left panel unless right panel at top/bottom

## Testing
- `pytest`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68960fc3dc54832ea71a15142941e65b