### PR TITLE
fix: ensure service category columns added to services

### DIFF
--- a/backend/app/db_utils.py
+++ b/backend/app/db_utils.py
@@ -37,13 +37,38 @@ def ensure_legacy_artist_user_type(engine: Engine) -> None:
 
 
 def ensure_service_category_id_column(engine: Engine) -> None:
-    """Add the ``service_category_id`` column to ``artist_profiles`` if missing."""
+    """Ensure tables support service categories.
 
+    Historically the ``service_category_id`` and ``details`` fields were
+    introduced after some databases were already in use.  This helper mirrors
+    the Alembic migration by adding the columns to both ``artist_profiles`` and
+    ``services`` when they are missing.  It allows deployments that have not run
+    migrations to function without SQL errors.
+    """
+
+    # ``artist_profiles`` gained ``service_category_id`` to record an artist's
+    # default category.  Add it when absent so API calls can filter by category.
     add_column_if_missing(
         engine,
         "artist_profiles",
         "service_category_id",
         "service_category_id INTEGER",
+    )
+
+    # ``services`` also received a ``service_category_id`` foreign key and an
+    # optional JSON ``details`` column for category specific data.  Ensure both
+    # columns exist to keep ORM queries in sync with the database schema.
+    add_column_if_missing(
+        engine,
+        "services",
+        "service_category_id",
+        "service_category_id INTEGER",
+    )
+    add_column_if_missing(
+        engine,
+        "services",
+        "details",
+        "details JSON",
     )
 
 

--- a/backend/tests/test_ensure_service_category_column.py
+++ b/backend/tests/test_ensure_service_category_column.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, MetaData, Table, inspect, create_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db_utils import ensure_service_category_id_column
+
+
+def test_ensure_service_category_columns():
+    # Create tables without category columns to simulate a pre-migration database
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    metadata = MetaData()
+    Table("artist_profiles", metadata, Column("user_id", Integer, primary_key=True))
+    Table("services", metadata, Column("id", Integer, primary_key=True))
+    metadata.create_all(engine)
+
+    # Run the helper which should add the missing columns
+    ensure_service_category_id_column(engine)
+    inspector = inspect(engine)
+
+    artist_cols = {col["name"] for col in inspector.get_columns("artist_profiles")}
+    service_cols = {col["name"] for col in inspector.get_columns("services")}
+
+    assert "service_category_id" in artist_cols
+    assert "service_category_id" in service_cols
+    assert "details" in service_cols


### PR DESCRIPTION
## Summary
- extend `ensure_service_category_id_column` to patch both `artist_profiles` and `services` tables with `service_category_id` and `details`
- add regression test verifying columns are auto-added for legacy databases

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68973dcaca60832ea1870120b31e3854