### PR TITLE
Require service category slug for services

### DIFF
--- a/backend/app/api/api_service.py
+++ b/backend/app/api/api_service.py
@@ -54,6 +54,13 @@ def create_service(
     category_id = service_data.pop("service_category_id", None)
     category_slug = service_data.pop("service_category_slug", None)
 
+    if category_id is None and category_slug is None:
+        raise error_response(
+            "Service category is required.",
+            {"service_category_slug": "required"},
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+
     if category_slug is not None:
         normalized = category_slug.replace("_", " ").lower()
         category = (

--- a/backend/app/schemas/service.py
+++ b/backend/app/schemas/service.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from ..models.service import ServiceType
 from .artist import ArtistProfileNested
@@ -37,8 +37,17 @@ class ServiceCreate(ServiceBase):
     price: Decimal
     service_type: ServiceType
     media_url: str
-    # ``service_category_id`` is optional and inherited from ``ServiceBase``.
-    # The artist ID will be set based on the authenticated artist, not in the schema.
+    # ``service_category_id`` and ``service_category_slug`` are optional on the
+    # base model, but one of them must be supplied when creating a service.
+
+    @model_validator(mode="after")
+    def category_required(cls, model: "ServiceCreate") -> "ServiceCreate":
+        """Ensure that a service category is provided either by slug or ID."""
+        if model.service_category_id is None and not model.service_category_slug:
+            raise ValueError(
+                "Either service_category_slug or service_category_id must be provided."
+            )
+        return model
 
 
 # Properties to receive on item update

--- a/backend/tests/test_service_schema.py
+++ b/backend/tests/test_service_schema.py
@@ -9,6 +9,7 @@ def test_service_create_requires_type():
             duration_minutes=10,
             price=5.0,
             media_url="x",
+            service_category_slug="dj",
         )
     s = ServiceCreate(
         title="Test",
@@ -17,6 +18,7 @@ def test_service_create_requires_type():
         service_type=ServiceType.OTHER,
         media_url="x",
         details={"genre": "rock"},
+        service_category_slug="dj",
     )
     assert s.service_type == ServiceType.OTHER
     assert s.service_category_id is None
@@ -34,3 +36,27 @@ def test_service_update_type_optional():
 def test_service_update_accepts_display_order():
     upd = ServiceUpdate(display_order=5)
     assert upd.display_order == 5
+
+
+def test_service_create_requires_category():
+    with pytest.raises(Exception) as exc:
+        ServiceCreate(
+            title="Test",
+            duration_minutes=10,
+            price=5.0,
+            service_type=ServiceType.OTHER,
+            media_url="x",
+        )
+    assert "service_category_slug or service_category_id" in str(exc.value)
+
+
+def test_service_create_accepts_category_slug():
+    s = ServiceCreate(
+        title="Test",
+        duration_minutes=10,
+        price=5.0,
+        service_type=ServiceType.OTHER,
+        media_url="x",
+        service_category_slug="dj",
+    )
+    assert s.service_category_slug == "dj"

--- a/docs/add_service_workflow.md
+++ b/docs/add_service_workflow.md
@@ -19,10 +19,10 @@ All service categories share the BaseServiceWizard for a consistent layout and n
 - **Bartender**
 - **MC & Host**
 
-Each category has a canonical numeric ID defined in `frontend/src/lib/categoryMap.ts`,
-ensuring services map to the correct providers regardless of display order.
+Each category is identified by a canonical slug defined in `frontend/src/lib/categoryMap.ts`.
+This slug is sent to the backend so services map to the correct providers without relying on database IDs.
 
-Each category adds its own fields; for example, a **Musician** selects a service type such as Live Performance and sets pricing, while a **Photographer** captures camera details and pricing. All wizards submit to the existing `/api/v1/services/` endpoint. Media files are read client-side and sent as base64 strings in the `media_url` field. When a provider chooses a line of work, the wizard maps the selected slug to the canonical `service_category_id` so the API links the new service to the correct backend category.
+Each category adds its own fields; for example, a **Musician** selects a service type such as Live Performance and sets pricing, while a **Photographer** captures camera details and pricing. All wizards submit to the existing `/api/v1/services/` endpoint. Media files are read client-side and sent as base64 strings in the `media_url` field. When a provider chooses a line of work, the wizard includes the selected slug as `service_category_slug` so the API links the new service to the correct backend category.
 
 The newly added **DJ** wizard records a preferred genre, while the **Event Service** wizard captures a description of the offering. Both reuse the BaseServiceWizard to provide the same navigation and media upload experience as other categories.
 
@@ -37,4 +37,4 @@ POST /api/v1/services/
 ```
 
 Additional category details (e.g., `camera_brand`) are included under the `details` object.
-Provide `service_category_id` only when the service belongs to one of the seeded categories; otherwise omit this field.
+Always provide a `service_category_slug` for seeded categories; requests without a category are rejected.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7695,6 +7695,10 @@
             ],
             "title": "Service Category Id"
           },
+          "service_category_slug": {
+            "type": "string",
+            "title": "Service Category Slug"
+          },
           "details": {
             "anyOf": [
               {
@@ -7714,7 +7718,8 @@
           "media_url",
           "duration_minutes",
           "price",
-          "service_type"
+          "service_type",
+          "service_category_slug"
         ],
         "title": "ServiceCreate"
       },
@@ -7891,6 +7896,13 @@
               }
             ],
             "title": "Service Category Id"
+          },
+          "service_category_slug": {
+            "anyOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ],
+            "title": "Service Category Slug"
           },
           "details": {
             "anyOf": [
@@ -8112,6 +8124,13 @@
               }
             ],
             "title": "Service Category Id"
+          },
+          "service_category_slug": {
+            "anyOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ],
+            "title": "Service Category Slug"
           },
           "details": {
             "anyOf": [

--- a/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
+++ b/frontend/src/components/dashboard/add-service/AddServiceModalMusician.tsx
@@ -23,7 +23,6 @@ import {
 import { DEFAULT_CURRENCY } from "@/lib/constants";
 import Button from "@/components/ui/Button";
 import { Stepper, TextInput, TextArea } from "@/components/ui";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 const serviceTypeIcons: Record<Service["service_type"], ElementType> = {
   "Live Performance": MusicalNoteIcon,
@@ -249,7 +248,7 @@ export default function AddServiceModalMusician({
         ...data,
         price: Number(data.price || 0),
         duration_minutes: Number(data.duration_minutes || 0),
-        service_category_id: UI_CATEGORY_TO_ID.musician,
+        service_category_slug: "musician",
         travel_rate: data.travel_rate ? Number(data.travel_rate) : undefined,
         travel_members: data.travel_members
           ? Number(data.travel_members)

--- a/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
+++ b/frontend/src/components/dashboard/add-service/BaseServiceWizard.tsx
@@ -16,7 +16,6 @@ import {
   createService as apiCreateService,
   updateService as apiUpdateService,
 } from "@/lib/api";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 import type { Service } from "@/types";
 
 function useImageThumbnails(files: File[]) {
@@ -181,9 +180,11 @@ export default function BaseServiceWizard<T extends FieldValues>({
         });
       }
       const payload: Partial<Service> = toPayload(data, mediaUrl);
-      if (serviceCategorySlug !== undefined) {
-        payload.service_category_id = UI_CATEGORY_TO_ID[serviceCategorySlug];
+      if (!serviceCategorySlug) {
+        alert("Service category is required.");
+        return;
       }
+      payload.service_category_slug = serviceCategorySlug;
       const res = service
         ? await apiUpdateService(service.id, payload)
         : await apiCreateService(payload);

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalBartender.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalBartender.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalBartender from "../AddServiceModalBartender";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalBartender", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalBartender", () => {
         service_type: "Other",
         details: { signature_drink: "Mojito" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.bartender,
+        service_category_slug: "bartender",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalCaterer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalCaterer.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalCaterer from "../AddServiceModalCaterer";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalCaterer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalCaterer", () => {
         service_type: "Other",
         details: { cuisine: "Italian" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.caterer,
+        service_category_slug: "caterer",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalDJ.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalDJ from "../AddServiceModalDJ";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalDJ", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalDJ", () => {
         service_type: "Live Performance",
         details: { genre: "EDM" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.dj,
+        service_category_slug: "dj",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalEventService.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalEventService.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalEventService from "../AddServiceModalEventService";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalEventService", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalEventService", () => {
         service_type: "Other",
         details: { description: "Lighting" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.event_service,
+        service_category_slug: "event_service",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMcHost.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMcHost.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalMcHost from "../AddServiceModalMcHost";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMcHost", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalMcHost", () => {
         service_type: "Other",
         details: { hosting_style: "Formal" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.mc_host,
+        service_category_slug: "mc_host",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMusician.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalMusician.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalMusician from "../AddServiceModalMusician";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMusician", () => {
   it.skip("validates required fields and submits payload", async () => {
@@ -51,7 +50,7 @@ describe("AddServiceModalMusician", () => {
         price: 100,
         service_type: "Live Performance",
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.musician,
+        service_category_slug: "musician",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalPhotographer.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalPhotographer from "../AddServiceModalPhotographer";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalPhotographer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -49,7 +48,7 @@ describe("AddServiceModalPhotographer", () => {
         service_type: "Other",
         details: { camera_brand: "Canon" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.photographer,
+        service_category_slug: "photographer",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalSpeaker.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalSpeaker.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalSpeaker from "../AddServiceModalSpeaker";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalSpeaker", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalSpeaker", () => {
         service_type: "Other",
         details: { topic: "Motivation" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.speaker,
+        service_category_slug: "speaker",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalVideographer.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalVideographer.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalVideographer from "../AddServiceModalVideographer";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalVideographer", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalVideographer", () => {
         service_type: "Other",
         details: { video_style: "Cinematic" },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.videographer,
+        service_category_slug: "videographer",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalWeddingVenue.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/AddServiceModalWeddingVenue.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import * as api from "@/lib/api";
 import AddServiceModalWeddingVenue from "../AddServiceModalWeddingVenue";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalWeddingVenue", () => {
   it("follows step flow and sends details payload", async () => {
@@ -43,7 +42,7 @@ describe("AddServiceModalWeddingVenue", () => {
         service_type: "Other",
         details: { capacity: 200 },
         media_url: expect.stringContaining("base64"),
-        service_category_id: UI_CATEGORY_TO_ID.wedding_venue,
+        service_category_slug: "wedding_venue",
       }),
     );
   });

--- a/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
+++ b/frontend/src/components/dashboard/add-service/__tests__/ServiceModalEdit.test.tsx
@@ -4,7 +4,6 @@ import AddServiceModalMusician from "../AddServiceModalMusician";
 import * as api from "@/lib/api";
 import { Service } from "@/types";
 import { flushPromises } from "@/test/utils/flush";
-import { UI_CATEGORY_TO_ID } from "@/lib/categoryMap";
 
 describe("AddServiceModalMusician editing", () => {
   it("calls updateService on submit", async () => {
@@ -42,7 +41,7 @@ describe("AddServiceModalMusician editing", () => {
     expect(spy).toHaveBeenCalledWith(
       1,
       expect.objectContaining({
-        service_category_id: UI_CATEGORY_TO_ID.musician,
+        service_category_slug: "musician",
       }),
     );
   });


### PR DESCRIPTION
## Summary
- enforce service category on ServiceCreate with validator
- reject service creation without category with 422 error
- send category slug from frontend wizards and add client-side validation
- document slug requirement for add-service workflow

## Testing
- `./scripts/test-backend.sh`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: 73 failed, 2 skipped, 316 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68987fc9a9e8832e8a601f70af2da32f