### PR TITLE
feat: remove card borders on service listings

### DIFF
--- a/frontend/src/components/artist/ArtistServiceCard.tsx
+++ b/frontend/src/components/artist/ArtistServiceCard.tsx
@@ -46,7 +46,7 @@ export default function ArtistServiceCard({ service, onBook }: ArtistServiceCard
   };
 
   return (
-    <Card role="listitem" className="border-none shadow-none hover:shadow-none">
+    <Card role="listitem" variant="flat">
       {/* Increased gap to add more spacing between media and details */}
       <div className="flex gap-6">
         {currentService.media_url && (

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   /** Display a loading state overlay */
   loading?: boolean;
-  variant?: 'default' | 'wizard';
+  variant?: 'default' | 'wizard' | 'flat';
 }
 
 export default function Card({
@@ -18,7 +18,9 @@ export default function Card({
   const base =
     variant === 'wizard'
       ? 'bg-white rounded-2xl shadow-xl p-8 max-w-md mx-auto'
-      : 'bg-white rounded-lg border border-gray-200 shadow-sm transition-shadow hover:shadow-md relative';
+      : variant === 'flat'
+        ? 'bg-white rounded-lg relative'
+        : 'bg-white rounded-lg border border-gray-200 shadow-sm transition-shadow hover:shadow-md relative';
   return (
     <div {...props} className={clsx(base, className)}>
       {loading && (


### PR DESCRIPTION
## Summary
- add `flat` variant to Card to allow borderless, shadowless cards
- use new variant for artist service listings to remove border and shadow

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm test -- --maxWorkers=50% --passWithNoTests` (fails: API error, unhandled exceptions)
- `./scripts/test-all.sh` (fails: Test run aborted)


------
https://chatgpt.com/codex/tasks/task_e_68970e8936f8832e9bc11715b79bb985