### PR TITLE
Clear artist list cache when services change

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.
 - Artist profile responses now include a `service_categories` array listing all categories the artist offers.
+- Artist search results clear their Redis cache whenever services change so new offerings appear immediately in category searches.
 - Bookings now track `payment_status`, `deposit_amount`, and `deposit_paid` in
   `bookings_simple`. The deposit amount defaults to half of the accepted quote
   total. Booking API responses now include these fields alongside

--- a/backend/app/api/api_service.py
+++ b/backend/app/api/api_service.py
@@ -15,6 +15,7 @@ from ..models.service_category import ServiceCategory
 from ..schemas.service import ServiceCreate, ServiceUpdate, ServiceResponse
 from .dependencies import get_current_active_artist
 from ..utils import error_response
+from ..utils.redis_cache import invalidate_artist_list_cache
 
 router = APIRouter(
     # Note: NO prefix here, because main.py already does `prefix="/api/v1/services"`
@@ -92,6 +93,7 @@ def create_service(
     db.add(new_service)
     db.commit()
     db.refresh(new_service)
+    invalidate_artist_list_cache()
     return new_service
 
 
@@ -155,6 +157,7 @@ def update_service(
     db.add(service)
     db.commit()
     db.refresh(service)
+    invalidate_artist_list_cache()
     return service
 
 
@@ -231,4 +234,5 @@ def delete_service(
 
     db.delete(service)
     db.commit()
+    invalidate_artist_list_cache()
     return None

--- a/backend/app/utils/redis_cache.py
+++ b/backend/app/utils/redis_cache.py
@@ -82,6 +82,17 @@ def cache_artist_list(
     return None
 
 
+def invalidate_artist_list_cache() -> None:
+    """Remove all cached artist list entries."""
+    client = get_redis_client()
+    try:
+        for key in client.scan_iter(f"{ARTIST_LIST_KEY_PREFIX}:*"):
+            client.delete(key)
+    except redis.exceptions.ConnectionError as exc:
+        logging.warning("Could not clear artist list cache: %s", exc)
+    return None
+
+
 def close_redis_client() -> None:
     """Close the global Redis client if it exists."""
     global _redis_client

--- a/backend/tests/test_artist_endpoint.py
+++ b/backend/tests/test_artist_endpoint.py
@@ -185,7 +185,6 @@ def test_dj_category_filters_legacy_artists(monkeypatch):
     legacy_profile = ArtistProfileV2(
         user_id=1,
         business_name="Legacy Artist",
-        service_category_id=dj_cat.id,
     )
     legacy_service = Service(
         artist_id=1,
@@ -209,7 +208,6 @@ def test_dj_category_filters_legacy_artists(monkeypatch):
     dj_profile = ArtistProfileV2(
         user_id=2,
         business_name="Beats Inc",
-        service_category_id=dj_cat.id,
     )
     dj_service = Service(
         artist_id=2,

--- a/backend/tests/test_service_cache_invalidation.py
+++ b/backend/tests/test_service_cache_invalidation.py
@@ -1,0 +1,82 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.api.dependencies import get_db, get_current_active_artist
+from app.models import User, UserType
+from app.models.artist_profile_v2 import ArtistProfileV2
+from app.models.service_category import ServiceCategory
+from app.db_utils import seed_service_categories
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    from app.models.base import BaseModel
+
+    BaseModel.metadata.create_all(engine)
+    seed_service_categories(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def test_create_service_invalidates_cache(monkeypatch):
+    Session = setup_app()
+    db = Session()
+    user = User(
+        email="sp@example.com",
+        user_type=UserType.SERVICE_PROVIDER,
+        first_name="A",
+        last_name="B",
+        password="x",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.add(ArtistProfileV2(user_id=user.id))
+    db.commit()
+
+    def override_artist():
+        return user
+    called = {"flag": False}
+
+    def fake_invalidate():
+        called["flag"] = True
+
+    monkeypatch.setattr(
+        __import__("app.api.api_service", fromlist=["invalidate_artist_list_cache"]),
+        "invalidate_artist_list_cache",
+        fake_invalidate,
+    )
+
+    app.dependency_overrides[get_current_active_artist] = override_artist
+    client = TestClient(app)
+    category = db.query(ServiceCategory).first()
+    payload = {
+        "title": "Gig",
+        "duration_minutes": 60,
+        "price": "100.00",
+        "service_type": "Other",
+        "media_url": "x",
+        "service_category_id": category.id,
+    }
+    res = client.post("/api/v1/services/", json=payload)
+    assert res.status_code == 201
+    assert called["flag"]
+
+    app.dependency_overrides.pop(get_current_active_artist, None)
+    db.close()


### PR DESCRIPTION
## Summary
- clear Redis artist list cache whenever services are created, updated, or deleted
- document cache invalidation in README
- cover cache clearing with tests

## Testing
- `PYTHONPATH=backend pytest`
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 43 failed, 2 skipped, 82 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689847be7d30832ead6e2d87bffb39a6