### PR TITLE
Handle unknown artist category filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map **Musician / Band** to the `Live Performance` service
   type so searching musicians shows available artists.
+- The artist search endpoint now ignores unrecognised `category` values (for
+  example, `category=Musician`) and returns all artists instead of a 422 error.
 - Category popup now includes an artist name search input for quick navigation to
   individual profiles.
 - An unobtrusive marketing strip replaces the old Hero section.


### PR DESCRIPTION
## Summary
- Accept string category filters and ignore unknown values like `Musician`
- Add regression test for unsupported artist categories
- Document category fallback behaviour

## Testing
- `./scripts/test-backend.sh`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(failed: TypeError `(0 , _navigation.useSearchParams) is not a function`, snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68970d7d655c832ebead7a4db43bdda3