### PR TITLE
Improve artist page scroll handling and media styling

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -141,7 +141,13 @@ export default function ArtistProfilePage() {
     const rightPanel = rightPanelRef.current;
     const { scrollTop, scrollHeight, clientHeight } = rightPanel;
 
-    // Always intercept the wheel event so the main page doesn't jump
+    const atTop = scrollTop <= 0;
+    const atBottom = scrollTop + clientHeight >= scrollHeight;
+
+    if ((e.deltaY < 0 && atTop) || (e.deltaY > 0 && atBottom)) {
+      return;
+    }
+
     e.preventDefault();
     e.stopPropagation();
 
@@ -191,7 +197,7 @@ export default function ArtistProfilePage() {
       <MainLayout hideFooter>
         <div className="md:flex md:h-[calc(100vh-4rem)] md:overflow-hidden bg-white">
           {/* Left Panel: image and host details */}
-          <aside className="md:w-2/5 md:flex md:flex-col bg-white md:pt-6 md:overflow-hidden" onWheel={handleLeftScroll}>
+          <aside className="md:w-2/5 md:flex md:flex-col bg-white md:pt-8 md:overflow-hidden" onWheel={handleLeftScroll}>
             <div
               className="relative h-32 md:h-48 overflow-hidden rounded-3xl mx-6"
               role="img"

--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -50,7 +50,7 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
               alt={currentService.title}
               fill
               unoptimized
-              className="object-cover rounded-md"
+              className="object-cover rounded-3xl"
               onError={(e) => {
                 (e.currentTarget as HTMLImageElement).src = getFullImageUrl(
                   '/static/default-avatar.svg',


### PR DESCRIPTION
## Summary
- Fix artist profile scroll handler to only capture wheel events when the main content can scroll
- Align left panel with right panel by adding top padding
- Use larger border radius for service media images

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68961c89ccc8832e9f2db4b44a8e4b98