### PR TITLE
feat: link services with category ids

### DIFF
--- a/frontend/src/components/dashboard/add-service/AddServiceModalBartender.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalBartender.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface BartenderForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalBartender({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['bartender']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalCaterer.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalCaterer.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface CatererForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalCaterer({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['caterer']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalDJ.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalDJ.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface DJForm {
   title: string;
@@ -179,6 +180,7 @@ export default function AddServiceModalDJ({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['dj']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalEventService.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalEventService.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput, TextArea } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface EventServiceForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalEventService({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['event_service']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalMcHost.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalMcHost.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface McHostForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalMcHost({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['mc_host']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
@@ -23,6 +23,7 @@ import {
 import { DEFAULT_CURRENCY } from "@/lib/constants";
 import Button from "@/components/ui/Button";
 import { Stepper, TextInput, TextArea } from "@/components/ui";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 const serviceTypeIcons: Record<Service["service_type"], ElementType> = {
   "Live Performance": MusicalNoteIcon,
@@ -248,6 +249,7 @@ export default function AddServiceModalMusician({
         ...data,
         price: Number(data.price || 0),
         duration_minutes: Number(data.duration_minutes || 0),
+        service_category_id: UI_CATEGORY_TO_ID['musician'],
         travel_rate: data.travel_rate ? Number(data.travel_rate) : undefined,
         travel_members: data.travel_members
           ? Number(data.travel_members)

--- a/frontend/src/components/dashboard/add-service/AddServiceModalPhotographer.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalPhotographer.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface PhotographerForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalPhotographer({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['photographer']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalSpeaker.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalSpeaker.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface SpeakerForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalSpeaker({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['speaker']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalVideographer.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalVideographer.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface VideographerForm {
   title: string;
@@ -182,6 +183,7 @@ export default function AddServiceModalVideographer({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['videographer']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/AddServiceModalWeddingVenue.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalWeddingVenue.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { TextInput } from "@/components/ui";
 import type { Service } from "@/types";
 import BaseServiceWizard, { type WizardStep } from "./BaseServiceWizard";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 interface WeddingVenueForm {
   title: string;
@@ -183,6 +184,7 @@ export default function AddServiceModalWeddingVenue({
       steps={steps}
       defaultValues={defaults}
       toPayload={toPayload}
+      serviceCategoryId={UI_CATEGORY_TO_ID['wedding_venue']}
     />
   );
 }

--- a/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
+++ b/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
@@ -62,6 +62,7 @@ interface BaseServiceWizardProps<T extends FieldValues> {
   steps: WizardStep<T>[];
   defaultValues: T;
   toPayload: (data: T, mediaUrl: string | null) => Partial<Service>;
+  serviceCategoryId?: number;
 }
 
 export default function BaseServiceWizard<T extends FieldValues>({
@@ -72,6 +73,7 @@ export default function BaseServiceWizard<T extends FieldValues>({
   steps,
   defaultValues,
   toPayload,
+  serviceCategoryId,
 }: BaseServiceWizardProps<T>) {
   const [step, setStep] = useState(0);
   const [maxStep, setMaxStep] = useState(0);
@@ -177,7 +179,10 @@ export default function BaseServiceWizard<T extends FieldValues>({
           reader.readAsDataURL(mediaFiles[0]);
         });
       }
-      const payload = toPayload(data, mediaUrl);
+      const payload: Partial<Service> = toPayload(data, mediaUrl);
+      if (serviceCategoryId !== undefined) {
+        payload.service_category_id = serviceCategoryId;
+      }
       const res = service
         ? await apiUpdateService(service.id, payload)
         : await apiCreateService(payload);

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalDJ from "../AddServiceModalDJ";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 import { flushPromises } from "@/test/utils/flush";
 
 describe("AddServiceModalDJ", () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalDJ", () => {
         service_type: "Live Performance",
         details: { genre: "EDM" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID['dj'],
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import AddServiceModalMusician from "../AddServiceModalMusician";
 import * as api from "@/lib/api";
 import { Service } from "@/types";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 import { flushPromises } from "@/test/utils/flush";
 
 describe("AddServiceModalMusician editing", () => {
@@ -38,6 +39,9 @@ describe("AddServiceModalMusician editing", () => {
     await user.click(screen.getByRole("button", { name: /Save Changes/i }));
     await flushPromises();
 
-    expect(spy).toHaveBeenCalledWith(1, expect.any(Object));
+    expect(spy).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ service_category_id: UI_CATEGORY_TO_ID['musician'] }),
+    );
   });
 });

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -14,6 +14,13 @@ export const UI_CATEGORIES = [
   { value: 'mc_host', label: 'MCs & Hosts', image: '/categories/mc_host.png' },
 ] as const; // `as const` ensures TypeScript infers literal types, which is good practice
 
+// Map UI category slugs to their canonical numeric IDs. The order of
+// `UI_CATEGORIES` mirrors the backend seed data so the index + 1
+// consistently matches the database IDs.
+export const UI_CATEGORY_TO_ID: Record<string, number> = Object.fromEntries(
+  UI_CATEGORIES.map((c, idx) => [c.value, idx + 1]),
+);
+
 // Map UI categories (keys are UI values) to backend service categories (values are backend values)
 export const UI_CATEGORY_TO_SERVICE: Record<string, string> = {
   musician: 'Musician',


### PR DESCRIPTION
## Summary
- map frontend service categories to canonical numeric IDs
- persist `service_category_id` when saving services
- verify DJ service modal includes category mapping

## Testing
- `./scripts/test-all.sh` *(fails: Snapshot Summary › 5 snapshots failed from 2 test suites. Test Suites: 37 failed, 2 skipped, 87 passed, 124 of 126 total)*

------
https://chatgpt.com/codex/tasks/task_e_689821ac008c832ea9490a2b6f4e4449