### PR TITLE
feat: unify service wizard modal styles

### DIFF
--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -1,6 +1,6 @@
 # Add Service Workflow
 
-Artists can now publish offerings using a shared **BaseServiceWizard**. The wizard manages step navigation, form submission and client-side media uploads while category wizards supply their own fields.
+Artists can now publish offerings using a shared **BaseServiceWizard**. The wizard mirrors the musician service modal so every category shares the same layout and navigation. It manages step flow, form submission and client-side media uploads while category wizards supply their own fields.
 
 ## Categories
 

--- a/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
+++ b/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment, useState, useEffect } from "react";
 import type { ReactNode } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   useForm,
   type FieldValues,
@@ -53,14 +54,15 @@ export default function BaseServiceWizard<T extends FieldValues>({
   const form = useForm<T>({ defaultValues });
   const { handleSubmit, trigger, reset, formState } = form;
 
+  // Track furthest step reached for stepper highlighting
+  useEffect(() => {
+    setMaxStep((prev) => Math.max(prev, step));
+  }, [step]);
+
   const next = async () => {
     const fields = steps[step].fields;
     if (fields && !(await trigger(fields as string[]))) return;
-    setStep((s) => {
-      const nextStep = s + 1;
-      setMaxStep((m) => (nextStep > m ? nextStep : m));
-      return nextStep;
-    });
+    setStep((s) => s + 1);
   };
 
   const back = () => setStep((s) => (s > 0 ? s - 1 : s));
@@ -91,6 +93,13 @@ export default function BaseServiceWizard<T extends FieldValues>({
     handleCancel();
   });
 
+  const stepVariants = {
+    initial: { opacity: 0, x: 50 },
+    animate: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: -50 },
+    transition: { duration: 0.3, ease: [0.42, 0, 0.58, 1] as const },
+  };
+
   return (
     <Transition show={isOpen} as={Fragment}>
       <Dialog as="div" className="fixed inset-0 z-50" onClose={handleCancel}>
@@ -116,54 +125,85 @@ export default function BaseServiceWizard<T extends FieldValues>({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl rounded bg-white p-6" data-testid="wizard">
-                <div className="mb-4 flex items-center justify-between">
-                  <Dialog.Title className="text-lg font-semibold">
-                    {service ? "Edit Service" : "Add Service"}
-                  </Dialog.Title>
-                  <button
-                    type="button"
-                    onClick={handleCancel}
-                    className="rounded p-1 hover:bg-gray-100"
-                  >
-                    <XMarkIcon className="h-5 w-5" />
-                  </button>
+              <Dialog.Panel
+                as="div"
+                className="pointer-events-auto relative flex h-full w-full max-w-none flex-col overflow-hidden rounded-none bg-white shadow-none md:flex-row"
+                data-testid="wizard"
+              >
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="absolute right-4 top-4 z-10 rounded-md p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-brand"
+                >
+                  <XMarkIcon className="pointer-events-none h-5 w-5" />
+                </button>
+
+                <div className="flex w-full flex-none flex-col justify-between overflow-y-auto bg-gray-50 p-6 md:w-1/5">
+                  <Stepper
+                    steps={steps.slice(0, steps.length - 1).map((s) => s.label)}
+                    currentStep={step}
+                    maxStepCompleted={maxStep}
+                    onStepClick={setStep}
+                    ariaLabel="Add service progress"
+                    className="space-y-4"
+                    orientation="vertical"
+                    noCircles
+                  />
                 </div>
-                <Stepper
-                  steps={steps.map((s) => s.label)}
-                  currentStep={step}
-                  maxStepCompleted={maxStep}
-                  className="mb-4"
-                />
-                <form id="service-form" onSubmit={onSubmit}>
-                  {steps[step].render({
-                    form: form as UseFormReturn<T>,
-                    mediaFiles,
-                    setMediaFiles,
-                  })}
-                </form>
-                <div className="mt-4 flex justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={step === 0 ? handleCancel : back}
-                    data-testid="back"
+
+                <div className="flex w-full flex-1 flex-col overflow-hidden md:w-3/5">
+                  <form
+                    id="service-form"
+                    onSubmit={onSubmit}
+                    className="flex-1 space-y-4 overflow-y-scroll p-6"
                   >
-                    {step === 0 ? "Cancel" : "Back"}
-                  </Button>
-                  {step < steps.length - 1 && (
-                    <Button onClick={next} data-testid="next">
-                      Next
-                    </Button>
-                  )}
-                  {step === steps.length - 1 && (
+                    <AnimatePresence mode="wait">
+                      <motion.div
+                        key={step}
+                        initial="initial"
+                        animate="animate"
+                        exit="exit"
+                        variants={stepVariants}
+                        transition={stepVariants.transition}
+                      >
+                        {steps[step].render({
+                          form: form as UseFormReturn<T>,
+                          mediaFiles,
+                          setMediaFiles,
+                        })}
+                      </motion.div>
+                    </AnimatePresence>
+                  </form>
+
+                  <div className="flex flex-shrink-0 flex-col-reverse gap-2 border-t border-gray-100 p-4 sm:flex-row sm:justify-between">
                     <Button
-                      type="submit"
-                      form="service-form"
-                      isLoading={formState.isSubmitting}
+                      variant="outline"
+                      onClick={step === 0 ? handleCancel : back}
+                      data-testid="back"
+                      className="min-h-[40px] w-full sm:w-auto"
                     >
-                      {service ? "Save" : "Publish"}
+                      {step === 0 ? "Cancel" : "Back"}
                     </Button>
-                  )}
+                    {step < steps.length - 1 && (
+                      <Button
+                        onClick={next}
+                        data-testid="next"
+                        className="min-h-[40px] w-full sm:w-auto"
+                      >
+                        Next
+                      </Button>
+                    )}
+                    {step === steps.length - 1 && (
+                      <Button
+                        type="submit"
+                        form="service-form"
+                        isLoading={formState.isSubmitting}
+                        className="min-h-[40px] w-full sm:w-auto"
+                      >
+                        {service ? "Save Changes" : "Publish"}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </Dialog.Panel>
             </Transition.Child>


### PR DESCRIPTION
## Summary
- restyle BaseServiceWizard to match musician modal (vertical stepper, animated steps, shared layout)
- note consistent wizard styling in documentation

## Testing
- `./scripts/test-all.sh` (fails: 31 failed, 85 passed)


------
https://chatgpt.com/codex/tasks/task_e_6897465d365c832e88efeb56956fa890