### PR TITLE
Handle legacy uppercase visible_to values

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The July 2025 update bumps key dependencies and Docker base images:
   each participant. The API also accepts the legacy values `text`, `quote`, and
   `system` (in any case) and automatically normalizes them to the uppercase
   values above for backward compatibility.
+- Legacy `visible_to` values such as `BOTH` are now accepted and normalized to
+  lowercase to prevent errors when loading old messages.
 - Backend now fetches these fields using a single optimized query for improved performance.
 - Booking request endpoints now embed the artist's business name so clients no longer see placeholder `user/unknown` names.
 

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import enum
 
 from .base import BaseModel
+from .types import CaseInsensitiveEnum
 
 class SenderType(str, enum.Enum):
     CLIENT = "client"
@@ -54,12 +55,11 @@ class Message(BaseModel):
         Enum(MessageType), nullable=False, default=MessageType.USER
     )
     # Store enum values ("artist", "client", "both") to match existing DB rows
+    # Legacy rows may use uppercase variants like "BOTH". ``CaseInsensitiveEnum``
+    # normalizes values to lowercase on read/write so these entries can be
+    # loaded without raising lookup errors.
     visible_to = Column(
-        Enum(
-            VisibleTo,
-            name="visibleto",
-            values_callable=lambda enum: [e.value for e in enum],
-        ),
+        CaseInsensitiveEnum(VisibleTo, name="visibleto"),
         nullable=False,
         default=VisibleTo.BOTH,
     )

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Enum as SAEnum
+
+
+class CaseInsensitiveEnum(SAEnum):
+    """Enum column type that accepts case-insensitive values."""
+
+    def __init__(self, enum_cls, **kwargs):
+        self._enum_cls = enum_cls
+        self._enum_kwargs = kwargs.copy()
+        kwargs.setdefault("values_callable", lambda enum: [e.value for e in enum])
+        super().__init__(enum_cls, **kwargs)
+
+    def adapt(self, impltype, **kw):
+        params = {**self._enum_kwargs, **kw}
+        return CaseInsensitiveEnum(self._enum_cls, **params)
+
+    def bind_processor(self, dialect):
+        parent = super().bind_processor(dialect)
+
+        def process(value):
+            if value is None:
+                return None
+            if isinstance(value, str):
+                value = value.lower()
+            else:
+                value = value.value
+            if parent:
+                return parent(value)
+            return value
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+        parent = super().result_processor(dialect, coltype)
+
+        def process(value):
+            if value is None:
+                return None
+            if isinstance(value, str):
+                value = value.lower()
+            if parent:
+                return parent(value)
+            return value
+
+        return process

--- a/backend/tests/test_service_delete.py
+++ b/backend/tests/test_service_delete.py
@@ -1,5 +1,6 @@
+import datetime
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.orm import sessionmaker
 
 from app.models import (
@@ -11,6 +12,7 @@ from app.models import (
     Message,
     MessageType,
     SenderType,
+    VisibleTo,
 )
 from app.models.service import ServiceType
 from app.models.artist_profile_v2 import ArtistProfileV2
@@ -78,6 +80,101 @@ def test_delete_service_cascades_messages():
     db.commit()
 
     assert db.query(Message).count() == 1
+    db.delete(service)
+    db.commit()
+
+    assert db.query(BookingRequest).count() == 0
+    assert db.query(Message).count() == 0
+
+
+def test_delete_service_handles_uppercase_visible_to():
+    """Services can be deleted even if messages store ``visible_to``
+    in uppercase from legacy rows."""
+
+    db = setup_db()
+    artist_user = User(
+        email="a@test.com",
+        password="x",
+        first_name="A",
+        last_name="Artist",
+        user_type=UserType.SERVICE_PROVIDER,
+    )
+    client_user = User(
+        email="c@test.com",
+        password="x",
+        first_name="C",
+        last_name="Client",
+        user_type=UserType.CLIENT,
+    )
+    db.add_all([artist_user, client_user])
+    db.commit()
+    db.refresh(artist_user)
+    db.refresh(client_user)
+
+    profile = ArtistProfileV2(user_id=artist_user.id)
+    service = Service(
+        artist_id=artist_user.id,
+        title="Gig",
+        price=100,
+        duration_minutes=60,
+        service_type=ServiceType.OTHER,
+        media_url="x",
+    )
+    profile.services.append(service)
+    db.add(profile)
+    db.commit()
+    db.refresh(service)
+
+    br = BookingRequest(
+        client_id=client_user.id,
+        artist_id=artist_user.id,
+        service_id=service.id,
+        status=BookingStatus.PENDING_QUOTE,
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+
+    # Insert message with uppercase visible_to directly via SQL
+    db.execute(
+        text(
+            """
+            INSERT INTO messages (
+                booking_request_id,
+                sender_id,
+                sender_type,
+                message_type,
+                visible_to,
+                content,
+                timestamp,
+                is_read
+            ) VALUES (
+                :br_id,
+                :sender_id,
+                :sender_type,
+                :message_type,
+                'BOTH',
+                :content,
+                :ts,
+                0
+            )
+            """
+        ),
+        {
+            "br_id": br.id,
+            "sender_id": client_user.id,
+            "sender_type": SenderType.CLIENT.name,
+            "message_type": MessageType.USER.name,
+            "content": "hi",
+            "ts": datetime.datetime.utcnow(),
+        },
+    )
+    db.commit()
+
+    # Ensure the ORM loads the enum correctly
+    msg = db.query(Message).first()
+    assert msg.visible_to == VisibleTo.BOTH
+
     db.delete(service)
     db.commit()
 


### PR DESCRIPTION
## Summary
- normalize message `visible_to` enum to handle legacy uppercase values
- add `CaseInsensitiveEnum` type and regression test for service deletion
- document compatibility for old `visible_to` values

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_689713548314832eabda2f1360fe69bb