### PR TITLE
feat: enhance media uploads in service wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 * Service deletion now requires confirmation to prevent mistakes.
 * **Add Service** button now opens a full-screen wizard. Steps appear in a coral-accented stepper with keyboard focus trapping. Pricing is captured directly on the **Details** step, removing the previous **Packages** step. The final review mirrors earlier steps with image thumbnails before publishing.
 * Add Service wizard validates fields on each keystroke with dynamic hints like "Need 3 more characters" and the **Next** button enables automatically once inputs are valid.
-* A shared **BaseServiceWizard** powers most category wizards. `AddServiceModalPhotographer` still uses it for navigation, media uploads and API submission, while `AddServiceModalMusician` now implements a custom stepper.
+* A shared **BaseServiceWizard** powers most category wizards. `AddServiceModalPhotographer` still uses it for navigation, media uploads and API submission, while `AddServiceModalMusician` now implements a custom stepper. The wizard's media step now mirrors the musician experience with image-only validation, thumbnail previews and removable selections.
 * Selecting **Live Performance** now reveals travel-related fields beneath the duration input. Artists can specify a travel rate in Rand per km (default R2.5) and the number of members travelling.
 * This travel rate now also factors into airport transfer costs when flying so estimates remain consistent.
 * The **Edit Service** modal now includes these travel fields so artists can update their rate per km and members travelling from the dashboard. These values are stored server-side so edits persist.

--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -1,6 +1,6 @@
 # Add Service Workflow
 
-Artists can now publish offerings using a shared **BaseServiceWizard**. The wizard mirrors the musician service modal so every category shares the same layout and navigation. It manages step flow, form submission and client-side media uploads while category wizards supply their own fields.
+Artists can now publish offerings using a shared **BaseServiceWizard**. The wizard mirrors the musician service modal so every category shares the same layout and navigation. It manages step flow, form submission and client-side media uploads while category wizards supply their own fields. Media uploads now match the musician experience with image-only validation, thumbnail previews and the ability to remove selections before publishing.
 
 ## Categories
 

--- a/frontend/src/components/dashboard/add-service/AddServiceModalPhotographer.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalPhotographer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
@@ -59,30 +60,102 @@ export default function AddServiceModalPhotographer({
     },
     {
       label: "Media",
-      render: ({ mediaFiles, setMediaFiles }) => (
+      validate: ({ mediaFiles, existingMediaUrl, mediaError }) =>
+        (mediaFiles.length > 0 || !!existingMediaUrl) && !mediaError,
+      render: ({
+        onFileChange,
+        removeFile,
+        mediaError,
+        thumbnails,
+        existingMediaUrl,
+        removeExistingMedia,
+      }) => (
         <div className="space-y-4">
           <h2 className="text-xl font-semibold">Upload Media</h2>
-          <input
-            aria-label="Media"
-            type="file"
-            accept="image/*"
-            onChange={(e) =>
-              setMediaFiles(e.target.files ? Array.from(e.target.files) : [])
-            }
-          />
-          {mediaFiles[0] && <p data-testid="file-name">{mediaFiles[0].name}</p>}
+          <label
+            htmlFor="media-upload"
+            className="flex min-h-40 w-full cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed p-4 text-center"
+          >
+            <p className="text-sm">Drag files here or click to upload</p>
+            <input
+              id="media-upload"
+              aria-label="Media"
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={(e) => onFileChange(e.target.files)}
+            />
+          </label>
+          {mediaError && (
+            <p className="mt-2 text-sm text-red-600">{mediaError}</p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2">
+            {existingMediaUrl && (
+              <div className="relative h-20 w-20 overflow-hidden rounded border">
+                <Image
+                  src={existingMediaUrl}
+                  alt="existing-media"
+                  width={80}
+                  height={80}
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={removeExistingMedia}
+                  className="absolute right-0 top-0 h-4 w-4 rounded-full bg-black/50 text-xs text-white"
+                >
+                  ×
+                </button>
+              </div>
+            )}
+            {thumbnails.map((src, i) => (
+              <div
+                key={i}
+                className="relative h-20 w-20 overflow-hidden rounded border"
+              >
+                <Image
+                  src={src}
+                  alt={`media-${i}`}
+                  width={80}
+                  height={80}
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeFile(i)}
+                  className="absolute right-0 top-0 h-4 w-4 rounded-full bg-black/50 text-xs text-white"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
         </div>
       ),
     },
     {
       label: "Review",
-      render: ({ form, mediaFiles }) => (
+      render: ({ form, thumbnails }) => (
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Review</h2>
           <p>{form.getValues("title")}</p>
           <p>{form.getValues("price")}</p>
           <p>{form.getValues("camera_brand")}</p>
-          {mediaFiles[0] && <p>{mediaFiles[0].name}</p>}
+          {thumbnails.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {thumbnails.map((src, i) => (
+                <Image
+                  key={i}
+                  src={src}
+                  alt={`media-${i}`}
+                  width={64}
+                  height={64}
+                  className="h-16 w-16 rounded object-cover"
+                />
+              ))}
+            </div>
+          )}
         </div>
       ),
     },

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
@@ -30,6 +30,7 @@ describe("AddServiceModalPhotographer", () => {
 
     const file = new File(["hello"], "cam.jpg", { type: "image/jpeg" });
     await user.upload(screen.getByLabelText(/Media/i), file);
+    await flushPromises();
     await user.click(screen.getByTestId("next"));
 
     // back flow


### PR DESCRIPTION
## Summary
- add thumbnail previews and image-only validation to BaseServiceWizard media handler
- mirror musician modal's upload experience in photographer service flow
- document upgraded media step for service wizard

## Testing
- `./scripts/test-all.sh` *(fails: 31 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68974ce1ef88832eb4bc3cc72e6553c9