### PR TITLE
fix: keep booking calendar within step container

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -141,9 +141,14 @@
   /* Booking wizard common styles */
   .wizard-step-container {
     /* Ensure a consistent width across all booking steps */
-    @apply w-full mx-auto max-w-xl space-y-6 rounded-2xl bg-white p-6 md:p-8;
+    @apply w-full mx-auto max-w-xl overflow-hidden space-y-6 rounded-2xl bg-white p-6 md:p-8;
     /* Keep height stable so the card doesn't jump between steps */
     @apply lg:min-h-[400px];
+  }
+
+  /* Allow the date picker step to expand while keeping content clipped */
+  .wizard-step-container-date {
+    @apply max-w-3xl;
   }
 
   .instruction-text {

--- a/frontend/src/components/booking/steps/DateTimeStep.tsx
+++ b/frontend/src/components/booking/steps/DateTimeStep.tsx
@@ -48,7 +48,7 @@ export default function DateTimeStep({
       description="When should we perform?"
       open={open}
       onToggle={onToggle}
-      className="wizard-step-container"
+      className="wizard-step-container wizard-step-container-date"
     >
       {loading || (!isMobile && !showPicker) ? (
         <div


### PR DESCRIPTION
## Summary
- prevent booking wizard calendar from overflowing its step container
- allow date step container to expand for the calendar

## Testing
- `npm test` *(fails: MobileMenuDrawer, MessageThread and others)*


------
https://chatgpt.com/codex/tasks/task_e_689707314018832e874658a630fc19b5