### PR TITLE
Fix layout alignment on artist profile

### DIFF
--- a/frontend/src/app/artists/[id]/page.tsx
+++ b/frontend/src/app/artists/[id]/page.tsx
@@ -266,7 +266,7 @@ export default function ArtistProfilePage() {
           </aside>
 
           {/* Right Panel: scrollable content */}
-          <section className="md:w-3/5 p-6 space-y-8">
+          <section className="md:w-3/5 p-6 space-y-8 md:mt-[5.5rem]">
             {/* Services Section */}
             <section id="services" aria-labelledby="services-heading" role="region">
             


### PR DESCRIPTION
## Summary
- offset artist profile right column to align with header layout

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68966edb0ee8832e97a559f868ee2474