### PR TITLE
fix: ensure category IDs map to correct providers

### DIFF
--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -19,6 +19,9 @@ All service categories share the BaseServiceWizard for a consistent layout and n
 - **Bartender**
 - **MC & Host**
 
+Each category has a canonical numeric ID defined in `frontend/src/lib/categoryMap.ts`,
+ensuring services map to the correct providers regardless of display order.
+
 Each category adds its own fields; for example, a **Musician** selects a service type such as Live Performance and sets pricing, while a **Photographer** captures camera details and pricing. All wizards submit to the existing `/api/v1/services/` endpoint. Media files are read client-side and sent as base64 strings in the `media_url` field.
 
 The newly added **DJ** wizard records a preferred genre, while the **Event Service** wizard captures a description of the offering. Both reuse the BaseServiceWizard to provide the same navigation and media upload experience as other categories.

--- a/frontend/src/lib/__tests__/categoryMap.test.ts
+++ b/frontend/src/lib/__tests__/categoryMap.test.ts
@@ -1,0 +1,9 @@
+import { UI_CATEGORIES, UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
+
+describe("categoryMap", () => {
+  it("maps each category value to its explicit id", () => {
+    UI_CATEGORIES.forEach((cat) => {
+      expect(UI_CATEGORY_TO_ID[cat.value]).toBe(cat.id);
+    });
+  });
+});

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -1,24 +1,24 @@
 // src/lib/categoryMap.ts
 
-// Define the shape of a UI category item
+// Define the shape of a UI category item including the canonical backend ID.
+// Explicit IDs remove the previous dependency on array ordering so lookups
+// remain stable even if categories are re-arranged or new ones are inserted.
 export const UI_CATEGORIES = [
-  { value: 'musician', label: 'Musicians', image: '/categories/musician.png' },
-  { value: 'dj', label: 'DJs', image: '/categories/dj.png' },
-  { value: 'photographer', label: 'Photographers', image: '/categories/photographer.png' },
-  { value: 'videographer', label: 'Videographers', image: '/categories/videographer.png' },
-  { value: 'speaker', label: 'Speakers', image: '/categories/speaker.png' },
-  { value: 'event_service', label: 'Event Services', image: '/categories/event_service.png' },
-  { value: 'wedding_venue', label: 'Wedding Venues', image: '/categories/wedding_venue.png' },
-  { value: 'caterer', label: 'Caterers', image: '/categories/caterer.png' },
-  { value: 'bartender', label: 'Bartenders', image: '/categories/bartender.png' },
-  { value: 'mc_host', label: 'MCs & Hosts', image: '/categories/mc_host.png' },
+  { id: 1, value: 'musician', label: 'Musicians', image: '/categories/musician.png' },
+  { id: 2, value: 'dj', label: 'DJs', image: '/categories/dj.png' },
+  { id: 3, value: 'photographer', label: 'Photographers', image: '/categories/photographer.png' },
+  { id: 4, value: 'videographer', label: 'Videographers', image: '/categories/videographer.png' },
+  { id: 5, value: 'speaker', label: 'Speakers', image: '/categories/speaker.png' },
+  { id: 6, value: 'event_service', label: 'Event Services', image: '/categories/event_service.png' },
+  { id: 7, value: 'wedding_venue', label: 'Wedding Venues', image: '/categories/wedding_venue.png' },
+  { id: 8, value: 'caterer', label: 'Caterers', image: '/categories/caterer.png' },
+  { id: 9, value: 'bartender', label: 'Bartenders', image: '/categories/bartender.png' },
+  { id: 10, value: 'mc_host', label: 'MCs & Hosts', image: '/categories/mc_host.png' },
 ] as const; // `as const` ensures TypeScript infers literal types, which is good practice
 
-// Map UI category slugs to their canonical numeric IDs. The order of
-// `UI_CATEGORIES` mirrors the backend seed data so the index + 1
-// consistently matches the database IDs.
+// Map UI category slugs to their canonical numeric IDs.
 export const UI_CATEGORY_TO_ID: Record<string, number> = Object.fromEntries(
-  UI_CATEGORIES.map((c, idx) => [c.value, idx + 1]),
+  UI_CATEGORIES.map((c) => [c.value, c.id]),
 );
 
 // Map UI categories (keys are UI values) to backend service categories (values are backend values)


### PR DESCRIPTION
## Summary
- assign explicit backend IDs to UI service categories
- document canonical category IDs in add-service workflow
- add tests to verify category-to-ID mappings

## Testing
- `./scripts/test-all.sh` (fails: 58 failed, 329 passed)


------
https://chatgpt.com/codex/tasks/task_e_68982bcfcd54832ea6de5d6e14720fc0