### PR TITLE
feat: fetch service categories dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Service categories are assigned when adding services; service providers no longer choose a category during onboarding. The `/api/v1/service-categories` endpoint lists the seeded categories.
+- Frontend components now fetch service categories dynamically via the `useServiceCategories` hook rather than relying on a static map.
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in

--- a/frontend/src/app/__tests__/ArtistsPage.test.tsx
+++ b/frontend/src/app/__tests__/ArtistsPage.test.tsx
@@ -3,19 +3,26 @@ import ArtistsPage from '../artists/page';
 import { getArtists } from '@/lib/api';
 import { useSearchParams, usePathname } from '@/tests/mocks/next-navigation';
 import { useAuth } from '@/contexts/AuthContext';
+import useServiceCategories from '@/hooks/useServiceCategories';
 
 jest.mock('next/navigation', () => require('@/tests/mocks/next-navigation'));
 jest.mock('@/lib/api');
 jest.mock('@/contexts/AuthContext');
+jest.mock('@/hooks/useServiceCategories');
 
 const mockedGetArtists = getArtists as jest.MockedFunction<typeof getArtists>;
 const mockedUseAuth = useAuth as jest.Mock;
+const mockedUseServiceCategories = useServiceCategories as jest.Mock;
 
 describe('ArtistsPage', () => {
   beforeEach(() => {
     useSearchParams.mockReturnValue(new URLSearchParams('category=DJ'));
     usePathname.mockReturnValue('/');
     mockedUseAuth.mockReturnValue({ user: { id: 1, first_name: 'Test', email: 't@example.com' } });
+    mockedUseServiceCategories.mockReturnValue([
+      { id: 1, value: 'dj', label: 'DJ' },
+      { id: 2, value: 'musician', label: 'Musician' },
+    ]);
     mockedGetArtists.mockResolvedValue({
       data: [
         {

--- a/frontend/src/app/artists/page.tsx
+++ b/frontend/src/app/artists/page.tsx
@@ -5,7 +5,7 @@ import { format, parseISO, isValid } from 'date-fns';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import MainLayout from '@/components/layout/MainLayout';
 import { getArtists, type PriceBucket } from '@/lib/api';
-import { UI_CATEGORY_TO_SERVICE, SERVICE_TO_UI_CATEGORY } from '@/lib/categoryMap';
+import useServiceCategories from '@/hooks/useServiceCategories';
 import { getFullImageUrl } from '@/lib/utils';
 import type { ArtistProfile } from '@/types';
 import ArtistCardCompact from '@/components/artist/ArtistCardCompact';
@@ -28,6 +28,7 @@ export default function ArtistsPage() {
 
   // Store the selected category as a UI slug (e.g. "dj") so we can map it
   // to the backend service name whenever querying the API.
+  const categories = useServiceCategories();
   const [category, setCategory] = useState<string | undefined>(undefined);
   const [location, setLocation] = useState('');
   const [sort, setSort] = useState<string | undefined>(undefined);
@@ -49,13 +50,15 @@ export default function ArtistsPage() {
   const LIMIT = 20;
 
   // Derived backend service name for the selected UI category.
-  const serviceName = category ? UI_CATEGORY_TO_SERVICE[category] : undefined;
+  const serviceName = category
+    ? categories.find((c) => c.value === category)?.label
+    : undefined;
 
   useEffect(() => {
     // ``category`` may arrive either as a backend service name ("DJ") or
-    // as a UI slug ("dj"). Normalize both forms to the UI value so the rest of
-    // the page logic consistently derives the backend name via
-    // ``UI_CATEGORY_TO_SERVICE``.
+    // as a UI slug ("dj"). Normalize both forms to the UI slug so the rest of
+    // the page logic can derive the backend name from the loaded categories.
+    if (!categories.length) return;
     let value = searchParams.get('category') || undefined;
     if (!value) {
       const match = pathname.match(/\/(?:artists\/category|category)\/([^/?]+)/);
@@ -65,12 +68,12 @@ export default function ArtistsPage() {
     }
     let uiValue: string | undefined;
     if (value) {
-      if (SERVICE_TO_UI_CATEGORY[value]) {
-        // Already a backend service name
-        uiValue = SERVICE_TO_UI_CATEGORY[value];
-      } else if (UI_CATEGORY_TO_SERVICE[value]) {
-        // Received a UI slug
-        uiValue = value;
+      const bySlug = categories.find((c) => c.value === value);
+      if (bySlug) {
+        uiValue = bySlug.value;
+      } else {
+        const byName = categories.find((c) => c.label === value);
+        uiValue = byName?.value;
       }
     }
     setCategory(uiValue);
@@ -92,7 +95,7 @@ export default function ArtistsPage() {
     setMinPrice(searchParams.get('minPrice') ? Number(searchParams.get('minPrice')) : SLIDER_MIN);
     setMaxPrice(searchParams.get('maxPrice') ? Number(searchParams.get('maxPrice')) : SLIDER_MAX);
     setFiltersReady(true);
-  }, [searchParams, pathname]);
+  }, [searchParams, pathname, categories]);
 
   const fetchArtists = useCallback(
     async (

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -5,7 +5,8 @@
  import Link from 'next/link';
  import { useEffect, useRef, useState } from 'react';
  import { ChevronRightIcon } from '@heroicons/react/24/solid';
- import { UI_CATEGORIES } from '@/lib/categoryMap';
+ import useServiceCategories from '@/hooks/useServiceCategories';
+ import { CATEGORY_IMAGES } from '@/lib/categoryMap';
  
 
  /**
@@ -46,6 +47,8 @@
   };
  
 
+  const categories = useServiceCategories();
+
   return (
   <section
   className="full-width mx-auto mt-4 px-4 sm:px-6 lg:px-8"
@@ -60,7 +63,7 @@
   data-testid="categories-scroll"
   className="flex gap-4 overflow-x-auto scroll-smooth pb-2 scrollbar-hide"
   >
-  {UI_CATEGORIES.map((cat) => (
+  {categories.map((cat) => (
   <Link
   key={cat.value}
   href={`/category/${encodeURIComponent(cat.value)}`}
@@ -68,7 +71,7 @@
   >
   <div className="relative h-40 w-40 overflow-hidden rounded-lg bg-gray-100">
   <Image
-  src={cat.image || '/bartender.png'}
+  src={CATEGORY_IMAGES[cat.value] || '/bartender.png'}
   alt={cat.label}
   fill
   sizes="160px"

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -2,11 +2,28 @@ import { createRoot } from 'react-dom/client';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import CategoriesCarousel from '../CategoriesCarousel';
-import { UI_CATEGORIES } from '@/lib/categoryMap';
+import { getServiceCategories } from '@/lib/api';
+import type { Category } from '@/hooks/useServiceCategories';
+
+jest.mock('@/lib/api');
+
+const mockedGetServiceCategories = getServiceCategories as jest.MockedFunction<
+  typeof getServiceCategories
+>;
+
+const MOCK_CATEGORIES: Category[] = [
+  { id: 1, value: 'dj', label: 'DJ' },
+  { id: 2, value: 'musician', label: 'Musician' },
+];
 
 describe('CategoriesCarousel', () => {
+  beforeEach(() => {
+    mockedGetServiceCategories.mockResolvedValue({ data: MOCK_CATEGORIES } as any);
+  });
+
   afterEach(() => {
     document.body.innerHTML = '';
+    jest.clearAllMocks();
   });
 
   it('renders categories with navigation buttons', () => {
@@ -16,12 +33,12 @@ describe('CategoriesCarousel', () => {
     act(() => {
       root.render(React.createElement(CategoriesCarousel));
     });
-    UI_CATEGORIES.forEach((cat) => {
+    MOCK_CATEGORIES.forEach((cat) => {
       expect(container.textContent).toContain(cat.label);
     });
     const imgs = container.querySelectorAll('img');
-    UI_CATEGORIES.forEach((cat, index) => {
-      expect(imgs[index].getAttribute('src')).toBe(cat.image);
+    MOCK_CATEGORIES.forEach((cat, index) => {
+      expect(imgs[index].getAttribute('src')).toContain(cat.value);
     });
     const next = container.querySelector('button[aria-label="Next"]');
     expect(next).not.toBeNull();
@@ -84,12 +101,10 @@ describe('CategoriesCarousel', () => {
     expect(wrapper?.className).toContain('w-40');
     expect(wrapper?.className).toContain('h-40');
 
-
     const label = container.querySelector('a p');
     expect(label?.className).toContain('absolute');
     expect(label?.className).toContain('left-2');
     expect(label?.className).toContain('bottom-2');
-
 
     act(() => root.unmount());
     container.remove();

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -12,10 +12,9 @@ import NotificationBell from './NotificationBell'; // Assuming NotificationBell 
 import MobileMenuDrawer from './MobileMenuDrawer'; // Assuming MobileMenuDrawer is set up
 import SearchBar from '../search/SearchBar'; // The full search bar component
 import { navItemClasses } from './navStyles';
-import { SERVICE_TO_UI_CATEGORY, UI_CATEGORIES } from '@/lib/categoryMap';
+import useServiceCategories, { Category } from '@/hooks/useServiceCategories';
 import { Avatar } from '../ui'; // Assuming Avatar is set up
 import clsx from 'clsx';
-import { type Category } from '../search/SearchFields'; // Import Category type from SearchFields
 import { parseISO, isValid } from 'date-fns';
 import { getStreetFromAddress } from '@/lib/utils';
 
@@ -94,14 +93,17 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
   const isArtistView = user?.user_type === 'service_provider' && artistViewActive;
 
   // Search parameters for the search bars (managed locally by Header and passed to SearchBar)
+  const categories = useServiceCategories();
   const [category, setCategory] = useState<Category | null>(null);
   const [location, setLocation] = useState<string>('');
   const [when, setWhen] = useState<Date | null>(null);
 
   useEffect(() => {
+    if (!categories.length) return;
     const serviceCat = searchParams.get('category');
-    const uiValue = serviceCat ? SERVICE_TO_UI_CATEGORY[serviceCat] || serviceCat : undefined;
-    const uiCategory = uiValue ? UI_CATEGORIES.find((c) => c.value === uiValue) || null : null;
+    const uiCategory = serviceCat
+      ? categories.find((c) => c.value === serviceCat) || null
+      : null;
     setCategory(uiCategory);
 
     setLocation(searchParams.get('location') || '');
@@ -117,7 +119,7 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
     } else {
       setWhen(null);
     }
-  }, [searchParams]);
+  }, [searchParams, categories]);
 
   const dateFormatter = new Intl.DateTimeFormat('en-US', {
     month: 'short',

--- a/frontend/src/components/search/SearchFields.tsx
+++ b/frontend/src/components/search/SearchFields.tsx
@@ -14,7 +14,7 @@ import { MusicalNoteIcon, CalendarIcon, MapPinIcon } from '@heroicons/react/24/o
 
 // Import types for consistency
 import type { ActivePopup } from './SearchBar'; // Assuming SearchBar defines ActivePopup
-import { Category as CategoryType } from '@/lib/categoryMap'; // Correctly import Category from categoryMap.ts
+import { Category as CategoryType } from '@/hooks/useServiceCategories';
 
 // Re-exporting for external use, if needed
 export type Category = CategoryType;

--- a/frontend/src/components/search/SearchModal.tsx
+++ b/frontend/src/components/search/SearchModal.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { BottomSheet, Button } from '@/components/ui';
 import { SearchFields, type Category } from './SearchFields';
-import { UI_CATEGORIES } from '@/lib/categoryMap';
+import useServiceCategories from '@/hooks/useServiceCategories';
 
 interface SearchModalProps {
   open: boolean;
@@ -25,9 +25,8 @@ export default function SearchModal({
   initialWhen,
   onSearch,
 }: SearchModalProps) {
-  const [category, setCategory] = useState<Category | null>(
-    initialCategory ? UI_CATEGORIES.find((c) => c.value === initialCategory) ?? null : null,
-  );
+  const categories = useServiceCategories();
+  const [category, setCategory] = useState<Category | null>(null);
   const [location, setLocation] = useState(initialLocation || '');
   const [when, setWhen] = useState<Date | null>(initialWhen || null);
   const firstRef = useRef<HTMLDivElement>(null);
@@ -36,14 +35,16 @@ export default function SearchModal({
   const handleFieldClick = () => {};
 
   useEffect(() => {
-    if (open) {
+    if (open && categories.length) {
       setCategory(
-        initialCategory ? UI_CATEGORIES.find((c) => c.value === initialCategory) ?? null : null,
+        initialCategory
+          ? categories.find((c) => c.value === initialCategory) ?? null
+          : null,
       );
       setLocation(initialLocation || '');
       setWhen(initialWhen || null);
     }
-  }, [open, initialCategory, initialLocation, initialWhen]);
+  }, [open, initialCategory, initialLocation, initialWhen, categories]);
 
   const handleClear = () => {
     setCategory(null);

--- a/frontend/src/components/search/SearchPopupContent.tsx
+++ b/frontend/src/components/search/SearchPopupContent.tsx
@@ -8,7 +8,7 @@ import { Listbox } from '@headlessui/react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
-import { UI_CATEGORIES } from '@/lib/categoryMap';
+import useServiceCategories from '@/hooks/useServiceCategories';
 import { getArtists } from '@/lib/api';
 import type { ArtistProfile } from '@/types';
 import { AUTOCOMPLETE_LISTBOX_ID } from '../ui/LocationInput';
@@ -64,6 +64,7 @@ export default function SearchPopupContent({
   const [announcement, setAnnouncement] = useState('');
   const [artistQuery, setArtistQuery] = useState('');
   const [artistResults, setArtistResults] = useState<ArtistProfile[]>([]);
+  const categories = useServiceCategories();
   const router = useRouter();
 
   useEffect(() => {
@@ -349,7 +350,7 @@ export default function SearchPopupContent({
           ref={categoryListboxOptionsRef}
           className="max-h-60 overflow-auto rounded-lg bg-white py-1 focus:outline-none scrollbar-thin"
         >
-          {UI_CATEGORIES.map((c, index) => (
+          {categories.map((c, index) => (
             <Listbox.Option key={c.value} value={c} as={React.Fragment}>
               {({ active, selected }) => (
                 <li

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import SearchBar from '../SearchBar';
-import { UI_CATEGORIES } from '@/lib/categoryMap';
+import { getServiceCategories } from '@/lib/api';
+import type { Category } from '@/hooks/useServiceCategories';
 
 // Mock next/dynamic to synchronously load a minimal SearchPopupContent
 jest.mock('next/dynamic', () => () => {
@@ -21,6 +22,20 @@ jest.mock('@/lib/loadPlaces', () => ({
       AutocompleteSessionToken: function () {},
     }),
 }));
+
+jest.mock('@/lib/api');
+
+const mockedGetServiceCategories = getServiceCategories as jest.MockedFunction<
+  typeof getServiceCategories
+>;
+const MOCK_CATEGORIES: Category[] = [
+  { id: 1, value: 'dj', label: 'DJ' },
+  { id: 2, value: 'musician', label: 'Musician' },
+];
+
+beforeEach(() => {
+  mockedGetServiceCategories.mockResolvedValue({ data: MOCK_CATEGORIES } as any);
+});
 
 describe('SearchBar', () => {
   it('keeps suggestions visible when typing in location', async () => {
@@ -167,7 +182,7 @@ describe('SearchBar', () => {
           <button
             type="button"
             data-testid="select-category"
-            onClick={() => setCategory(UI_CATEGORIES[0])}
+            onClick={() => setCategory(MOCK_CATEGORIES[0])}
           >
             select
           </button>
@@ -182,5 +197,29 @@ describe('SearchBar', () => {
     fireEvent.click(getByTestId('select-category'));
 
     expect(queryByLabelText('Clear Category')).not.toBeNull();
+  });
+
+  it('renders categories from the API', async () => {
+    const onSearch = jest.fn();
+    const Wrapper = () => {
+      const [category, setCategory] = React.useState<Category | null>(null);
+      const [location, setLocation] = React.useState('');
+      const [when, setWhen] = React.useState<Date | null>(null);
+      return (
+        <SearchBar
+          category={category}
+          setCategory={setCategory}
+          location={location}
+          setLocation={setLocation}
+          when={when}
+          setWhen={setWhen}
+          onSearch={onSearch}
+        />
+      );
+    };
+
+    const { getByRole, findByText } = render(<Wrapper />);
+    fireEvent.click(getByRole('button', { name: /Category/ }));
+    expect(await findByText('DJ')).not.toBeNull();
   });
 });

--- a/frontend/src/hooks/useServiceCategories.ts
+++ b/frontend/src/hooks/useServiceCategories.ts
@@ -1,0 +1,38 @@
+// src/hooks/useServiceCategories.ts
+import { useEffect, useState } from 'react';
+import { getServiceCategories } from '@/lib/api';
+import { categorySlug } from '@/lib/categoryMap';
+
+export interface Category {
+  id: number;
+  value: string; // slug used in URLs and queries
+  label: string; // human-readable name
+}
+
+let cachedCategories: Category[] | null = null;
+
+export default function useServiceCategories(): Category[] {
+  const [categories, setCategories] = useState<Category[]>(
+    cachedCategories || [],
+  );
+
+  useEffect(() => {
+    if (cachedCategories) return;
+    getServiceCategories()
+      .then((res) => {
+        const data = res.data.map((c) => ({
+          id: c.id,
+          value: categorySlug(c.name),
+          label: c.name,
+        }));
+        cachedCategories = data;
+        setCategories(data);
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch service categories', err);
+      });
+  }, []);
+
+  return categories;
+}

--- a/frontend/src/lib/__tests__/categoryMap.test.ts
+++ b/frontend/src/lib/__tests__/categoryMap.test.ts
@@ -1,9 +1,8 @@
-import { UI_CATEGORIES, UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
+import { categorySlug } from '@/lib/categoryMap';
 
-describe("categoryMap", () => {
-  it("maps each category value to its explicit id", () => {
-    UI_CATEGORIES.forEach((cat) => {
-      expect(UI_CATEGORY_TO_ID[cat.value]).toBe(cat.id);
-    });
+describe('categoryMap helpers', () => {
+  it('slugifies names consistently', () => {
+    expect(categorySlug('MC & Host')).toBe('mc_host');
+    expect(categorySlug('Wedding Venue')).toBe('wedding_venue');
   });
 });

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -1,44 +1,23 @@
 // src/lib/categoryMap.ts
+// Mapping helpers for service categories. The list of categories themselves is
+// fetched from the backend; this file only keeps UI resources that cannot be
+// derived from the API.
 
-// Define the shape of a UI category item including the canonical backend ID.
-// Explicit IDs remove the previous dependency on array ordering so lookups
-// remain stable even if categories are re-arranged or new ones are inserted.
-export const UI_CATEGORIES = [
-  { id: 1, value: 'musician', label: 'Musicians', image: '/categories/musician.png' },
-  { id: 2, value: 'dj', label: 'DJs', image: '/categories/dj.png' },
-  { id: 3, value: 'photographer', label: 'Photographers', image: '/categories/photographer.png' },
-  { id: 4, value: 'videographer', label: 'Videographers', image: '/categories/videographer.png' },
-  { id: 5, value: 'speaker', label: 'Speakers', image: '/categories/speaker.png' },
-  { id: 6, value: 'event_service', label: 'Event Services', image: '/categories/event_service.png' },
-  { id: 7, value: 'wedding_venue', label: 'Wedding Venues', image: '/categories/wedding_venue.png' },
-  { id: 8, value: 'caterer', label: 'Caterers', image: '/categories/caterer.png' },
-  { id: 9, value: 'bartender', label: 'Bartenders', image: '/categories/bartender.png' },
-  { id: 10, value: 'mc_host', label: 'MCs & Hosts', image: '/categories/mc_host.png' },
-] as const; // `as const` ensures TypeScript infers literal types, which is good practice
-
-// Map UI category slugs to their canonical numeric IDs.
-export const UI_CATEGORY_TO_ID: Record<string, number> = Object.fromEntries(
-  UI_CATEGORIES.map((c) => [c.value, c.id]),
-);
-
-// Map UI categories (keys are UI values) to backend service categories (values are backend values)
-export const UI_CATEGORY_TO_SERVICE: Record<string, string> = {
-  musician: 'Musician',
-  dj: 'DJ',
-  photographer: 'Photographer',
-  videographer: 'Videographer',
-  speaker: 'Speaker',
-  event_service: 'Event Service',
-  wedding_venue: 'Wedding Venue',
-  caterer: 'Caterer',
-  bartender: 'Bartender',
-  mc_host: 'MC & Host',
+// Map category slugs to their representative image paths.
+export const CATEGORY_IMAGES: Record<string, string> = {
+  musician: '/categories/musician.png',
+  dj: '/categories/dj.png',
+  photographer: '/categories/photographer.png',
+  videographer: '/categories/videographer.png',
+  speaker: '/categories/speaker.png',
+  event_service: '/categories/event_service.png',
+  wedding_venue: '/categories/wedding_venue.png',
+  caterer: '/categories/caterer.png',
+  bartender: '/categories/bartender.png',
+  mc_host: '/categories/mc_host.png',
 };
 
-// Create a reverse map from backend service categories to UI categories (for display purposes)
-export const SERVICE_TO_UI_CATEGORY: Record<string, string> = Object.fromEntries(
-  Object.entries(UI_CATEGORY_TO_SERVICE).map(([ui, service]) => [service, ui]),
-);
-
-// You can optionally export a type for clarity across components
-export type Category = typeof UI_CATEGORIES[number]; // Infers union of all UI category items
+// Convert a backend category name to a URL-friendly slug. This mirrors the
+// previous hard-coded mapping but works for future categories as well.
+export const categorySlug = (name: string): string =>
+  name.toLowerCase().replace(/&/g, '').replace(/\s+/g, '_');


### PR DESCRIPTION
## Summary
- fetch service categories from the backend with a shared hook
- render categories dynamically in search UI, header and carousel
- trim category map to image and slug helpers
- adjust tests to mock API and verify dynamic categories

## Testing
- `./scripts/test-all.sh` *(fails: 'service_category_id' is an invalid keyword argument for ArtistProfileV2)*

------
https://chatgpt.com/codex/tasks/task_e_68983bba4224832eb3702e79b81bfd05