### PR TITLE
feat: bypass email confirmation for service providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,9 @@ The default `https://example.com` is a placeholder. The API logs a warning on st
 Users registering via `/auth/register` receive a short-lived token in an email
 pointing to `/confirm-email?token=<token>`. Submitting this token through the
 new `POST /auth/confirm-email` endpoint marks the user as verified and removes
-the token from the `email_tokens` table.
+the token from the `email_tokens` table. Service providers are currently
+auto-verified on registration, so they can sign in without confirming their
+email.
 All email addresses are normalized to lowercase during registration and login so
 `User@Example.com` and `user@example.com` refer to the same account.
 Gmail addresses are further canonicalized: dots and `+tags` are ignored and

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -83,7 +83,9 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
         first_name=user_data.first_name,
         last_name=user_data.last_name,
         phone_number=user_data.phone_number,
-        user_type=user_data.user_type
+        user_type=user_data.user_type,
+        # Service providers can skip email confirmation in this environment.
+        is_verified=(user_data.user_type == UserType.SERVICE_PROVIDER),
     )
 
     try:
@@ -95,6 +97,7 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
             service_provider_profile = ServiceProviderProfile(user_id=db_user.id)
             db.add(service_provider_profile)
             db.commit()
+            return db_user
 
         token_value = secrets.token_urlsafe(32)
         expires = datetime.utcnow() + timedelta(hours=24)

--- a/backend/tests/test_email_confirmation.py
+++ b/backend/tests/test_email_confirmation.py
@@ -83,6 +83,31 @@ def test_token_created_on_register():
     app.dependency_overrides.pop(get_db, None)
 
 
+def test_service_provider_auto_verified():
+    Session = setup_app()
+    client = TestClient(app)
+
+    res = client.post(
+        '/auth/register',
+        json={
+            'email': 'sp@test.com',
+            'password': 'secret',
+            'first_name': 'S',
+            'last_name': 'Provider',
+            'phone_number': '123',
+            'user_type': 'service_provider',
+        },
+    )
+    assert res.status_code == 200
+    db = Session()
+    user_db = db.query(User).filter(User.email == 'sp@test.com').first()
+    token = db.query(EmailToken).filter(EmailToken.user_id == user_db.id).first()
+    db.close()
+    assert user_db.is_verified is True
+    assert token is None
+    app.dependency_overrides.pop(get_db, None)
+
+
 def test_confirm_email():
     Session = setup_app()
     user_id, token, _ = create_user(Session)

--- a/frontend/e2e/auth-flow.spec.ts
+++ b/frontend/e2e/auth-flow.spec.ts
@@ -1,51 +1,66 @@
 import { test, expect } from '@playwright/test';
-import { stubRegister, stubConfirmEmail, stubCatchAllApi } from './stub-helpers';
+import { stubRegister, stubConfirmEmail, stubCatchAllApi, stubRegisterServiceProvider } from './stub-helpers';
 
- test.describe('Auth flow', () => {
-   test.beforeEach(async ({ page }) => {
-     await stubCatchAllApi(page);
-   });
+test.describe('Auth flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubCatchAllApi(page);
+  });
 
-   test('registration redirects to confirm email', async ({ page }) => {
-     await stubRegister(page);
-     await page.goto('/register');
-     await page.getByLabel('Email address').fill('new@test.com');
-     await page.getByLabel('First name').fill('New');
-     await page.getByLabel('Last name').fill('User');
-     await page.getByLabel('Phone number').fill('+1234567890');
-     await page.selectOption('#user_type', 'client');
-     await page.getByLabel('Password').fill('secret!1');
-     await page.getByLabel('Confirm password').fill('secret!1');
-     await page.getByRole('button', { name: /create account/i }).click();
-     await expect(page).toHaveURL('/confirm-email');
-     await expect(page.getByText('Check your email')).toBeVisible();
-   });
+  test('registration redirects to confirm email', async ({ page }) => {
+    await stubRegister(page);
+    await page.goto('/register');
+    await page.getByLabel('Email address').fill('new@test.com');
+    await page.getByLabel('First name').fill('New');
+    await page.getByLabel('Last name').fill('User');
+    await page.getByLabel('Phone number').fill('+1234567890');
+    await page.selectOption('#user_type', 'client');
+    await page.getByLabel('Password').fill('secret!1');
+    await page.getByLabel('Confirm password').fill('secret!1');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL('/confirm-email');
+    await expect(page.getByText('Check your email')).toBeVisible();
+  });
 
-   test('confirm email success and failure', async ({ page }) => {
-     await stubConfirmEmail(page, 200);
-     await page.goto('/confirm-email?token=abc');
-     await expect(page.getByText('Email confirmed!')).toBeVisible();
-     await page.getByRole('button', { name: /continue to login/i }).click();
-     await expect(page).toHaveURL('/login');
+  test('service provider registration skips email confirmation', async ({ page }) => {
+    await stubRegisterServiceProvider(page);
+    await page.goto('/register');
+    await page.getByLabel('Email address').fill('sp@test.com');
+    await page.getByLabel('First name').fill('New');
+    await page.getByLabel('Last name').fill('Provider');
+    await page.getByLabel('Phone number').fill('+1234567890');
+    await page.selectOption('#user_type', 'service_provider');
+    await page.getByLabel('Password').fill('secret!1');
+    await page.getByLabel('Confirm password').fill('secret!1');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await expect(page).toHaveURL('/login');
+    await expect(page.getByText('Registration successful!')).toBeVisible();
+  });
 
-     await stubConfirmEmail(page, 400);
-     await page.goto('/confirm-email?token=bad');
-     await expect(page.getByText('Invalid or expired token.')).toBeVisible();
-   });
+  test('confirm email success and failure', async ({ page }) => {
+    await stubConfirmEmail(page, 200);
+    await page.goto('/confirm-email?token=abc');
+    await expect(page.getByText('Email confirmed!')).toBeVisible();
+    await page.getByRole('button', { name: /continue to login/i }).click();
+    await expect(page).toHaveURL('/login');
 
-   test('social login buttons initiate OAuth flow', async ({ page }) => {
-     await page.route('**/auth/google/login**', (route) => route.abort());
-     await page.route('**/auth/github/login**', (route) => route.abort());
-     await page.goto('/login');
-     const [googleReq] = await Promise.all([
-       page.waitForRequest('**/auth/google/login**'),
-       page.getByRole('button', { name: /google/i }).click(),
-     ]);
-     expect(googleReq.url()).toContain('/auth/google/login?next=%2Fdashboard');
-     const [githubReq] = await Promise.all([
-       page.waitForRequest('**/auth/github/login**'),
-       page.getByRole('button', { name: /github/i }).click(),
-     ]);
-     expect(githubReq.url()).toContain('/auth/github/login?next=%2Fdashboard');
-   });
- });
+    await stubConfirmEmail(page, 400);
+    await page.goto('/confirm-email?token=bad');
+    await expect(page.getByText('Invalid or expired token.')).toBeVisible();
+  });
+
+  test('social login buttons initiate OAuth flow', async ({ page }) => {
+    await page.route('**/auth/google/login**', (route) => route.abort());
+    await page.route('**/auth/github/login**', (route) => route.abort());
+    await page.goto('/login');
+    const [googleReq] = await Promise.all([
+      page.waitForRequest('**/auth/google/login**'),
+      page.getByRole('button', { name: /google/i }).click(),
+    ]);
+    expect(googleReq.url()).toContain('/auth/google/login?next=%2Fdashboard');
+    const [githubReq] = await Promise.all([
+      page.waitForRequest('**/auth/github/login**'),
+      page.getByRole('button', { name: /github/i }).click(),
+    ]);
+    expect(githubReq.url()).toContain('/auth/github/login?next=%2Fdashboard');
+  });
+});

--- a/frontend/e2e/stub-helpers.ts
+++ b/frontend/e2e/stub-helpers.ts
@@ -23,6 +23,16 @@ export async function stubRegister(page: Page) {
   });
 }
 
+export async function stubRegisterServiceProvider(page: Page) {
+  await page.route('**/auth/register', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 1, name: 'Test Provider', user_type: 'service_provider' }),
+    });
+  });
+}
+
 export async function stubConfirmEmail(page: Page, status = 200) {
   await page.route('**/auth/confirm-email', async (route) => {
     await route.fulfill({

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -41,8 +41,13 @@ export default function RegisterPage() {
       const { confirmPassword, ...userData } = data;
       void confirmPassword;
       await registerUser(userData);
-      toast.success('Registration successful! Check your email to verify.');
-      router.push('/confirm-email');
+      if (userData.user_type === 'service_provider') {
+        toast.success('Registration successful!');
+        router.push('/login');
+      } else {
+        toast.success('Registration successful! Check your email to verify.');
+        router.push('/confirm-email');
+      }
     } catch (err: unknown) {
       console.error('Registration error:', err);
       const message =


### PR DESCRIPTION
## Summary
- Skip email confirmation for service provider registrations and mark them verified immediately
- Note auto-verification in documentation and add tests for provider signup flow
- Adjust register page and e2e tests to redirect providers directly to login

## Testing
- `E2E=1 ./scripts/test-all.sh` *(fails: 30 test suites failed, 1 skipped, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68961e2b711c832e810f39a9abdac2e8