### PR TITLE
test: update service provider paths

### DIFF
--- a/frontend/e2e/collapsible-section.spec.ts
+++ b/frontend/e2e/collapsible-section.spec.ts
@@ -1,17 +1,17 @@
 import { test, expect, devices } from '@playwright/test';
-import { stubArtist, stubCatchAllApi, stubGoogleMaps } from './stub-helpers';
+import { stubServiceProvider, stubCatchAllApi, stubGoogleMaps } from './stub-helpers';
 
 test.describe('CollapsibleSection mobile behavior', () => {
   test.skip(({ browserName, isMobile }) => !(browserName === 'webkit' && isMobile), 'iPhone WebKit only');
 
   test.beforeEach(async ({ page }) => {
-    await stubArtist(page);
+    await stubServiceProvider(page);
     await stubCatchAllApi(page);
     await stubGoogleMaps(page);
   });
 
   test('opens section when tapping header', async ({ page }) => {
-    await page.goto('/booking?artist_id=1&service_id=1');
+    await page.goto('/booking?service_provider_id=1&service_id=1');
     await expect(page.getByTestId('step-heading')).toHaveText(/Date & Time/);
     await page.getByRole('button', { name: 'Event Type' }).click();
     await expect(page.getByTestId('step-heading')).toHaveText(/Event Type/);
@@ -22,13 +22,13 @@ test.describe('CollapsibleSection cross-browser', () => {
   test.skip(({ browserName }) => browserName === 'firefox', 'Chrome and WebKit only');
 
   test.beforeEach(async ({ page }) => {
-    await stubArtist(page);
+    await stubServiceProvider(page);
     await stubCatchAllApi(page);
     await stubGoogleMaps(page);
   });
 
   test('toggles section on click', async ({ page }) => {
-    await page.goto('/booking?artist_id=1&service_id=1');
+    await page.goto('/booking?service_provider_id=1&service_id=1');
     const firstButton = page.getByRole('button', { name: 'Date & Time' });
     const eventTypeButton = page.getByRole('button', { name: 'Event Type' });
     await expect(firstButton).toHaveAttribute('aria-expanded', 'true');

--- a/frontend/e2e/full-booking.spec.ts
+++ b/frontend/e2e/full-booking.spec.ts
@@ -2,14 +2,14 @@ import { test, expect } from '@playwright/test';
 import {
   setupDepositStubs,
   stubRegister,
-  stubArtist,
+  stubServiceProvider,
 } from './stub-helpers';
 
 test.describe('Signup to deposit flow', () => {
   test.beforeEach(async ({ page }) => {
     await setupDepositStubs(page);
     await stubRegister(page);
-    await stubArtist(page);
+    await stubServiceProvider(page);
   });
 
   test('completes signup, requests quote, and pays deposit', async ({ page }) => {
@@ -29,7 +29,7 @@ test.describe('Signup to deposit flow', () => {
     await page.getByRole('button', { name: /sign in/i }).click();
     await expect(page).toHaveURL('/dashboard/client');
 
-    await page.goto('/booking?artist_id=1&service_id=1');
+    await page.goto('/booking?service_provider_id=1&service_id=1');
     await expect(page.getByTestId('step-heading')).toHaveText(/Date & Time/);
     await page.getByTestId('date-next-button').click();
     await expect(page.getByTestId('step-heading')).toHaveText(/Event Type/);

--- a/frontend/e2e/mobile-booking.spec.ts
+++ b/frontend/e2e/mobile-booking.spec.ts
@@ -5,14 +5,14 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Booking Wizard mobile flow', () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/v1/artists/1', async (route) => {
+    await page.route('**/api/v1/service-provider-profiles/1', async (route) => {
       await route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ location: 'NYC' }),
       });
     });
-    await page.route('**/api/v1/artists/1/availability', async (route) => {
+    await page.route('**/api/v1/service-provider-profiles/1/availability', async (route) => {
       await route.fulfill({
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -58,7 +58,7 @@ test.describe('Booking Wizard mobile flow', () => {
   });
 
   test('advances to location step', async ({ page }) => {
-    await page.goto('/booking?artist_id=1&service_id=1');
+    await page.goto('/booking?service_provider_id=1&service_id=1');
     await expect(page.getByTestId('step-heading')).toHaveText(/Date & Time/);
     await page.getByTestId('date-next-button').click();
     await expect(page.getByTestId('step-heading')).toHaveText(/Event Type/);

--- a/frontend/e2e/stub-helpers.ts
+++ b/frontend/e2e/stub-helpers.ts
@@ -87,13 +87,13 @@ export async function stubBookingRequest(page: Page, requestId = 42) {
       body: JSON.stringify({
         id: requestId,
         client_id: 1,
-        artist_id: 1,
+        service_provider_id: 1,
         service_id: 1,
         status: 'quote_provided',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
         client: { first_name: 'Client' },
-        artist: { user: { first_name: 'Artist' } },
+        service_provider: { user: { first_name: 'Provider' } },
         service: { title: 'Gig' },
       }),
     });
@@ -112,7 +112,7 @@ export async function stubMessages(page: Page, requestId = 42, quoteId = 1) {
             id: 1,
             booking_request_id: requestId,
             sender_id: 1,
-            sender_type: 'artist',
+            sender_type: 'service_provider',
             content: 'Quote',
             // Backend emits message types in uppercase.
             message_type: 'QUOTE',
@@ -139,7 +139,7 @@ export async function stubQuoteFlow(
         id: quoteId,
         booking_id: status === 'accepted' ? bookingId : null,
         booking_request_id: 42,
-        artist_id: 1,
+        service_provider_id: 1,
         client_id: 1,
         services: [{ description: 'Gig', price: 100 }],
         sound_fee: 0,
@@ -161,7 +161,7 @@ export async function stubQuoteFlow(
       body: JSON.stringify({
         id: bookingId,
         quote_id: quoteId,
-        artist_id: 1,
+        service_provider_id: 1,
         client_id: 1,
         confirmed: true,
         payment_status: 'pending',
@@ -189,15 +189,15 @@ export async function stubPayments(page: Page, paymentId = 'pay_1') {
   });
 }
 
-export async function stubArtist(page: Page, artistId = 1) {
-  await page.route(`**/api/v1/artists/${artistId}`, async (route) => {
+export async function stubServiceProvider(page: Page, serviceProviderId = 1) {
+  await page.route(`**/api/v1/service-provider-profiles/${serviceProviderId}`, async (route) => {
     await route.fulfill({
       status: 200,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ location: 'NYC' }),
     });
   });
-  await page.route(`**/api/v1/artists/${artistId}/availability`, async (route) => {
+  await page.route(`**/api/v1/service-provider-profiles/${serviceProviderId}/availability`, async (route) => {
     await route.fulfill({
       status: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/__tests__/artistViewToggle.test.tsx
+++ b/frontend/src/__tests__/artistViewToggle.test.tsx
@@ -12,8 +12,8 @@ jest.mock('@/contexts/AuthContext');
 
 const mockUseAuth = useAuth as jest.Mock;
 
-describe('Header artist view', () => {
-  it('shows artist links without search when artistViewActive', () => {
+describe('Header service provider view', () => {
+  it('shows service provider links without search when artistViewActive', () => {
     const toggleArtistView = jest.fn();
     mockUseAuth.mockReturnValue({
       user: { id: 1, user_type: 'service_provider', email: 'a', first_name: 'A', last_name: 'B' },
@@ -26,7 +26,7 @@ describe('Header artist view', () => {
     expect(screen.getByText('Services')).toBeTruthy();
     expect(screen.getByText('Messages')).toBeTruthy();
     expect(screen.getAllByText('View Profile')).toHaveLength(1);
-    expect(screen.queryByText('Add artist')).toBeNull();
+    expect(screen.queryByText('Add service provider')).toBeNull();
     expect(screen.queryByText('Add location')).toBeNull();
     expect(document.querySelector('#compact-search-trigger')).toBeNull();
     expect(mockUseAuth).toHaveBeenCalled();

--- a/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`Header matches compact snapshot with filter control 1`] = `
               <div
                 class="flex-1 px-2 truncate"
               >
-                Add artist
+                Add service provider
               </div>
               <div
                 class="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis"
@@ -290,7 +290,7 @@ exports[`Header matches compact snapshot with filter control 1`] = `
               <span
                 class="block truncate pointer-events-none select-none text-gray-500 text-base text-xs"
               >
-                Add artist
+                Add service provider
               </span>
             </button>
           </div>
@@ -586,7 +586,7 @@ exports[`Header renders search bar when enabled 1`] = `
               <div
                 class="flex-1 px-2 truncate"
               >
-                Add artist
+                Add service provider
               </div>
               <div
                 class="flex-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis"
@@ -669,7 +669,7 @@ exports[`Header renders search bar when enabled 1`] = `
               <span
                 class="block truncate pointer-events-none select-none text-gray-500 text-base text-xs"
               >
-                Add artist
+                Add service provider
               </span>
             </button>
           </div>


### PR DESCRIPTION
## Summary
- adjust header toggle test and snapshot for "Add service provider"
- update Playwright stubs and specs to use `/service-provider-profiles` APIs and `service_provider_id` routes

## Testing
- `npm test` *(fails: Test Suites: 43 failed, 2 skipped, 82 passed, 125 of 127 total)*
- `npx playwright test -c ../playwright.config.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_689879c946f0832e91e141d48cbebac0