### PR TITLE
feat: modular booking flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,9 +892,13 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Travel estimates now include artist-specified car rental and flight prices when provided.
 * Success toasts when saving a draft or submitting a request.
 * Simplified buttons sit below each step in a responsive button group. On phones
-  the order is **Next**, **Save Draft**, **Back** but remains **Back**, **Save Draft**,
+  the order is **Next**, **Save Draft**, **Back** but remains **Back**, **Save Draft**, 
   **Next** on larger screens.
 * Guests step now matches the others with Back, Save Draft, and Next buttons.
+* Step lists now come from a category-based `bookingFlowRegistry`, so musicians,
+  photographers, and videographers follow tailored flows.
+* Booking requests persist category-specific fields in a new `details` JSON
+  payload.
 * Attachment uploads in the notes step display a progress bar and disable the Next button until finished.
 * Collapsible sections ensure only the active step is expanded on phones.
 * Mobile devices use native date and time pickers for faster input.

--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -30,6 +30,7 @@ class BookingRequest(Base):
     travel_mode = Column(String, nullable=True)
     travel_cost = Column(Numeric(10, 2), nullable=True)
     travel_breakdown = Column(JSON, nullable=True)
+    details = Column(JSON, nullable=True)
     
     status = Column(SQLAlchemyEnum(BookingStatus), nullable=False, default=BookingStatus.PENDING_QUOTE)
 

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -21,6 +21,7 @@ class BookingRequestBase(BaseModel):
     travel_mode: Optional[str] = None
     travel_cost: Optional[Decimal] = None
     travel_breakdown: Optional[dict] = None
+    details: Optional[dict] = None
 
 class BookingRequestCreate(BookingRequestBase):
     artist_id: int # Client must specify the artist they are requesting
@@ -35,6 +36,7 @@ class BookingRequestUpdateByClient(BaseModel): # Client can withdraw or update m
     travel_mode: Optional[str] = None
     travel_cost: Optional[Decimal] = None
     travel_breakdown: Optional[dict] = None
+    details: Optional[dict] = None
     status: Optional[BookingStatus] = None # e.g. REQUEST_WITHDRAWN
 
 class BookingRequestUpdateByArtist(BaseModel): # Artist can decline
@@ -50,6 +52,7 @@ class BookingRequestResponse(BookingRequestBase):
     travel_mode: Optional[str] = None
     travel_cost: Optional[Decimal] = None
     travel_breakdown: Optional[dict] = None
+    details: Optional[dict] = None
     
     client: Optional[UserResponse] = None
     artist: Optional[UserResponse] = None  # Original artist user details

--- a/docs/booking_wizard_layout.md
+++ b/docs/booking_wizard_layout.md
@@ -39,6 +39,6 @@ This snippet demonstrates the HTML structure and Tailwind CSS classes for the bo
 </main>
 ```
 
-The stepper text is bright red for the active step and muted gray for the rest. On small screens, the stepper stacks above the card and remains centered. On larger screens, the card keeps a consistent width and minimum height across all steps so the layout doesn't shift as you progress.
+The stepper text is bright red for the active step and muted gray for the rest. On small screens, the stepper stacks above the card and remains centered. On larger screens, the card keeps a consistent width and minimum height across all steps so the layout doesn't shift as you progress. The exact set of steps is loaded from a `bookingFlowRegistry` based on the provider's service category so musicians, photographers, and videographers see tailored flows.
 
 Navigation controls live in a sticky footer so the primary actions remain visible even when the form scrolls. Each button has a minimum tap area of 44×44 px to satisfy mobile accessibility guidelines. Heavy widgets such as the map preview and calendar picker are loaded lazily once their sections expand, keeping the initial payload light on mobile connections.

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import React, { useEffect, useState, useRef, Fragment, useCallback } from 'react';
+import React, { useEffect, useState, useRef, Fragment, useCallback, type ComponentType } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
-import * as yup from 'yup';
 
 import { useBooking } from '@/contexts/BookingContext';
 import { useAuth } from '@/contexts/AuthContext';
@@ -27,8 +26,7 @@ import { BookingRequestCreate } from '@/types';
 import Stepper from '../ui/Stepper';
 import ProgressBar from '../ui/ProgressBar';
 import toast from '../ui/Toast';
-
-// --- Step Components ---
+import { bookingFlowRegistry, type BookingFlowModule } from './bookingFlowRegistry';
 import EventDescriptionStep from './steps/EventDescriptionStep';
 import LocationStep from './steps/LocationStep';
 import DateTimeStep from './steps/DateTimeStep';
@@ -37,7 +35,7 @@ import GuestsStep from './steps/GuestsStep';
 import VenueStep from './steps/VenueStep';
 import SoundStep from './steps/SoundStep';
 import NotesStep from './steps/NotesStep';
-import ReviewStep from './steps/ReviewStep'; // Ensure this is the modified one
+import ReviewStep from './steps/ReviewStep';
 
 // --- EventDetails Type & Schema ---
 type EventDetails = {
@@ -52,35 +50,6 @@ type EventDetails = {
   notes?: string;
   attachment_url?: string;
 };
-
-const schema = yup.object<EventDetails>().shape({
-  eventType: yup.string().required('Event type is required.'),
-  eventDescription: yup.string().required('Event description is required.').min(5, 'Description must be at least 5 characters.'),
-  date: yup.date().required('Date is required.').min(new Date(), 'Date cannot be in the past.'),
-  time: yup.string().optional(),
-  location: yup.string().required('Location is required.'),
-  guests: yup.string().required('Number of guests is required.').matches(/^\d+$/, 'Guests must be a number.'),
-  venueType: yup
-    .mixed<'indoor' | 'outdoor' | 'hybrid'>()
-    .oneOf(['indoor', 'outdoor', 'hybrid'], 'Venue type is required.')
-    .required(),
-  sound: yup.string().oneOf(['yes', 'no'], 'Sound equipment preference is required.').required(),
-  notes: yup.string().optional(),
-  attachment_url: yup.string().optional(),
-});
-
-// --- Wizard Steps & Instructions ---
-const steps = [
-  'Event Details',
-  'Location',
-  'Date & Time',
-  'Event Type',
-  'Guests',
-  'Venue Type',
-  'Sound',
-  'Notes',
-  'Review',
-];
 
 
 // --- Animation Variants ---
@@ -116,6 +85,8 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   } = useBooking();
   const { user } = useAuth();
 
+  const [flow, setFlow] = useState<BookingFlowModule>(bookingFlowRegistry.musician);
+
   // --- Component States ---
   const [unavailable, setUnavailable] = useState<string[]>([]);
   const [artistLocation, setArtistLocation] = useState<string | null>(null);
@@ -130,7 +101,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
   const isMobile = useIsMobile();
   // Convert zero-based step index to progress percentage for the mobile progress bar.
-  const progressValue = ((step + 1) / steps.length) * 100;
+  const progressValue = ((step + 1) / flow.steps.length) * 100;
   const hasLoaded = useRef(false);
 
   // --- Form Hook (React Hook Form + Yup) ---
@@ -141,7 +112,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
     setValue,
     watch,
     errors, // Directly destructure errors, assuming useBookingForm returns it at top level
-  } = useBookingForm(schema, details, setDetails);
+  } = useBookingForm(flow.validationSchema as any, details, setDetails);
 
   // --- Effects ---
 
@@ -162,6 +133,12 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
         ]);
         setUnavailable(availabilityRes.data.unavailable_dates);
         setArtistLocation(artistRes.data.location || null);
+        const categoryKey = artistRes.data.service_category?.name?.toLowerCase();
+        if (categoryKey && bookingFlowRegistry[categoryKey]) {
+          setFlow(bookingFlowRegistry[categoryKey]);
+          setStep(0);
+          setMaxStepCompleted(0);
+        }
       } catch (err) {
         console.error('Failed to fetch artist data:', err);
       }
@@ -289,7 +266,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
     if (e.key !== 'Enter' || e.shiftKey || isMobile) return;
     e.preventDefault();
-    if (step < steps.length - 1) {
+    if (step < flow.steps.length - 1) {
       void next();
     } else {
       // For the review step, the submit is handled by the ReviewStep component's internal button
@@ -299,20 +276,24 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
   // Navigates to the next step after validation
   const next = async () => {
-    const stepFields: (keyof EventDetails)[][] = [
-      ['eventDescription'],
-      ['location'],
-      ['date'],
-      ['eventType'],
-      ['guests'],
-      ['venueType'],
-      ['sound'],
-      [],
-      [], // Review step has no fields to validate for "next"
-    ];
-    const fieldsToValidate = stepFields[step] as (keyof EventDetails)[];
+    const validationMap = new Map<ComponentType<any>, (keyof EventDetails)[]>([
+      [EventDescriptionStep, ['eventDescription']],
+      [LocationStep, ['location']],
+      [DateTimeStep, ['date']],
+      [EventTypeStep, ['eventType']],
+      [GuestsStep, ['guests']],
+      [VenueStep, ['venueType']],
+      [SoundStep, ['sound']],
+      [NotesStep, []],
+      [ReviewStep, []],
+    ]);
+    const fieldsToValidate =
+      validationMap.get(flow.steps[step]?.component) ?? [];
 
-    const valid = fieldsToValidate.length > 0 ? await trigger(fieldsToValidate) : true;
+    const valid =
+      fieldsToValidate.length > 0
+        ? await trigger(fieldsToValidate)
+        : true;
 
     if (valid) {
       const newStep = step + 1;
@@ -351,6 +332,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       travel_mode: travelResult?.mode,
       travel_cost: travelResult?.totalCost,
       travel_breakdown: travelResult?.breakdown,
+      details: {
+        event_type: vals.eventType,
+        event_description: vals.eventDescription,
+        guests: vals.guests,
+        venue_type: vals.venueType,
+        ...(vals.sound ? { sound: vals.sound } : {}),
+      },
     };
     try {
       if (requestId) {
@@ -391,6 +379,13 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       travel_mode: travelResult.mode,
       travel_cost: travelResult.totalCost,
       travel_breakdown: travelResult.breakdown,
+      details: {
+        event_type: vals.eventType,
+        event_description: vals.eventDescription,
+        guests: vals.guests,
+        venue_type: vals.venueType,
+        ...(vals.sound ? { sound: vals.sound } : {}),
+      },
     };
 
     try {
@@ -402,8 +397,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       if (!id) throw new Error('Missing booking request ID after creation/update.');
 
       await postMessageToBookingRequest(id, {
-        content: `Booking details:\nEvent Type: ${vals.eventType || 'N/A'}\nDescription: ${vals.eventDescription || 'N/A'}\nDate: ${vals.date?.toLocaleDateString() || 'N/A'}\nLocation: ${vals.location || 'N/A'}\nGuests: ${vals.guests || 'N/A'}\nVenue: ${vals.venueType || 'N/A'}\nSound: ${vals.sound || 'N/A'}\nNotes: ${vals.notes || 'N/A'}`,
-        // Backend expects uppercase message types.
+        content: flow.buildSummary(vals),
         message_type: 'SYSTEM',
       });
 
@@ -420,54 +414,38 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
 
   // --- Render Step Logic ---
   const renderStep = () => {
-    switch (step) {
-      case 0:
-        return (
-          <EventDescriptionStep
-            control={control}
-            setValue={setValue}
-            watch={watch}
-          />
-        );
-      case 1:
-        return (
-          <LocationStep
-            control={control}
-            artistLocation={artistLocation}
-            setWarning={setWarning}
-          />
-        );
-      case 2:
-        return <DateTimeStep control={control} unavailable={unavailable} />;
-      case 3:
-        return <EventTypeStep control={control} />;
-      case 4:
-        return <GuestsStep control={control} />;
-      case 5:
-        return <VenueStep control={control} />;
-      case 6:
-        return <SoundStep control={control} />;
-      case 7:
-        return <NotesStep control={control} setValue={setValue} />;
-      case 8:
-        return (
-          <ReviewStep
-            step={step}
-            steps={steps}
-            onBack={prev}
-            onSaveDraft={saveDraft}
-          onNext={submitRequest}
-          submitting={submitting}
-          isLoadingReviewData={isLoadingReviewData}
-          reviewDataError={reviewDataError}
-          calculatedPrice={calculatedPrice}
-          travelResult={travelResult}
-          submitLabel="Submit Request"
-          baseServicePrice={baseServicePrice}
-        />
-      );
-      default: return null;
+    const StepComponent = flow.steps[step]?.component;
+    if (!StepComponent) return null;
+    const stepProps: any = { control };
+    if (StepComponent === EventDescriptionStep) {
+      stepProps.setValue = setValue;
+      stepProps.watch = watch;
     }
+    if (StepComponent === LocationStep) {
+      stepProps.artistLocation = artistLocation;
+      stepProps.setWarning = setWarning;
+    }
+    if (StepComponent === DateTimeStep) {
+      stepProps.unavailable = unavailable;
+    }
+    if (StepComponent === NotesStep) {
+      stepProps.setValue = setValue;
+    }
+    if (StepComponent === ReviewStep) {
+      stepProps.step = step;
+      stepProps.steps = flow.steps.map((s) => s.label);
+      stepProps.onBack = prev;
+      stepProps.onSaveDraft = saveDraft;
+      stepProps.onNext = submitRequest;
+      stepProps.submitting = submitting;
+      stepProps.isLoadingReviewData = isLoadingReviewData;
+      stepProps.reviewDataError = reviewDataError;
+      stepProps.calculatedPrice = calculatedPrice;
+      stepProps.travelResult = travelResult;
+      stepProps.submitLabel = 'Submit Request';
+      stepProps.baseServicePrice = baseServicePrice;
+    }
+    return <StepComponent {...stepProps} />;
   };
 
   if (!isOpen) return null;
@@ -498,7 +476,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                 />
               ) : (
                 <Stepper
-                  steps={steps}
+                  steps={flow.steps.map((s) => s.label)}
                   currentStep={step}
                   maxStepCompleted={maxStepCompleted}
                   onStepClick={setStep}
@@ -552,7 +530,7 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                 </button>
 
                 {/* Conditional rendering for Next button (only if not on Review Step) */}
-                {step < steps.length - 1 && (
+                {step < flow.steps.length - 1 && (
                   <button
                     type="button" // Ensure it's a button, not a submit
                     onClick={next}

--- a/frontend/src/components/booking/bookingFlowRegistry.ts
+++ b/frontend/src/components/booking/bookingFlowRegistry.ts
@@ -1,0 +1,104 @@
+import type { ReactElement } from 'react';
+import * as yup from 'yup';
+
+import EventDescriptionStep from './steps/EventDescriptionStep';
+import LocationStep from './steps/LocationStep';
+import DateTimeStep from './steps/DateTimeStep';
+import EventTypeStep from './steps/EventTypeStep';
+import GuestsStep from './steps/GuestsStep';
+import VenueStep from './steps/VenueStep';
+import SoundStep from './steps/SoundStep';
+import NotesStep from './steps/NotesStep';
+import ReviewStep from './steps/ReviewStep';
+
+export interface BookingFlowStep {
+  label: string;
+  component: (props: any) => ReactElement | null;
+}
+
+export interface BookingFlowModule {
+  steps: BookingFlowStep[];
+  validationSchema: yup.ObjectSchema<any>;
+  buildSummary: (details: Record<string, any>) => string;
+}
+
+const musicianSchema = yup.object().shape({
+  eventType: yup.string().required('Event type is required.'),
+  eventDescription: yup
+    .string()
+    .required('Event description is required.')
+    .min(5, 'Description must be at least 5 characters.'),
+  date: yup.date().required('Date is required.').min(new Date(), 'Date cannot be in the past.'),
+  time: yup.string().optional(),
+  location: yup.string().required('Location is required.'),
+  guests: yup.string().required('Number of guests is required.').matches(/^\d+$/, 'Guests must be a number.'),
+  venueType: yup
+    .mixed<'indoor' | 'outdoor' | 'hybrid'>()
+    .oneOf(['indoor', 'outdoor', 'hybrid'], 'Venue type is required.')
+    .required(),
+  sound: yup.string().oneOf(['yes', 'no'], 'Sound equipment preference is required.').required(),
+  notes: yup.string().optional(),
+  attachment_url: yup.string().optional(),
+});
+
+const baseSchema = yup.object().shape({
+  eventType: yup.string().required('Event type is required.'),
+  eventDescription: yup
+    .string()
+    .required('Event description is required.')
+    .min(5, 'Description must be at least 5 characters.'),
+  date: yup.date().required('Date is required.').min(new Date(), 'Date cannot be in the past.'),
+  time: yup.string().optional(),
+  location: yup.string().required('Location is required.'),
+  guests: yup.string().required('Number of guests is required.').matches(/^\d+$/, 'Guests must be a number.'),
+  venueType: yup
+    .mixed<'indoor' | 'outdoor' | 'hybrid'>()
+    .oneOf(['indoor', 'outdoor', 'hybrid'], 'Venue type is required.')
+    .required(),
+  notes: yup.string().optional(),
+  attachment_url: yup.string().optional(),
+});
+
+const musicianFlow: BookingFlowModule = {
+  steps: [
+    { label: 'Event Details', component: EventDescriptionStep },
+    { label: 'Location', component: LocationStep },
+    { label: 'Date & Time', component: DateTimeStep },
+    { label: 'Event Type', component: EventTypeStep },
+    { label: 'Guests', component: GuestsStep },
+    { label: 'Venue Type', component: VenueStep },
+    { label: 'Sound', component: SoundStep },
+    { label: 'Notes', component: NotesStep },
+    { label: 'Review', component: ReviewStep },
+  ],
+  validationSchema: musicianSchema,
+  buildSummary: (d) =>
+    `Booking details:\nEvent Type: ${d.eventType || 'N/A'}\nDescription: ${d.eventDescription || 'N/A'}\nDate: ${d.date?.toLocaleDateString() || 'N/A'}\nLocation: ${d.location || 'N/A'}\nGuests: ${d.guests || 'N/A'}\nVenue: ${d.venueType || 'N/A'}\nSound: ${d.sound || 'N/A'}\nNotes: ${d.notes || 'N/A'}`,
+};
+
+const photographerFlow: BookingFlowModule = {
+  steps: [
+    { label: 'Event Details', component: EventDescriptionStep },
+    { label: 'Location', component: LocationStep },
+    { label: 'Date & Time', component: DateTimeStep },
+    { label: 'Event Type', component: EventTypeStep },
+    { label: 'Guests', component: GuestsStep },
+    { label: 'Venue Type', component: VenueStep },
+    { label: 'Notes', component: NotesStep },
+    { label: 'Review', component: ReviewStep },
+  ],
+  validationSchema: baseSchema,
+  buildSummary: (d) =>
+    `Booking details:\nEvent Type: ${d.eventType || 'N/A'}\nDescription: ${d.eventDescription || 'N/A'}\nDate: ${d.date?.toLocaleDateString() || 'N/A'}\nLocation: ${d.location || 'N/A'}\nGuests: ${d.guests || 'N/A'}\nVenue: ${d.venueType || 'N/A'}\nNotes: ${d.notes || 'N/A'}`,
+};
+
+const videographerFlow: BookingFlowModule = {
+  ...photographerFlow,
+};
+
+export const bookingFlowRegistry: Record<string, BookingFlowModule> = {
+  musician: musicianFlow,
+  photographer: photographerFlow,
+  videographer: videographerFlow,
+};
+

--- a/frontend/src/contexts/BookingContext.tsx
+++ b/frontend/src/contexts/BookingContext.tsx
@@ -10,7 +10,7 @@ export interface EventDetails {
   location: string;
   guests: string;
   venueType: 'indoor' | 'outdoor' | 'hybrid';
-  sound: 'yes' | 'no';
+  sound?: 'yes' | 'no';
   notes?: string;
   attachment_url?: string;
 }
@@ -42,7 +42,7 @@ const initialDetails: EventDetails = {
   location: '',
   guests: '',
   venueType: 'indoor',
-  sound: 'yes',
+  sound: undefined,
   attachment_url: '',
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -148,6 +148,7 @@ export interface BookingRequestCreate {
   travel_mode?: 'fly' | 'drive';
   travel_cost?: number;
   travel_breakdown?: Record<string, unknown>;
+  details?: Record<string, unknown>;
 }
 
 export interface ParsedBookingDetails {
@@ -175,6 +176,7 @@ export interface BookingRequest {
   travel_mode?: 'fly' | 'drive' | null;
   travel_cost?: number | null;
   travel_breakdown?: Record<string, unknown> | null;
+  details?: Record<string, unknown> | null;
   status: BookingStatus;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- add bookingFlowRegistry with musician, photographer, and videographer flows
- dynamically load category-based steps and schemas in BookingWizard
- persist category-specific details via new `details` JSON field

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68960fb5da88832eb0fa191bb07b1298