### PR TITLE
Fix videographer search returning musicians

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,9 +1112,11 @@ The dashboard brings common actions to the surface with a tidy layout:
 `GET /api/v1/artist-profiles/` supports pagination and optional filters:
 
 ```
-page=<number>&limit=<1-100>&category=<ServiceType>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&include_price_distribution=<true|false>
+page=<number>&limit=<1-100>&category=<slug>&location=<substring>&sort=<top_rated|most_booked|newest>&minPrice=<number>&maxPrice=<number>&include_price_distribution=<true|false>
 &when=<YYYY-MM-DD>
 ```
+
+The `category` parameter accepts a lowercase slug such as `musician` or `videographer`.
 
 When building query strings in JavaScript, format dates as pure `YYYY-MM-DD`
 values to avoid validation errors:


### PR DESCRIPTION
## Summary
- normalize category filter to match service categories by slug
- update artist filter tests to use service categories
- document slug-based category filtering in README

## Testing
- `./scripts/test-all.sh` *(frontend tests failing: e.g., TypeError: (0 , _navigation.useSearchParams) is not a function)*
- `./scripts/test-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_68978bd251a8832eb7a17feebaab400d