### PR TITLE
Show DJs without requiring business names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Dashboard now casts `user.id` to a number when fetching services to avoid 422 errors if the ID is stored as a string.
 - Search categories now map each service category to its corresponding service type (for example, **Musician / Band** maps to `Live Performance`) so searching by category shows available artists.
 - Visiting `/category/dj` (or the legacy `/artists/category/dj`) normalizes the category path so listings only show matching services.
+- DJ listings now include providers even if their business name matches their personal name, ensuring all DJs who add a service are visible.
 - The artist search endpoint now ignores unrecognised `category` values (for example, `category=Musician` or `category=DJ`) and returns all artists instead of a 422 error.
 - Category popup now includes an artist name search input for quick navigation to
   individual profiles.

--- a/backend/app/api/v1/api_artist.py
+++ b/backend/app/api/v1/api_artist.py
@@ -615,20 +615,10 @@ def read_all_artist_profiles(
         profiles = [p for p in profiles if p.is_available]
         total_count = len(profiles)
 
-    # When browsing the DJ category, exclude legacy artist records where
-    # the business name matches the user's first and last name. These
-    # entries stem from older imports and represent musicians rather than
-    # actual DJ businesses.
-    if category_slug == "dj":
-        def _is_legacy(p: ArtistProfileResponse) -> bool:
-            full_name = (
-                f"{p.user.first_name} {p.user.last_name}" if p.user else ""
-            ).strip().lower()
-            business = (p.business_name or "").strip().lower()
-            return business == full_name or business == ""
-
-        profiles = [p for p in profiles if not _is_legacy(p)]
-        total_count = len(profiles)
+    # Previously, legacy DJ records with a business name matching the user's
+    # full name were filtered out. This excluded legitimate providers who had
+    # not set a distinct business name. All providers with a DJ service should
+    # now be visible, so no additional filtering is applied here.
 
     if not include_price_distribution and when is None:
         cache_artist_list(

--- a/backend/tests/test_artist_endpoint.py
+++ b/backend/tests/test_artist_endpoint.py
@@ -165,8 +165,8 @@ def test_category_excludes_artists_without_services(monkeypatch):
     app.dependency_overrides.pop(get_db, None)
 
 
-def test_dj_category_filters_legacy_artists(monkeypatch):
-    """Profiles with a business name matching the user's full name are excluded."""
+def test_dj_category_includes_legacy_artists(monkeypatch):
+    """Profiles with a business name matching the user's full name should appear."""
     Session = setup_app(monkeypatch)
     db = Session()
 
@@ -236,6 +236,8 @@ def test_dj_category_filters_legacy_artists(monkeypatch):
     res = client.get("/api/v1/artist-profiles/?category=DJ")
     assert res.status_code == 200
     body = res.json()
-    assert body["total"] == 1
-    assert body["data"][0]["business_name"] == "Beats Inc"
+    assert body["total"] == 2
+    names = {item["business_name"] for item in body["data"]}
+    assert "Beats Inc" in names
+    assert "Legacy Artist" in names
     app.dependency_overrides.pop(get_db, None)

--- a/frontend/src/app/__tests__/ArtistsPage.test.tsx
+++ b/frontend/src/app/__tests__/ArtistsPage.test.tsx
@@ -37,7 +37,7 @@ describe('ArtistsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('requests and filters DJs', async () => {
+  it('requests DJs including those without business names', async () => {
     render(<ArtistsPage />);
     await waitFor(() => expect(mockedGetArtists).toHaveBeenCalledTimes(1));
     expect(mockedGetArtists).toHaveBeenCalledWith(
@@ -45,7 +45,7 @@ describe('ArtistsPage', () => {
     );
 
     await screen.findByText('DJ One Biz');
-    expect(screen.queryByText('DJ NoBiz')).toBeNull();
+    await screen.findByText('DJ NoBiz');
   });
 
   it('normalizes UI slug category query param', async () => {

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -116,19 +116,9 @@ export default function ArtistsPage() {
           includePriceDistribution: true,
         });
         // Filter client-side to guard against any backend responses that
-        // include artists from other service categories. For the DJ category,
-        // only include profiles with a business name so personal artist names
-        // never appear.
-        const filtered = res.data.filter((a) => {
-          if (serviceName === 'DJ') {
-            const business = a.business_name?.trim().toLowerCase();
-            const fullName = `${a.user?.first_name ?? ''} ${a.user?.last_name ?? ''}`
-              .trim()
-              .toLowerCase();
-            return !!business && business !== fullName;
-          }
-          return !!(a.business_name || a.user);
-        });
+        // include artists from other service categories. All DJs are now
+        // included regardless of business name.
+        const filtered = res.data.filter((a) => !!(a.business_name || a.user));
         setHasMore(filtered.length === LIMIT);
         setArtists((prev) => (append ? [...prev, ...filtered] : filtered));
         setPriceDistribution(res.price_distribution || []);


### PR DESCRIPTION
## Summary
- remove server-side filter that excluded DJs whose business name matched their personal name
- allow frontend artist listing to display all DJs regardless of business name
- document DJ listing behavior in README

## Testing
- `./scripts/test-all.sh` *(failed: Git remote 'origin' not found)*
- `pytest` *(errors during collection)*
- `npm test` *(failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689825625068832ea815a1a912cfa4e4