### PR TITLE
fix: avoid unfiltered artist results when filtering by category

### DIFF
--- a/frontend/src/app/__tests__/ArtistsPage.test.tsx
+++ b/frontend/src/app/__tests__/ArtistsPage.test.tsx
@@ -62,8 +62,10 @@ describe('ArtistsPage', () => {
 
   it('requests and filters DJs', async () => {
     render(<ArtistsPage />);
-    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalled());
-    expect(mockedGetArtists).toHaveBeenCalledWith(expect.objectContaining({ category: 'DJ' }));
+    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalledTimes(1));
+    expect(mockedGetArtists).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'DJ' }),
+    );
 
     await screen.findByText('DJ One Biz');
     expect(screen.queryByText('DJ NoBiz')).toBeNull();
@@ -76,15 +78,19 @@ describe('ArtistsPage', () => {
   it('normalizes UI slug category query param', async () => {
     useSearchParams.mockReturnValue(new URLSearchParams('category=dj'));
     render(<ArtistsPage />);
-    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalled());
-    expect(mockedGetArtists).toHaveBeenCalledWith(expect.objectContaining({ category: 'DJ' }));
+    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalledTimes(1));
+    expect(mockedGetArtists).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'DJ' }),
+    );
   });
 
   it('derives category from /category path', async () => {
     useSearchParams.mockReturnValue(new URLSearchParams());
     usePathname.mockReturnValue('/category/dj');
     render(<ArtistsPage />);
-    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalled());
-    expect(mockedGetArtists).toHaveBeenCalledWith(expect.objectContaining({ category: 'DJ' }));
+    await waitFor(() => expect(mockedGetArtists).toHaveBeenCalledTimes(1));
+    expect(mockedGetArtists).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'DJ' }),
+    );
   });
 });

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -38,6 +38,11 @@ export default function ArtistsPage() {
   const [maxPrice, setMaxPrice] = useState<number>(SLIDER_MAX);
   const [priceDistribution, setPriceDistribution] = useState<PriceBucket[]>([]);
 
+  // Avoid fetching artists until all filters (including category from the
+  // URL) have been parsed. This prevents an initial unfiltered request that
+  // briefly shows providers from other categories.
+  const [filtersReady, setFiltersReady] = useState(false);
+
   const debouncedMinPrice = useDebounce(minPrice, 300);
   const debouncedMaxPrice = useDebounce(maxPrice, 300);
 
@@ -126,6 +131,7 @@ export default function ArtistsPage() {
     setSort(searchParams.get('sort') || undefined);
     setMinPrice(searchParams.get('minPrice') ? Number(searchParams.get('minPrice')) : SLIDER_MIN);
     setMaxPrice(searchParams.get('maxPrice') ? Number(searchParams.get('maxPrice')) : SLIDER_MAX);
+    setFiltersReady(true);
   }, [searchParams, pathname]);
 
   const fetchArtists = useCallback(
@@ -187,9 +193,19 @@ export default function ArtistsPage() {
   );
 
   useEffect(() => {
+    if (!filtersReady) return;
     setPage(1);
     fetchArtists({ pageNumber: 1 });
-  }, [category, location, when, sort, debouncedMinPrice, debouncedMaxPrice, fetchArtists]);
+  }, [
+    filtersReady,
+    category,
+    location,
+    when,
+    sort,
+    debouncedMinPrice,
+    debouncedMaxPrice,
+    fetchArtists,
+  ]);
 
   const loadMore = () => {
     const next = page + 1;


### PR DESCRIPTION
## Summary
- avoid initial unfiltered artist fetch by waiting for filters to parse
- test that artist search only makes one category-specific request

## Testing
- `npx jest src/app/__tests__/ArtistsPage.test.tsx`
- `npx jest src/app/__tests__/HomePage.test.tsx` *(fails: 1 failed, 1 total)*

------
https://chatgpt.com/codex/tasks/task_e_6897b648a838832ea26149102223b57d