### PR TITLE
fix: ensure service category selector overlay layering

### DIFF
--- a/frontend/src/components/dashboard/AddServiceCategorySelector.tsx
+++ b/frontend/src/components/dashboard/AddServiceCategorySelector.tsx
@@ -58,10 +58,10 @@ export default function AddServiceCategorySelector({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black/30" />
+          <div className="fixed inset-0 z-0 bg-black/30" />
         </Transition.Child>
 
-        <Dialog.Panel className="flex h-full w-full flex-col bg-white">
+        <Dialog.Panel className="relative z-10 flex h-full w-full flex-col bg-white">
           <div className="flex items-center justify-between p-6">
             <Dialog.Title className="text-lg font-semibold">
               Select Service Category

--- a/frontend/src/components/dashboard/__tests__/AddServiceCategorySelector.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/AddServiceCategorySelector.test.tsx
@@ -117,7 +117,9 @@ describe("AddServiceCategorySelector", () => {
       );
     });
 
-    const panel = document.body.querySelector("div.flex.h-full.w-full");
+    const panel = document.body.querySelector(
+      "div.relative.z-10.flex.h-full.w-full"
+    );
     expect(panel).not.toBeNull();
 
     act(() => root.unmount());


### PR DESCRIPTION
## Summary
- fix service category selector overlay being unclickable by placing panel above backdrop
- test selector panel layering

## Testing
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689775e98194832eab703fbf533bb541