### PR TITLE
fix artist profile layout and header behavior

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef, type WheelEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -52,7 +52,6 @@ export default function ArtistProfilePage() {
   const [error, setError] = useState<string | null>(null);
   const [isBookingOpen, setIsBookingOpen] = useState(false);
   const [selectedService, setSelectedService] = useState<Service | null>(null);
-  const rightPanelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!artistId) return;
@@ -133,30 +132,6 @@ export default function ArtistProfilePage() {
     setSelectedService(null);
   };
 
-  // Scroll the right panel when hovering over the left section
-  // and prevent the overall page from jumping
-  const handleLeftScroll = (e: WheelEvent) => {
-    if (!rightPanelRef.current) return;
-
-    const rightPanel = rightPanelRef.current;
-    const { scrollTop, scrollHeight, clientHeight } = rightPanel;
-
-    const atTop = scrollTop <= 0;
-    const atBottom = scrollTop + clientHeight >= scrollHeight;
-
-    if ((e.deltaY < 0 && atTop) || (e.deltaY > 0 && atBottom)) {
-      return;
-    }
-
-    e.preventDefault();
-    e.stopPropagation();
-
-    const nextScrollTop = scrollTop + e.deltaY;
-    rightPanel.scrollTo({
-      top: Math.max(0, Math.min(nextScrollTop, scrollHeight - clientHeight)),
-    });
-  };
-
   if (loading) {
     return (
       <MainLayout hideFooter>
@@ -195,11 +170,11 @@ export default function ArtistProfilePage() {
         {profilePictureUrl && <meta property="og:image" content={profilePictureUrl} />}
       </Head>
       <MainLayout hideFooter>
-        <div className="md:flex md:h-[calc(100vh-4rem)] md:overflow-hidden bg-white">
+        <div className="md:flex bg-white">
           {/* Left Panel: image and host details */}
           <aside
-            className="md:w-2/5 md:flex md:flex-col bg-white p-6 md:overflow-hidden"
-            onWheel={handleLeftScroll}
+            className="md:w-2/5 md:flex md:flex-col bg-white p-6 md:sticky md:self-start"
+            style={{ top: '5.5rem' }}
           >
             <div
               className="relative h-32 md:h-48 overflow-hidden rounded-3xl"
@@ -291,7 +266,7 @@ export default function ArtistProfilePage() {
           </aside>
 
           {/* Right Panel: scrollable content */}
-          <section ref={rightPanelRef} className="md:w-3/5 md:overflow-y-auto p-6 space-y-8">
+          <section className="md:w-3/5 p-6 space-y-8">
             {/* Services Section */}
             <section id="services" aria-labelledby="services-heading" role="region">
             

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -43,32 +43,42 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
   const prevHeaderHeight = useRef(0); // Store header height before state change
 
   // Boolean derived from headerState to control global overlay visibility
-  const showSearchOverlay = headerState === 'expanded-from-compact';
+  const showSearchOverlay =
+    headerState === 'expanded-from-compact' && !isArtistDetail;
 
 
   // Callback to force header state (e.g., when compact search is clicked or search is submitted)
   // This function is passed to the Header component.
-  const forceHeaderState = useCallback((state: HeaderState, scrollTarget?: number) => {
-    // Only update state if it's actually changing
-    if (headerState === state) return;
+  const forceHeaderState = useCallback(
+    (state: HeaderState, scrollTarget?: number) => {
+      // Lock the header in its initial state on artist profile pages
+      if (isArtistDetail) {
+        setHeaderState('initial');
+        return;
+      }
 
-    // Capture current header height before state change (for later scroll adjustment)
-    if (headerRef.current) {
+      // Only update state if it's actually changing
+      if (headerState === state) return;
+
+      // Capture current header height before state change (for later scroll adjustment)
+      if (headerRef.current) {
         prevHeaderHeight.current = headerRef.current.offsetHeight;
-    }
+      }
 
-    setHeaderState(state);
+      setHeaderState(state);
 
-    // If a specific scroll target is provided, initiate programmatic scroll
-    if (typeof scrollTarget === 'number') {
+      // If a specific scroll target is provided, initiate programmatic scroll
+      if (typeof scrollTarget === 'number') {
         isAdjustingScroll.current = true;
         window.scrollTo({ top: scrollTarget, behavior: 'smooth' });
         // Reset flag after scroll is expected to complete
         setTimeout(() => {
-            isAdjustingScroll.current = false;
+          isAdjustingScroll.current = false;
         }, TRANSITION_DURATION + 150);
-    }
-  }, [headerState]); // Depend on headerState to prevent stale closures
+      }
+    },
+    [headerState, isArtistDetail],
+  ); // Depend on headerState to prevent stale closures
 
   // Function to adjust scroll after header's height transition
   const adjustScrollAfterHeaderChange = useCallback(() => {


### PR DESCRIPTION
## Summary
- make artist profile left panel sticky with proper top offset
- prevent header state changes on artist profile pages

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `pytest` *(fails: Interrupted: 63 errors during collection)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: cannot find module '../ChatThreadView')*


------
https://chatgpt.com/codex/tasks/task_e_689643d44400832eaeba2825398634c4