### PR TITLE
Avoid default photographer category for new providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Service categories are assigned when adding services; service providers no longer choose a category during onboarding. The `/api/v1/service-categories` endpoint lists the seeded categories.
+- Newly registered service providers start with no default category, ensuring they aren't automatically labeled (e.g., as photographers) until they add a service.
 - Frontend components now fetch service categories dynamically via the `useServiceCategories` hook rather than relying on a static map.
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Event Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -94,9 +94,13 @@ def register(user_data: UserCreate, db: Session = Depends(get_db)):
         db.refresh(db_user)
 
         if db_user.user_type == UserType.SERVICE_PROVIDER:
+            # Create an empty service provider profile so the artist can
+            # decide their categories later. No default services are added,
+            # preventing accidental classification (e.g. as a photographer).
             service_provider_profile = ServiceProviderProfile(user_id=db_user.id)
             db.add(service_provider_profile)
             db.commit()
+            db.refresh(service_provider_profile)
             return db_user
 
         token_value = secrets.token_urlsafe(32)

--- a/backend/tests/test_service_provider_registration.py
+++ b/backend/tests/test_service_provider_registration.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.api.dependencies import get_db
+from app.models.base import BaseModel
+from app.models.service_provider_profile import ServiceProviderProfile
+from app.utils import redis_cache
+
+
+def setup_app(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    monkeypatch.setattr(redis_cache, "get_cached_artist_list", lambda *a, **k: None)
+    monkeypatch.setattr(redis_cache, "cache_artist_list", lambda *a, **k: None)
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def test_service_provider_has_no_default_category(monkeypatch):
+    Session = setup_app(monkeypatch)
+    client = TestClient(app)
+    payload = {
+        "email": "sp@example.com",
+        "password": "secret123",
+        "first_name": "Service",
+        "last_name": "Provider",
+        "phone_number": "+1234567890",
+        "user_type": "service_provider",
+    }
+    res = client.post("/auth/register", json=payload)
+    assert res.status_code == 200
+
+    db = Session()
+    profile = db.query(ServiceProviderProfile).first()
+    assert profile is not None
+    # Newly registered providers should not have any services yet,
+    # so they are not categorized until they add one.
+    assert profile.services == []
+    db.close()
+    app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary
- ensure service-provider registration creates an empty profile with no default category
- document that new providers are uncategorized until adding a service
- test that service providers start without service categories

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `PYTHONPATH=. pytest tests/test_service_provider_registration.py`


------
https://chatgpt.com/codex/tasks/task_e_689876037eb4832e9bbfcab3f594e5b7