### PR TITLE
Fix service deletion by cascading related records

### DIFF
--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -12,7 +12,7 @@ class Booking(BaseModel):
     id         = Column(Integer, primary_key=True, index=True)
     artist_id  = Column(Integer, ForeignKey("artist_profiles.user_id"))
     client_id  = Column(Integer, ForeignKey("users.id"))
-    service_id = Column(Integer, ForeignKey("services.id"))
+    service_id = Column(Integer, ForeignKey("services.id", ondelete="CASCADE"))
     start_time = Column(DateTime, nullable=False)
     end_time   = Column(DateTime, nullable=False)
     status     = Column(Enum(BookingStatus), default=BookingStatus.PENDING)

--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -20,7 +20,7 @@ class BookingRequest(Base):
     id = Column(Integer, primary_key=True, index=True)
     client_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     artist_id = Column(Integer, ForeignKey("users.id"), nullable=False) # The artist's user_id
-    service_id = Column(Integer, ForeignKey("services.id"), nullable=True) # Optional
+    service_id = Column(Integer, ForeignKey("services.id", ondelete="CASCADE"), nullable=True) # Optional
 
     message = Column(Text, nullable=True)
     attachment_url = Column(String, nullable=True)

--- a/backend/app/models/review.py
+++ b/backend/app/models/review.py
@@ -8,7 +8,7 @@ class Review(BaseModel):
 
     id = Column(Integer, primary_key=True, index=True)
     booking_id  = Column(Integer, ForeignKey("bookings.id"), nullable=False)
-    service_id  = Column(Integer, ForeignKey("services.id"), nullable=False)
+    service_id  = Column(Integer, ForeignKey("services.id", ondelete="CASCADE"), nullable=False)
     artist_id   = Column(Integer, ForeignKey("artist_profiles.user_id"), nullable=False)
 
     rating      = Column(Integer, nullable=False)

--- a/backend/tests/test_service_delete.py
+++ b/backend/tests/test_service_delete.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from app.models import (
@@ -19,6 +19,13 @@ from app.models.base import BaseModel
 
 def setup_db():
     engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+
+    @event.listens_for(engine, "connect")
+    def enable_foreign_keys(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     BaseModel.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     return Session()


### PR DESCRIPTION
## Summary
- cascade service deletions to bookings, booking requests, and reviews
- enable SQLite foreign key checks in service deletion test

## Testing
- `PYTHONPATH=. pytest tests/test_service_delete.py::test_delete_service_cascades_messages -q`
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm test` *(fails: multiple frontend tests)*

------
https://chatgpt.com/codex/tasks/task_e_689709c7d350832e8285fb4002531dc6