### PR TITLE
Allow service creation without service_category_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Service providers choose from predefined service categories during onboarding. A new `/api/v1/service-categories` endpoint lists the seeded categories and a post‑registration page stores the selection.
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
-- Services now store a `service_category_id` and optional JSON `details` object for category-specific attributes, enabling tailored service data.
+- Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -31,8 +31,8 @@ class ServiceCreate(ServiceBase):
     price: Decimal
     service_type: ServiceType
     media_url: str
-    service_category_id: int
-    # artist_id will be set based on the authenticated artist, not in schema
+    # ``service_category_id`` is optional and inherited from ``ServiceBase``.
+    # The artist ID will be set based on the authenticated artist, not in the schema.
 
 
 # Properties to receive on item update

--- a/backend/tests/test_service_schema.py
+++ b/backend/tests/test_service_schema.py
@@ -2,22 +2,13 @@ import pytest
 from app.schemas.service import ServiceCreate, ServiceUpdate, ServiceType
 
 
-def test_service_create_requires_type_and_category():
+def test_service_create_requires_type():
     with pytest.raises(Exception):
         ServiceCreate(
             title="Test",
             duration_minutes=10,
             price=5.0,
             media_url="x",
-            service_category_id=1,
-        )
-    with pytest.raises(Exception):
-        ServiceCreate(
-            title="Test",
-            duration_minutes=10,
-            price=5.0,
-            media_url="x",
-            service_type=ServiceType.OTHER,
         )
     s = ServiceCreate(
         title="Test",
@@ -25,11 +16,10 @@ def test_service_create_requires_type_and_category():
         price=5.0,
         service_type=ServiceType.OTHER,
         media_url="x",
-        service_category_id=1,
         details={"genre": "rock"},
     )
     assert s.service_type == ServiceType.OTHER
-    assert s.service_category_id == 1
+    assert s.service_category_id is None
     assert s.details["genre"] == "rock"
     assert s.display_order is None
     assert s.currency == "ZAR"

--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -32,3 +32,4 @@ POST /api/v1/services/
 ```
 
 Additional category details (e.g., `camera_brand`) are included under the `details` object.
+Provide `service_category_id` only when the service belongs to one of the seeded categories; otherwise omit this field.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7785,7 +7785,14 @@
             "title": "Flight Price"
           },
           "service_category_id": {
-            "type": "integer",
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Service Category Id"
           },
           "details": {
@@ -7807,8 +7814,7 @@
           "media_url",
           "duration_minutes",
           "price",
-          "service_type",
-          "service_category_id"
+          "service_type"
         ],
         "title": "ServiceCreate"
       },


### PR DESCRIPTION
## Summary
- make `service_category_id` optional when creating services
- document optional category in README and add_service_workflow docs
- refresh OpenAPI spec

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897a081343c832e87bacf0215986b8d