### PR TITLE
Add category-specific URLs and default service categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Fixed an initial load bug where a selected date sent an invalid `when` value and caused a 422 error.
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map each service category to its corresponding service type (for example, **Musician / Band** maps to `Live Performance`) so searching by category shows available artists.
-- Visiting `/artists?category=DJ` or similar URLs now normalizes the `category` query so listings and recommendations only show matching services.
+- Visiting `/artists/category/dj` or similar URLs now normalizes the category path so listings and recommendations only show matching services.
 - The artist search endpoint now ignores unrecognised `category` values (for example, `category=Musician` or `category=DJ`) and returns all artists instead of a 422 error.
 - Category popup now includes an artist name search input for quick navigation to
   individual profiles.

--- a/frontend/src/app/artists/category/[slug]/page.tsx
+++ b/frontend/src/app/artists/category/[slug]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../page';

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -78,10 +78,17 @@ export default function ArtistsPage() {
   }, [category, user]);
 
   useEffect(() => {
-    const serviceCat = searchParams.get('category') || undefined;
-    // Convert the backend service name in the query string back to the
-    // corresponding UI slug. If no mapping exists, clear the category so we
-    // don't accidentally show results from unrelated services.
+    let serviceCat = searchParams.get('category') || undefined;
+    if (!serviceCat) {
+      const match = pathname.match(/\/artists\/category\/([^/?]+)/);
+      if (match) {
+        const slug = match[1];
+        serviceCat = UI_CATEGORY_TO_SERVICE[slug] || slug;
+      }
+    }
+    // Convert the backend service name or path slug back to the corresponding
+    // UI value. If no mapping exists, clear the category so we don't
+    // accidentally show results from unrelated services.
     setCategory(serviceCat ? SERVICE_TO_UI_CATEGORY[serviceCat] : undefined);
     setLocation(searchParams.get('location') || '');
     const w = searchParams.get('when');
@@ -100,7 +107,7 @@ export default function ArtistsPage() {
     setSort(searchParams.get('sort') || undefined);
     setMinPrice(searchParams.get('minPrice') ? Number(searchParams.get('minPrice')) : SLIDER_MIN);
     setMaxPrice(searchParams.get('maxPrice') ? Number(searchParams.get('maxPrice')) : SLIDER_MAX);
-  }, [searchParams]);
+  }, [searchParams, pathname]);
 
   const fetchArtists = useCallback(
     async (

--- a/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
+++ b/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
@@ -17,6 +17,7 @@ import {
   updateService as apiUpdateService,
 } from "@/lib/api";
 import type { Service } from "@/types";
+import { useAuth } from "@/contexts/AuthContext";
 
 function useImageThumbnails(files: File[]) {
   const [thumbnails, setThumbnails] = useState<string[]>([]);
@@ -81,6 +82,8 @@ export default function BaseServiceWizard<T extends FieldValues>({
     service?.media_url ?? null,
   );
   const thumbnails = useImageThumbnails(mediaFiles);
+
+  const { user } = useAuth();
 
   const form = useForm<T>({ defaultValues });
   const { handleSubmit, trigger, reset, formState } = form;
@@ -177,6 +180,9 @@ export default function BaseServiceWizard<T extends FieldValues>({
         });
       }
       const payload = toPayload(data, mediaUrl);
+      if (user?.service_category_id && payload.service_category_id == null) {
+        payload.service_category_id = user.service_category_id;
+      }
       const res = service
         ? await apiUpdateService(service.id, payload)
         : await apiCreateService(payload);

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -5,7 +5,7 @@
  import Link from 'next/link';
  import { useEffect, useRef, useState } from 'react';
  import { ChevronRightIcon } from '@heroicons/react/24/solid';
- import { UI_CATEGORIES, UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
+ import { UI_CATEGORIES } from '@/lib/categoryMap';
  
 
  /**
@@ -63,9 +63,7 @@
   {UI_CATEGORIES.map((cat) => (
   <Link
   key={cat.value}
-  href={`/artists?category=${encodeURIComponent(
-  UI_CATEGORY_TO_SERVICE?.[cat.value] || cat.value,
-  )}`}
+  href={`/artists/category/${encodeURIComponent(cat.value)}`}
   className="flex-shrink-0 flex flex-col hover:no-underline"
   >
   <div className="relative h-40 w-40 overflow-hidden rounded-lg bg-gray-100">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,7 +12,7 @@ import NotificationBell from './NotificationBell'; // Assuming NotificationBell 
 import MobileMenuDrawer from './MobileMenuDrawer'; // Assuming MobileMenuDrawer is set up
 import SearchBar from '../search/SearchBar'; // The full search bar component
 import { navItemClasses } from './navStyles';
-import { UI_CATEGORY_TO_SERVICE, SERVICE_TO_UI_CATEGORY, UI_CATEGORIES } from '@/lib/categoryMap';
+import { SERVICE_TO_UI_CATEGORY, UI_CATEGORIES } from '@/lib/categoryMap';
 import { Avatar } from '../ui'; // Assuming Avatar is set up
 import clsx from 'clsx';
 import { type Category } from '../search/SearchFields'; // Import Category type from SearchFields
@@ -129,10 +129,11 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
   const handleSearch = useCallback(
     ({ category, location, when }: SearchParams) => {
       const params = new URLSearchParams();
-      if (category) params.set('category', UI_CATEGORY_TO_SERVICE[category] || category);
       if (location) params.set('location', location);
       if (when) params.set('when', when.toISOString());
-      router.push(`/artists?${params.toString()}`);
+      const path = category ? `/artists/category/${category}` : '/artists';
+      const qs = params.toString();
+      router.push(qs ? `${path}?${qs}` : path);
       
       // After search submission, revert header.
       // Let MainLayout's scroll logic handle the final state based on current scroll.

--- a/frontend/src/components/layout/Hero.tsx
+++ b/frontend/src/components/layout/Hero.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect, Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import SearchBar from '../search/SearchBar'; // ✨ Import your new component
-import { UI_CATEGORY_TO_SERVICE } from '@/lib/categoryMap';
 import { type Category } from '../search/SearchFields';
 import { useRouter } from 'next/navigation';
 
@@ -33,14 +32,11 @@ export default function Hero() {
 
   const handleSearch = ({ category: cat, location: loc, when: date }: { category?: string; location?: string; when?: Date | null }) => {
     const params = new URLSearchParams();
-    if (cat) {
-      const mapped = UI_CATEGORY_TO_SERVICE[cat] || cat;
-      params.set('category', mapped);
-    }
     if (loc) params.set('location', loc);
     if (date) params.set('when', date.toISOString());
+    const path = cat ? `/artists/category/${cat}` : '/artists';
     const qs = params.toString();
-    router.push(qs ? `/artists?${qs}` : '/artists');
+    router.push(qs ? `${path}?${qs}` : path);
     setModalOpen(false);
   };
 


### PR DESCRIPTION
## Summary
- Support category in artist URLs by handling `/artists/category/:slug`
- Default new services to the artist's category
- Link homepage and search to category-specific artist pages

## Testing
- `./scripts/test-all.sh` *(failed: Git remote 'origin' not found)*
- `pytest` *(failed: 65 errors during collection)*
- `npm test` *(failed: multiple test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_6897a583c3c0832eba04f95aebe957c4