### PR TITLE
Remove extra padding from artist service card

### DIFF
--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -46,7 +46,7 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
   };
 
   return (
-    <Card role="listitem" className="p-4 border-none shadow-sm hover:shadow-sm">
+    <Card role="listitem" className="border-none shadow-sm hover:shadow-sm">
       <div className="flex gap-4">
         {currentService.media_url && (
           <div className="relative w-35 h-35 flex-shrink-0 pr-4">


### PR DESCRIPTION
## Summary
- remove `p-4` padding from artist service card to align content with top margin

## Testing
- `./scripts/test-all.sh` *(fails: FAIL src/components/layout/__tests__/MobileMenuDrawer.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6896618b26d4832e8c76e2652c4a6935