### PR TITLE
Use service category to pick wizard for editing services

### DIFF
--- a/frontend/src/app/dashboard/artist/page.tsx
+++ b/frontend/src/app/dashboard/artist/page.tsx
@@ -22,6 +22,7 @@ import {
   formatStatus,
   applyDisplayOrder,
 } from "@/lib/utils";
+import { ID_TO_UI_CATEGORY } from "@/lib/categoryMap";
 import {
   AddServiceCategorySelector,
   UpdateRequestModal,
@@ -688,7 +689,12 @@ export default function DashboardPage() {
                           service={service}
                           onEdit={(s) => {
                             setEditingService(s);
-                            setWizardCategory('musician');
+                            const slug =
+                              s.service_category_slug ||
+                              (s.service_category_id
+                                ? ID_TO_UI_CATEGORY[s.service_category_id]
+                                : null);
+                            setWizardCategory(slug || 'musician');
                           }}
                           onDelete={handleDeleteService}
                         />

--- a/frontend/src/components/dashboard/add-service/__tests__/EditDJServiceOpensWizard.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/EditDJServiceOpensWizard.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ArtistDashboardPage from "@/app/dashboard/artist/page";
+import * as api from "@/lib/api";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRouter, useSearchParams, usePathname } from "@/tests/mocks/next-navigation";
+import { Service } from "@/types";
+import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
+
+jest.mock("@/lib/api");
+jest.mock("@/contexts/AuthContext");
+
+test("editing a DJ service opens the DJ wizard", async () => {
+  useRouter.mockReturnValue({ push: jest.fn(), replace: jest.fn() });
+  usePathname.mockReturnValue("/dashboard/artist");
+  useSearchParams.mockReturnValue({ get: (key: string) => (key === "tab" ? "services" : null) });
+  (useAuth as jest.Mock).mockReturnValue({
+    user: {
+      id: 1,
+      user_type: "service_provider",
+      email: "dj@example.com",
+      first_name: "DJ",
+      last_name: "Tester",
+      phone_number: "",
+      is_active: true,
+      is_verified: true,
+    },
+    loading: false,
+  });
+  (api.getMyArtistBookings as jest.Mock).mockResolvedValue({ data: [] });
+  (api.getServiceCategories as jest.Mock).mockResolvedValue({ data: [] });
+  const djService = {
+    id: 1,
+    artist_id: 1,
+    title: "Spin",
+    description: "desc",
+    media_url: "",
+    price: 100,
+    duration_minutes: 60,
+    service_type: "Live Performance",
+    display_order: 0,
+    service_category_slug: "dj",
+    service_category_id: UI_CATEGORY_TO_ID.dj,
+  } as Service;
+  (api.getServiceProviderServices as jest.Mock).mockResolvedValue({ data: [djService] });
+  (api.getServiceProviderProfileMe as jest.Mock).mockResolvedValue({ data: {} });
+  (api.getBookingRequestsForArtist as jest.Mock).mockResolvedValue({ data: [] });
+  (api.getDashboardStats as jest.Mock).mockResolvedValue({ data: {} });
+
+  const user = userEvent.setup();
+  render(<ArtistDashboardPage />);
+
+  const editButton = await screen.findByText("Edit");
+  await user.click(editButton);
+
+  expect(await screen.findByText(/DJ Details/i)).toBeTruthy();
+});
+

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -33,6 +33,12 @@ export const UI_CATEGORY_TO_ID: Record<string, number> = {
   mc_host: 10,
 };
 
+// Inverse lookup from category ID to slug for cases where only the numeric ID
+// is available, such as when editing an existing service without a stored slug.
+export const ID_TO_UI_CATEGORY: Record<number, string> = Object.fromEntries(
+  Object.entries(UI_CATEGORY_TO_ID).map(([slug, id]) => [id, slug]),
+);
+
 // Convert a backend category name to a URL-friendly slug. This mirrors the
 // previous hard-coded mapping but works for future categories as well.
 export const categorySlug = (name: string): string =>


### PR DESCRIPTION
## Summary
- derive service wizard category from service metadata instead of defaulting to musician
- map category IDs to slugs and load appropriate wizard
- add test ensuring editing DJ service opens DJ wizard

## Testing
- `npx jest src/components/dashboard/add-service/__tests__/EditDJServiceOpensWizard.test.tsx --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_68987daadc28832ebaaa2986d7d8d77e