### PR TITLE
Refine service card spacing and page padding

### DIFF
--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -47,7 +47,8 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
 
   return (
     <Card role="listitem" className="border-none shadow-none hover:shadow-none">
-      <div className="flex gap-4">
+      {/* Increased gap to add more spacing between media and details */}
+      <div className="flex gap-6">
         {currentService.media_url && (
           <div className="relative w-35 h-35 flex-shrink-0 pr-4">
             <Image
@@ -70,8 +71,9 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
           <h3 className="text-lg font-semibold text-gray-900">
             {currentService.title}
           </h3>
-          <div className="mt-1 text-sm text-gray-600 flex flex-wrap items-center gap-x-2">
-            <span className="text-base font-semibold text-gray-900">
+          {/* Price styling tweaked to be smaller and not bold, closer to title */}
+          <div className="mt-0.5 text-sm text-gray-600 flex flex-wrap items-center gap-x-2">
+            <span className="text-sm font-normal text-gray-900">
               {formatCurrency(Number(currentService.price))}
             </span>
             <span>per guest</span>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -207,9 +207,10 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
   }, [adjustScrollAfterHeaderChange]);
 
 
+  // Increased default horizontal padding for page content
   const contentWrapperClasses = fullWidthContent
     ? 'w-full'
-    : 'w-full px-4 sm:px-6 lg:px-8';
+    : 'w-full px-6 sm:px-8 lg:px-12';
 
 
   const showSearchBar =


### PR DESCRIPTION
## Summary
- Tweak ArtistServiceCard layout: increase gap between media and details, reduce price font and weight, and move pricing closer to the title.
- Expand MainLayout horizontal padding for roomier page edges and note the change in code.

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6896fe626c54832e885d5c88c57cb906