### PR TITLE
Map service line-of-work to category ID

### DIFF
--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -22,7 +22,7 @@ All service categories share the BaseServiceWizard for a consistent layout and n
 Each category has a canonical numeric ID defined in `frontend/src/lib/categoryMap.ts`,
 ensuring services map to the correct providers regardless of display order.
 
-Each category adds its own fields; for example, a **Musician** selects a service type such as Live Performance and sets pricing, while a **Photographer** captures camera details and pricing. All wizards submit to the existing `/api/v1/services/` endpoint. Media files are read client-side and sent as base64 strings in the `media_url` field.
+Each category adds its own fields; for example, a **Musician** selects a service type such as Live Performance and sets pricing, while a **Photographer** captures camera details and pricing. All wizards submit to the existing `/api/v1/services/` endpoint. Media files are read client-side and sent as base64 strings in the `media_url` field. When a provider chooses a line of work, the wizard maps the selected slug to the canonical `service_category_id` so the API links the new service to the correct backend category.
 
 The newly added **DJ** wizard records a preferred genre, while the **Event Service** wizard captures a description of the offering. Both reuse the BaseServiceWizard to provide the same navigation and media upload experience as other categories.
 

--- a/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
@@ -23,6 +23,7 @@ import {
 import { DEFAULT_CURRENCY } from "@/lib/constants";
 import Button from "@/components/ui/Button";
 import { Stepper, TextInput, TextArea } from "@/components/ui";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 const serviceTypeIcons: Record<Service["service_type"], ElementType> = {
   "Live Performance": MusicalNoteIcon,
@@ -248,7 +249,7 @@ export default function AddServiceModalMusician({
         ...data,
         price: Number(data.price || 0),
         duration_minutes: Number(data.duration_minutes || 0),
-        service_category_slug: 'musician',
+        service_category_id: UI_CATEGORY_TO_ID.musician,
         travel_rate: data.travel_rate ? Number(data.travel_rate) : undefined,
         travel_members: data.travel_members
           ? Number(data.travel_members)

--- a/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
+++ b/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
@@ -16,6 +16,7 @@ import {
   createService as apiCreateService,
   updateService as apiUpdateService,
 } from "@/lib/api";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 import type { Service } from "@/types";
 
 function useImageThumbnails(files: File[]) {
@@ -181,7 +182,7 @@ export default function BaseServiceWizard<T extends FieldValues>({
       }
       const payload: Partial<Service> = toPayload(data, mediaUrl);
       if (serviceCategorySlug !== undefined) {
-        payload.service_category_slug = serviceCategorySlug;
+        payload.service_category_id = UI_CATEGORY_TO_ID[serviceCategorySlug];
       }
       const res = service
         ? await apiUpdateService(service.id, payload)

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalBartender.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalBartender.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalBartender from "../AddServiceModalBartender";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalBartender", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalBartender", () => {
         service_type: "Other",
         details: { signature_drink: "Mojito" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.bartender,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalCaterer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalCaterer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalCaterer from "../AddServiceModalCaterer";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalCaterer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalCaterer", () => {
         service_type: "Other",
         details: { cuisine: "Italian" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.caterer,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalDJ from "../AddServiceModalDJ";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalDJ", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,7 +43,7 @@ describe("AddServiceModalDJ", () => {
         service_type: "Live Performance",
         details: { genre: "EDM" },
         media_url: expect.stringContaining("base64"),
-        service_category_slug: 'dj',
+        service_category_id: UI_CATEGORY_TO_ID.dj,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalEventService.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalEventService.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalEventService from "../AddServiceModalEventService";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalEventService", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalEventService", () => {
         service_type: "Other",
         details: { description: "Lighting" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.event_service,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMcHost.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMcHost.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalMcHost from "../AddServiceModalMcHost";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMcHost", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalMcHost", () => {
         service_type: "Other",
         details: { hosting_style: "Formal" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.mc_host,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMusician.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMusician.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalMusician from "../AddServiceModalMusician";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMusician", () => {
   it.skip("validates required fields and submits payload", async () => {
@@ -50,6 +51,7 @@ describe("AddServiceModalMusician", () => {
         price: 100,
         service_type: "Live Performance",
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.musician,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalPhotographer from "../AddServiceModalPhotographer";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalPhotographer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -48,6 +49,7 @@ describe("AddServiceModalPhotographer", () => {
         service_type: "Other",
         details: { camera_brand: "Canon" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.photographer,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalSpeaker.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalSpeaker.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalSpeaker from "../AddServiceModalSpeaker";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalSpeaker", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalSpeaker", () => {
         service_type: "Other",
         details: { topic: "Motivation" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.speaker,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalVideographer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalVideographer.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalVideographer from "../AddServiceModalVideographer";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalVideographer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalVideographer", () => {
         service_type: "Other",
         details: { video_style: "Cinematic" },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.videographer,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalWeddingVenue.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalWeddingVenue.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalWeddingVenue from "../AddServiceModalWeddingVenue";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalWeddingVenue", () => {
   it("follows step flow and sends details payload", async () => {
@@ -42,6 +43,7 @@ describe("AddServiceModalWeddingVenue", () => {
         service_type: "Other",
         details: { capacity: 200 },
         media_url: expect.stringContaining("base64"),
+        service_category_id: UI_CATEGORY_TO_ID.wedding_venue,
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
@@ -4,6 +4,7 @@ import AddServiceModalMusician from "../AddServiceModalMusician";
 import * as api from "@/lib/api";
 import { Service } from "@/types";
 import { flushPromises } from "@/test/utils/flush";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMusician editing", () => {
   it("calls updateService on submit", async () => {
@@ -40,7 +41,9 @@ describe("AddServiceModalMusician editing", () => {
 
     expect(spy).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({ service_category_slug: 'musician' }),
+      expect.objectContaining({
+        service_category_id: UI_CATEGORY_TO_ID.musician,
+      }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- map selected line of work slugs to canonical service_category_id when saving services
- update musician wizard and related tests to use category IDs
- document slug-to-ID mapping in service addition workflow

## Testing
- `./scripts/test-all.sh` *(fails: 37 failed, 88 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689836163124832ea42aef54dd0ed496