### PR TITLE
feat: add category booking flows

### DIFF
--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -30,6 +30,7 @@ class BookingRequest(Base):
     travel_mode = Column(String, nullable=True)
     travel_cost = Column(Numeric(10, 2), nullable=True)
     travel_breakdown = Column(JSON, nullable=True)
+    details = Column(JSON, nullable=True)
     
     status = Column(SQLAlchemyEnum(BookingStatus), nullable=False, default=BookingStatus.PENDING_QUOTE)
 

--- a/backend/app/schemas/request_quote.py
+++ b/backend/app/schemas/request_quote.py
@@ -21,6 +21,7 @@ class BookingRequestBase(BaseModel):
     travel_mode: Optional[str] = None
     travel_cost: Optional[Decimal] = None
     travel_breakdown: Optional[dict] = None
+    details: Optional[dict] = None
 
 class BookingRequestCreate(BookingRequestBase):
     artist_id: int # Client must specify the artist they are requesting
@@ -35,6 +36,7 @@ class BookingRequestUpdateByClient(BaseModel): # Client can withdraw or update m
     travel_mode: Optional[str] = None
     travel_cost: Optional[Decimal] = None
     travel_breakdown: Optional[dict] = None
+    details: Optional[dict] = None
     status: Optional[BookingStatus] = None # e.g. REQUEST_WITHDRAWN
 
 class BookingRequestUpdateByArtist(BaseModel): # Artist can decline

--- a/frontend/src/components/booking/flows/index.ts
+++ b/frontend/src/components/booking/flows/index.ts
@@ -1,0 +1,12 @@
+import { BookingFlow } from './types';
+import musician from './musician';
+import photographer from './photographer';
+import videographer from './videographer';
+
+export const bookingFlowRegistry: Record<string, BookingFlow> = {
+  musician,
+  photographer,
+  videographer,
+};
+
+export type { BookingFlow } from './types';

--- a/frontend/src/components/booking/flows/musician.tsx
+++ b/frontend/src/components/booking/flows/musician.tsx
@@ -1,0 +1,147 @@
+import * as yup from 'yup';
+import EventDescriptionStep from '../steps/EventDescriptionStep';
+import LocationStep from '../steps/LocationStep';
+import DateTimeStep from '../steps/DateTimeStep';
+import EventTypeStep from '../steps/EventTypeStep';
+import GuestsStep from '../steps/GuestsStep';
+import VenueStep from '../steps/VenueStep';
+import SoundStep from '../steps/SoundStep';
+import NotesStep from '../steps/NotesStep';
+import ReviewStep from '../steps/ReviewStep';
+import { BookingFlow, BookingStepContext } from './types';
+
+const flow: BookingFlow = [
+  {
+    name: 'Event Details',
+    render: ({ control, setValue, watch }: BookingStepContext) => (
+      <EventDescriptionStep control={control} setValue={setValue} watch={watch} />
+    ),
+    validation: {
+      eventDescription: yup
+        .string()
+        .required('Event description is required.')
+        .min(5, 'Description must be at least 5 characters.'),
+    },
+    fieldsToValidate: ['eventDescription'],
+    buildSummary: (v) => ({ eventDescription: v.eventDescription }),
+  },
+  {
+    name: 'Location',
+    render: ({ control, artistLocation, setWarning }: BookingStepContext) => (
+      <LocationStep control={control} artistLocation={artistLocation} setWarning={setWarning} />
+    ),
+    validation: {
+      location: yup.string().required('Location is required.'),
+    },
+    fieldsToValidate: ['location'],
+    buildSummary: (v) => ({ location: v.location }),
+  },
+  {
+    name: 'Date & Time',
+    render: ({ control, unavailable }: BookingStepContext) => (
+      <DateTimeStep control={control} unavailable={unavailable} />
+    ),
+    validation: {
+      date: yup
+        .date()
+        .required('Date is required.')
+        .min(new Date(), 'Date cannot be in the past.'),
+      time: yup.string().optional(),
+    },
+    fieldsToValidate: ['date'],
+    buildSummary: (v) => ({ date: v.date, time: v.time }),
+  },
+  {
+    name: 'Event Type',
+    render: ({ control }: BookingStepContext) => <EventTypeStep control={control} />,
+    validation: {
+      eventType: yup.string().required('Event type is required.'),
+    },
+    fieldsToValidate: ['eventType'],
+    buildSummary: (v) => ({ eventType: v.eventType }),
+  },
+  {
+    name: 'Guests',
+    render: ({ control }: BookingStepContext) => <GuestsStep control={control} />,
+    validation: {
+      guests: yup
+        .string()
+        .required('Number of guests is required.')
+        .matches(/^\d+$/, 'Guests must be a number.'),
+    },
+    fieldsToValidate: ['guests'],
+    buildSummary: (v) => ({ guests: v.guests }),
+  },
+  {
+    name: 'Venue Type',
+    render: ({ control }: BookingStepContext) => <VenueStep control={control} />,
+    validation: {
+      venueType: yup
+        .mixed<'indoor' | 'outdoor' | 'hybrid'>()
+        .oneOf(['indoor', 'outdoor', 'hybrid'], 'Venue type is required.')
+        .required(),
+    },
+    fieldsToValidate: ['venueType'],
+    buildSummary: (v) => ({ venueType: v.venueType }),
+  },
+  {
+    name: 'Sound',
+    render: ({ control }: BookingStepContext) => <SoundStep control={control} />,
+    validation: {
+      sound: yup
+        .string()
+        .oneOf(['yes', 'no'], 'Sound equipment preference is required.')
+        .required(),
+    },
+    fieldsToValidate: ['sound'],
+    buildSummary: (v) => ({ sound: v.sound }),
+  },
+  {
+    name: 'Notes',
+    render: ({ control, setValue }: BookingStepContext) => (
+      <NotesStep control={control} setValue={setValue} />
+    ),
+    validation: {
+      notes: yup.string().optional(),
+      attachment_url: yup.string().optional(),
+    },
+    fieldsToValidate: [],
+    buildSummary: (v) => ({ notes: v.notes, attachment_url: v.attachment_url }),
+  },
+  {
+    name: 'Review',
+    render: ({
+      step,
+      steps,
+      onBack,
+      onSaveDraft,
+      onNext,
+      submitting,
+      isLoadingReviewData,
+      reviewDataError,
+      calculatedPrice,
+      travelResult,
+      baseServicePrice,
+    }: BookingStepContext) => (
+      <ReviewStep
+        step={step}
+        steps={steps}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        onNext={onNext}
+        submitting={submitting}
+        isLoadingReviewData={isLoadingReviewData}
+        reviewDataError={reviewDataError}
+        calculatedPrice={calculatedPrice}
+        travelResult={travelResult}
+        submitLabel="Submit Request"
+        baseServicePrice={baseServicePrice}
+      />
+    ),
+    validation: {},
+    fieldsToValidate: [],
+    buildSummary: () => ({}),
+  },
+];
+
+export default flow;

--- a/frontend/src/components/booking/flows/photographer.ts
+++ b/frontend/src/components/booking/flows/photographer.ts
@@ -1,0 +1,2 @@
+import flow from './musician';
+export default flow;

--- a/frontend/src/components/booking/flows/types.ts
+++ b/frontend/src/components/booking/flows/types.ts
@@ -1,0 +1,38 @@
+import * as yup from 'yup';
+import { EventDetails } from '@/contexts/BookingContext';
+
+/** Context passed to each step module's render function. */
+export interface BookingStepContext {
+  control: any;
+  setValue: any;
+  watch: any;
+  unavailable: string[];
+  artistLocation: string | null;
+  setWarning: (msg: string | null) => void;
+  step: number;
+  steps: string[];
+  onBack: () => void;
+  onSaveDraft: () => void;
+  onNext: () => void;
+  submitting: boolean;
+  isLoadingReviewData: boolean;
+  reviewDataError: string | null;
+  calculatedPrice: number | null;
+  travelResult: any;
+  baseServicePrice: number;
+}
+
+/** Definition of a booking step module. */
+export interface BookingStepModule {
+  name: string;
+  /** Render the step component. */
+  render: (ctx: BookingStepContext) => JSX.Element;
+  /** Yup field validations applied for this step. */
+  validation: Record<string, yup.AnySchema>;
+  /** Fields to validate before moving to the next step. */
+  fieldsToValidate: (keyof EventDetails)[];
+  /** Extracts data for the backend `details` payload. */
+  buildSummary: (values: EventDetails) => Record<string, unknown>;
+}
+
+export type BookingFlow = BookingStepModule[];

--- a/frontend/src/components/booking/flows/videographer.ts
+++ b/frontend/src/components/booking/flows/videographer.ts
@@ -1,0 +1,2 @@
+import flow from './musician';
+export default flow;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -148,6 +148,7 @@ export interface BookingRequestCreate {
   travel_mode?: 'fly' | 'drive';
   travel_cost?: number;
   travel_breakdown?: Record<string, unknown>;
+  details?: Record<string, unknown>;
 }
 
 export interface ParsedBookingDetails {
@@ -175,6 +176,7 @@ export interface BookingRequest {
   travel_mode?: 'fly' | 'drive' | null;
   travel_cost?: number | null;
   travel_breakdown?: Record<string, unknown> | null;
+  details?: Record<string, unknown> | null;
   status: BookingStatus;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
- support category-specific booking flows with step modules
- persist provider-specific booking details in requests
- expose details payload on frontend and backend types

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896163d3eb8832e8749931f6f685c8c