### PR TITLE
Fix category filtering for artist search

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -49,3 +49,9 @@ an automatic migration that adds the `media_url` column to the `services` table 
 running against older databases, preventing runtime errors when querying services
 without this field.
 
+## Artist search
+
+The `/api/v1/artist-profiles/` endpoint returns an empty list when a `category`
+query parameter is provided but no matching `ServiceCategory` exists. This
+ensures that irrelevant artists are not shown when a category has no services.
+

--- a/backend/app/api/v1/api_artist.py
+++ b/backend/app/api/v1/api_artist.py
@@ -444,7 +444,8 @@ def read_all_artist_profiles(
     # Normalize ``category`` to a slug (e.g. "videographer") so the filter works
     # regardless of whether the frontend sends "Videographer" or "videographer".
     category_slug: Optional[str] = None
-    if isinstance(category, str) and category:
+    category_provided = isinstance(category, str) and category
+    if category_provided:
         category_slug = category.lower().replace(" ", "_")
         normalized_name = category_slug.replace("_", " ")
         exists = (
@@ -453,7 +454,11 @@ def read_all_artist_profiles(
             .first()
         )
         if not exists:
-            category_slug = None
+            return {
+                "data": [],
+                "total": 0,
+                "price_distribution": [],
+            }
 
     cache_category = category_slug
     cached = None

--- a/backend/tests/test_artist_endpoint.py
+++ b/backend/tests/test_artist_endpoint.py
@@ -58,8 +58,8 @@ def test_artist_profiles_endpoint_returns_paginated(monkeypatch):
     app.dependency_overrides.pop(get_db, None)
 
 
-def test_artist_profiles_unknown_category_ignored(monkeypatch):
-    """Requests with an unknown category should not raise 422."""
+def test_artist_profiles_unknown_category_returns_empty(monkeypatch):
+    """Unknown categories should yield an empty result set."""
     Session = setup_app(monkeypatch)
     db = Session()
     user = User(
@@ -74,8 +74,8 @@ def test_artist_profiles_unknown_category_ignored(monkeypatch):
     db.add(profile)
     db.commit()
     client = TestClient(app)
-    res = client.get("/api/v1/artist-profiles/?category=Musician")
+    res = client.get("/api/v1/artist-profiles/?category=Guitarist")
     assert res.status_code == 200
     body = res.json()
-    assert body["total"] == 1
+    assert body["total"] == 0
     app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_artist_filters.py
+++ b/backend/tests/test_artist_filters.py
@@ -160,3 +160,22 @@ def test_service_price_none_without_category(monkeypatch):
     assert len(res["data"]) == 1
     assert res["data"][0].service_price is None
 
+
+def test_unknown_category_returns_empty(monkeypatch):
+    db = setup_db()
+    create_artist(db, 'Solo', 'NY', 'Musician')
+    monkeypatch.setattr(
+        'app.utils.redis_cache.get_cached_artist_list',
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        'app.utils.redis_cache.cache_artist_list',
+        lambda *args, **kwargs: None,
+    )
+
+    res = read_all_artist_profiles(
+        category='videographer', db=db, page=1, limit=20
+    )
+    assert res["data"] == []
+    assert res["total"] == 0
+


### PR DESCRIPTION
## Summary
- return empty results when an unknown service category is requested
- document behaviour of `/api/v1/artist-profiles` when category is missing
- add regression tests for unknown category filtering

## Testing
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_68978f9b4c00832eacbcc32607dd40bb