### PR TITLE
Fix service media image on artist page

### DIFF
--- a/frontend/src/__tests__/ArtistServiceCard.test.tsx
+++ b/frontend/src/__tests__/ArtistServiceCard.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import ArtistServiceCard from '@/components/artist/ArtistServiceCard';
+import type { Service } from '@/types';
+
+describe('ArtistServiceCard', () => {
+  const baseService: Service = {
+    id: 1,
+    artist_id: 1,
+    title: 'Test Service',
+    description: 'desc',
+    media_url: '/test.jpg',
+    service_type: 'Live Performance',
+    duration_minutes: 60,
+    display_order: 1,
+    price: 100,
+    artist: {} as any,
+  };
+
+  it('renders service media image when media_url is provided', () => {
+    render(<ArtistServiceCard service={baseService} onBook={jest.fn()} />);
+    const img = screen.getByRole('img', { name: baseService.title });
+    expect(img).toBeTruthy();
+  });
+});

--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -42,7 +42,7 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
     <Card role="listitem" className="p-4 border-none shadow-sm hover:shadow-sm">
       <div className="flex gap-4">
         {currentService.media_url && (
-          <div className="relative w-30 h-30 flex-shrink-0">
+          <div className="relative w-32 h-32 flex-shrink-0 pr-4">
             <Image
               src={
                 getFullImageUrl(currentService.media_url) || currentService.media_url


### PR DESCRIPTION
## Summary
- Ensure service media image renders at fixed size with right padding in artist service cards
- Add unit test verifying service media images appear

## Testing
- `npm test src/__tests__/ArtistServiceCard.test.tsx`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Test Suites: 30 failed, 1 skipped, 85 passed)*
- `cd backend && pytest` *(fails: 63 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689611a8d588832e977e8080ec0e88da