### PR TITLE
chore: hide service providers category

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,6 +56,10 @@ Focusing the category chooser opens a popup that spans half of the search bar fr
 
  The home page includes a "Services Near You" carousel that lists common service categories such as Musicians and DJs. Each category supports its own image, defined in `src/lib/categoryMap.ts` and served from `public/categories`. Items display the image with the label below and link to the service providers page filtered by the selected category. On desktop, left and right buttons page through the list for easier navigation.
 
+### Service Categories
+
+Service categories are fetched from the backend. A generic "Service Providers" entry may be returned but is intentionally hidden in the UI because individual providers can offer services across multiple categories.
+
 
 ### Loading Indicators
 

--- a/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
+++ b/frontend/src/components/home/__tests__/CategoriesCarousel.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import CategoriesCarousel from '../CategoriesCarousel';
 import { getServiceCategories } from '@/lib/api';
-import type { Category } from '@/hooks/useServiceCategories';
 
 jest.mock('@/lib/api');
 
@@ -11,9 +10,10 @@ const mockedGetServiceCategories = getServiceCategories as jest.MockedFunction<
   typeof getServiceCategories
 >;
 
-const MOCK_CATEGORIES: Category[] = [
-  { id: 1, value: 'dj', label: 'DJ' },
-  { id: 2, value: 'musician', label: 'Musician' },
+const MOCK_CATEGORIES = [
+  { id: 0, name: 'Service Providers' },
+  { id: 1, name: 'DJ' },
+  { id: 2, name: 'Musician' },
 ];
 
 describe('CategoriesCarousel', () => {
@@ -33,13 +33,13 @@ describe('CategoriesCarousel', () => {
     act(() => {
       root.render(React.createElement(CategoriesCarousel));
     });
-    MOCK_CATEGORIES.forEach((cat) => {
-      expect(container.textContent).toContain(cat.label);
-    });
+    expect(container.textContent).toContain('DJ');
+    expect(container.textContent).toContain('Musician');
+    expect(container.textContent).not.toContain('Service Providers');
     const imgs = container.querySelectorAll('img');
-    MOCK_CATEGORIES.forEach((cat, index) => {
-      expect(imgs[index].getAttribute('src')).toContain(cat.value);
-    });
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0].getAttribute('src')).toContain('dj');
+    expect(imgs[1].getAttribute('src')).toContain('musician');
     const next = container.querySelector('button[aria-label="Next"]');
     expect(next).not.toBeNull();
     act(() => root.unmount());

--- a/frontend/src/components/search/__tests__/SearchBar.test.tsx
+++ b/frontend/src/components/search/__tests__/SearchBar.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import SearchBar from '../SearchBar';
 import { getServiceCategories } from '@/lib/api';
-import type { Category } from '@/hooks/useServiceCategories';
 
 // Mock next/dynamic to synchronously load a minimal SearchPopupContent
 jest.mock('next/dynamic', () => () => {
@@ -28,9 +27,10 @@ jest.mock('@/lib/api');
 const mockedGetServiceCategories = getServiceCategories as jest.MockedFunction<
   typeof getServiceCategories
 >;
-const MOCK_CATEGORIES: Category[] = [
-  { id: 1, value: 'dj', label: 'DJ' },
-  { id: 2, value: 'musician', label: 'Musician' },
+const MOCK_CATEGORIES = [
+  { id: 0, name: 'Service Providers' },
+  { id: 1, name: 'DJ' },
+  { id: 2, name: 'Musician' },
 ];
 
 beforeEach(() => {
@@ -182,7 +182,7 @@ describe('SearchBar', () => {
           <button
             type="button"
             data-testid="select-category"
-            onClick={() => setCategory(MOCK_CATEGORIES[0])}
+            onClick={() => setCategory({ id: 1, value: 'dj', label: 'DJ' })}
           >
             select
           </button>
@@ -218,8 +218,9 @@ describe('SearchBar', () => {
       );
     };
 
-    const { getByRole, findByText } = render(<Wrapper />);
+    const { getByRole, findByText, queryByText } = render(<Wrapper />);
     fireEvent.click(getByRole('button', { name: /Category/ }));
+    expect(queryByText('Service Providers')).toBeNull();
     expect(await findByText('DJ')).not.toBeNull();
   });
 });

--- a/frontend/src/hooks/useServiceCategories.ts
+++ b/frontend/src/hooks/useServiceCategories.ts
@@ -20,11 +20,13 @@ export default function useServiceCategories(): Category[] {
     if (cachedCategories) return;
     getServiceCategories()
       .then((res) => {
-        const data = res.data.map((c) => ({
-          id: c.id,
-          value: categorySlug(c.name),
-          label: c.name,
-        }));
+        const data = res.data
+          .filter((c) => c.name.toLowerCase() !== 'service providers')
+          .map((c) => ({
+            id: c.id,
+            value: categorySlug(c.name),
+            label: c.name,
+          }));
         cachedCategories = data;
         setCategories(data);
       })


### PR DESCRIPTION
## Summary
- filter out generic "Service Providers" category when loading categories on the frontend
- document exclusion of the generic category in the frontend README
- adjust category tests to ensure the generic entry is not rendered

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npx jest src/components/home/__tests__/CategoriesCarousel.test.tsx src/components/search/__tests__/SearchBar.test.tsx` *(fails: Test Suites: 2 failed, 2 total)*

------
https://chatgpt.com/codex/tasks/task_e_68988f487c8c832eb26eb89766ede519