### PR TITLE
feat: filter homepage by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - An unobtrusive marketing strip replaces the old Hero section.
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
+- Selecting a category now routes back to the homepage with the category filter applied so matching service providers appear immediately.
 - Service categories are assigned when adding services; service providers no longer choose a category during onboarding. The `/api/v1/service-categories` endpoint lists the seeded categories.
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.

--- a/frontend/src/app/__tests__/HomePage.test.tsx
+++ b/frontend/src/app/__tests__/HomePage.test.tsx
@@ -25,4 +25,18 @@ describe('HomePage', () => {
     });
     div.remove();
   });
+
+  it('renders category-specific providers when category is selected', async () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<HomePage searchParams={{ category: 'dj' }} />);
+    });
+    expect(div.textContent).toContain('DJs');
+    act(() => {
+      root.unmount();
+    });
+    div.remove();
+  });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,29 @@
 import MainLayout from '@/components/layout/MainLayout'
 import ArtistsSection from '@/components/home/ArtistsSection'
 import CategoriesCarousel from '@/components/home/CategoriesCarousel'
+import { UI_CATEGORY_TO_SERVICE, UI_CATEGORIES } from '@/lib/categoryMap'
 
-export default function HomePage() {
+interface HomePageProps {
+  searchParams?: { category?: string }
+}
+
+export default function HomePage({ searchParams }: HomePageProps = {}) {
+  const category = searchParams?.category
+  const serviceName = category ? UI_CATEGORY_TO_SERVICE[category] : undefined
+  const categoryLabel = category
+    ? UI_CATEGORIES.find((c) => c.value === category)?.label
+    : undefined
+
   return (
     <MainLayout>
       <CategoriesCarousel />
+      {serviceName && categoryLabel && (
+        <ArtistsSection
+          title={`${categoryLabel} Service Providers`}
+          query={{ category: serviceName }}
+          hideIfEmpty
+        />
+      )}
       <ArtistsSection
         title="Popular Musicians"
         query={{ sort: 'most_booked' }}

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -8,12 +8,13 @@
  import { UI_CATEGORIES } from '@/lib/categoryMap';
  
 
- /**
-  * Displays a horizontally scrollable list of service categories.
-  * Each item shows a square image placeholder and a label below.
-  * Clicking an item navigates to the artists listing with the
-  * category pre-selected.
-  */
+/**
+ * Displays a horizontally scrollable list of service categories.
+ * Each item shows a square image placeholder and a label below.
+ * Clicking an item navigates to the homepage with the category
+ * pre-selected via a query parameter so the relevant service
+ * providers render immediately.
+ */
  export default function CategoriesCarousel() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -63,7 +64,7 @@
   {UI_CATEGORIES.map((cat) => (
   <Link
   key={cat.value}
-  href={`/category/${encodeURIComponent(cat.value)}`}
+        href={`/?category=${encodeURIComponent(cat.value)}`}
   className="flex-shrink-0 flex flex-col hover:no-underline"
   >
   <div className="relative h-40 w-40 overflow-hidden rounded-lg bg-gray-100">

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -29,6 +29,19 @@ describe('CategoriesCarousel', () => {
     container.remove();
   });
 
+  it('links categories to the homepage with query params', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(React.createElement(CategoriesCarousel));
+    });
+    const firstLink = container.querySelector('a');
+    expect(firstLink?.getAttribute('href')).toBe('/?category=musician');
+    act(() => root.unmount());
+    container.remove();
+  });
+
   it('scrolls when clicking the next button', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- route category carousel items to the homepage with a category query parameter
- render category-specific providers on the homepage when a category is selected
- document homepage category filtering and add unit tests

## Testing
- `npm test -- --maxWorkers=50% --passWithNoTests` (fails: ChatThreadView module not found; 37 test suites failed)

------
https://chatgpt.com/codex/tasks/task_e_6897b905dd34832e9e4e277d00c3560a