### PR TITLE
Fix VisibleTo enum mapping to match stored DB values

### DIFF
--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -51,8 +51,15 @@ class Message(BaseModel):
     message_type = Column(
         Enum(MessageType), nullable=False, default=MessageType.USER
     )
+    # Store enum values ("artist", "client", "both") to match existing DB rows
     visible_to = Column(
-        Enum(VisibleTo), nullable=False, default=VisibleTo.BOTH
+        Enum(
+            VisibleTo,
+            name="visibleto",
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+        default=VisibleTo.BOTH,
     )
     content = Column(Text, nullable=False)
     # Link to the newer quotes_v2 table so quote messages render properly


### PR DESCRIPTION
## Summary
- ensure Message.visible_to uses enum values instead of names so existing rows like `both` load correctly

## Testing
- `pytest`
- `npm test` *(fails: MobileMenuDrawer and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68970caf3860832eab036997d580a5e1