### PR TITLE
Graceful handling for unauthenticated service saves

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -158,6 +158,17 @@ describe('response interceptor', () => {
     });
   });
 
+  it('overrides server detail for 401 responses', async () => {
+    expect.assertions(1);
+    const err: unknown = {
+      isAxiosError: true,
+      response: { status: 401, data: { detail: 'Could not validate credentials' } },
+    };
+    await rejected(err).catch((e: Error) => {
+      expect(e.message).toBe('Authentication required. Please log in.');
+    });
+  });
+
   it('falls back to extracted detail and logs error', async () => {
     expect.assertions(2);
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,7 +60,8 @@ api.interceptors.response.use(
   (error) => {
     if (axios.isAxiosError(error)) {
       const status = error.response?.status;
-      let message = extractErrorMessage(error.response?.data?.detail);
+      const detail = error.response?.data?.detail;
+      let message = extractErrorMessage(detail);
 
       if (status) {
         const map: Record<number, string> = {
@@ -71,14 +72,16 @@ api.interceptors.response.use(
           422: 'Validation failed. Please check your input.',
           500: 'Server error. Please try again later.',
         };
-        if (message === 'An unexpected error occurred.') {
+        if (status in map && !(status === 422 && message !== 'An unexpected error occurred.')) {
+          message = map[status];
+        } else if (message === 'An unexpected error occurred.') {
           message = map[status] || message;
         }
       } else {
         message = 'Network error. Please check your connection.';
       }
 
-      console.error('API error:', error);
+      console.error('API error:', { status, detail }, error);
       return Promise.reject(new Error(message));
     }
 


### PR DESCRIPTION
## Summary
- Map 401 responses to a generic auth error and log server details
- Guard service wizard submission with try/catch to alert users on failure
- Test 401 detail override in API response interceptor

## Testing
- `npx eslint src/lib/api.ts src/components/dashboard/add-service/BaseServiceWizard.tsx src/lib/__tests__/api.test.ts`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: Test Suites: 37 failed, 2 skipped, 87 passed, 124 of 126 total; Tests: 57 failed, 2 skipped, 327 passed, 386 total)*

------
https://chatgpt.com/codex/tasks/task_e_68979d98a0b8832ea2e609f22a7463a8