### PR TITLE
feat: update service categories seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Service providers choose from predefined service categories during onboarding. A new `/api/v1/service-categories` endpoint lists the seeded categories and a post‑registration page stores the selection.
+- Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services now store a `service_category_id` and optional JSON `details` object for category-specific attributes, enabling tailored service data.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote


### PR DESCRIPTION
## Summary
- seed new service categories like Musician, DJ, Photographer, and more
- upsert and cleanup service category records so table stays in sync
- document current service category list

## Testing
- `./scripts/test-all.sh` *(failed: multiple frontend test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689748c08f70832e876c154ae4330d0e