### PR TITLE
feat: hide service-less providers from listings

### DIFF
--- a/backend/app/api/v1/api_artist.py
+++ b/backend/app/api/v1/api_artist.py
@@ -507,6 +507,8 @@ def read_all_artist_profiles(
         .outerjoin(rating_subq, rating_subq.c.artist_id == Artist.user_id)
         .outerjoin(booking_subq, booking_subq.c.artist_id == Artist.user_id)
     )
+    # Exclude service providers who have not added any services.
+    query = query.filter(Artist.services.any())
     if artist:
         query = query.join(User).filter(
             or_(

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -35,6 +35,7 @@ class RecommendationService:
         return (
             db.query(ArtistProfile)
             .outerjoin(Review, Review.artist_id == ArtistProfile.user_id)
+            .filter(ArtistProfile.services.any())
             .group_by(ArtistProfile.user_id)
             .order_by(func.coalesce(func.avg(Review.rating), 0).desc())
             .limit(limit)

--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -2,6 +2,8 @@
 
 Artists can now publish offerings using a shared **BaseServiceWizard**. The wizard mirrors the musician service modal so every category shares the same layout and navigation. It manages step flow, form submission and client-side media uploads while category wizards supply their own fields. Media uploads now match the musician experience with image-only validation, thumbnail previews and the ability to remove selections before publishing.
 
+> **Visibility note:** Service providers remain hidden from search results and the homepage until they publish at least one service. Adding a service through this workflow makes the profile publicly discoverable.
+
 ## Categories
 
 All service categories share the BaseServiceWizard for a consistent layout and navigation. Seeded categories include:


### PR DESCRIPTION
## Summary
- ignore artist profiles without services in search results
- skip service-less artists in recommendation fallback
- document requirement to add a service for visibility

## Testing
- `./scripts/test-all.sh`
- `PYTHONPATH=backend pytest backend/tests/test_artist_endpoint.py::test_artist_profiles_excludes_artists_without_services backend/tests/test_recommendation_endpoint.py::test_recommendations_fallback`


------
https://chatgpt.com/codex/tasks/task_e_6897b9202918832ea19f87f40584e4b4