### PR TITLE
fix: remove deprecated metadata viewport

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,7 +14,6 @@ const inter = Inter({
 export const metadata = {
   title: 'Artist Booking App',
   description: 'Book your favorite artists for services',
-  viewport: 'width=device-width, initial-scale=1',
 };
 
 export const viewport = {


### PR DESCRIPTION
## Summary
- remove unsupported `viewport` property from root app metadata

## Testing
- `npm test` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68981f748bf4832e8ce677a7a1ea4fdf