### PR TITLE
feat: expand service category options

### DIFF
--- a/frontend/src/components/dashboard/AddServiceCategorySelector.tsx
+++ b/frontend/src/components/dashboard/AddServiceCategorySelector.tsx
@@ -2,7 +2,17 @@
 
 import { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { XMarkIcon, MusicalNoteIcon, CameraIcon } from "@heroicons/react/24/outline";
+import {
+  XMarkIcon,
+  MusicalNoteIcon,
+  CameraIcon,
+  MegaphoneIcon,
+  SparklesIcon,
+  HomeModernIcon,
+  CakeIcon,
+  BeakerIcon,
+  MicrophoneIcon,
+} from "@heroicons/react/24/outline";
 
 interface Category {
   id: string;
@@ -13,6 +23,12 @@ interface Category {
 const categories: Category[] = [
   { id: "musician", label: "Musician", Icon: MusicalNoteIcon },
   { id: "photographer", label: "Photographer", Icon: CameraIcon },
+  { id: "speaker", label: "Speaker", Icon: MegaphoneIcon },
+  { id: "event_service", label: "Event Service", Icon: SparklesIcon },
+  { id: "wedding_venue", label: "Wedding Venue", Icon: HomeModernIcon },
+  { id: "caterer", label: "Caterer", Icon: CakeIcon },
+  { id: "bartender", label: "Bartender", Icon: BeakerIcon },
+  { id: "mc_host", label: "MC & Host", Icon: MicrophoneIcon },
 ];
 
 interface AddServiceCategorySelectorProps {

--- a/frontend/src/components/dashboard/__tests__/AddServiceCategorySelector.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceCategorySelector.test.tsx
@@ -21,7 +21,7 @@ describe("AddServiceCategorySelector", () => {
       );
     });
 
-    const button = container.querySelector(
+    const button = document.body.querySelector(
       'button[data-testid="category-musician"]'
     ) as HTMLButtonElement;
 
@@ -30,6 +30,38 @@ describe("AddServiceCategorySelector", () => {
     });
 
     expect(onSelect).toHaveBeenCalledWith("musician");
+    expect(onClose).toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("handles selecting newly added categories", async () => {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AddServiceCategorySelector, {
+          isOpen: true,
+          onClose,
+          onSelect,
+        })
+      );
+    });
+
+    const button = document.body.querySelector(
+      'button[data-testid="category-speaker"]'
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("speaker");
     expect(onClose).toHaveBeenCalled();
 
     act(() => root.unmount());


### PR DESCRIPTION
## Summary
- extend AddServiceCategorySelector with additional service categories and icons
- test selecting newly added categories

## Testing
- `npm test frontend/src/components/dashboard/__tests__/AddServiceCategorySelector.test.tsx`
- `./scripts/test-all.sh` *(fails: Test Suites: 30 failed, 2 skipped, 86 passed, 116 of 118 total)*

------
https://chatgpt.com/codex/tasks/task_e_689748d5e064832e8d514c1c84005606