### PR TITLE
Hide service labels on provider cards

### DIFF
--- a/frontend/src/components/service-provider/ServiceProviderCard.tsx
+++ b/frontend/src/components/service-provider/ServiceProviderCard.tsx
@@ -2,14 +2,13 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { HTMLAttributes } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import {
   StarIcon,
   CheckBadgeIcon,
 } from '@heroicons/react/24/solid';
-import { Tag } from '@/components/ui';
 import { getFullImageUrl } from '@/lib/utils';
 
 export interface ServiceProviderCardProps extends HTMLAttributes<HTMLDivElement> {
@@ -61,13 +60,9 @@ export default function ServiceProviderCard({
   // Ensure unused props don't trigger lint errors until availability features land
   void ratingCount;
   void isAvailable;
-  const tags = useMemo(
-    () => specialties || specialities || [],
-    [specialties, specialities],
-  );
-  // Display at most two tags so pills remain compact.
-  const maxTags = 2;
-  const limitedTags = tags.slice(0, maxTags);
+  void subtitle;
+  void specialties;
+  void specialities;
   const [imgLoaded, setImgLoaded] = useState(false);
   const [supportsHover, setSupportsHover] = useState(true);
 
@@ -139,16 +134,6 @@ export default function ServiceProviderCard({
           <h2 className="flex-1 text-lg font-semibold text-gray-900 truncate mt-4 mb-2">{name}</h2>
           {verified && <CheckBadgeIcon className="h-4 w-4 text-brand" aria-label="Verified" />}
         </div>
-        {subtitle && <p className="text-sm text-gray-500 leading-tight line-clamp-2">{subtitle}</p>}
-        {limitedTags.length > 0 && (
-          <div className="flex flex-nowrap overflow-hidden gap-1 mt-2 whitespace-nowrap">
-            {limitedTags.map((s) => (
-              <Tag key={`${serviceProviderId}-${s}`} className="text-[10px]">
-                {s}
-              </Tag>
-            ))}
-          </div>
-        )}
         <hr className="mt-4 mb-4 border-gray-200" />
         <div className="flex justify-between items-center text-sm text-gray-700">
           <span className="flex items-center">

--- a/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
+++ b/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
@@ -40,6 +40,8 @@ export default function ServiceProviderCardCompact({
   ...props
 }: ServiceProviderCardCompactProps) {
   const [loaded, setLoaded] = useState(false);
+  void subtitle;
+  void categories;
   return (
     <Link
       href={href}
@@ -93,12 +95,6 @@ export default function ServiceProviderCardCompact({
       </div>
       <div className="p-1 space-y-0.5">
         <p className="text-sm font-semibold truncate text-black">{name}</p>
-        {subtitle && <p className="text-xs text-gray-600 truncate">{subtitle}</p>}
-        {categories && categories.length > 0 && (
-          <p className="text-xs text-gray-500 truncate">
-            {categories.join(', ')}
-          </p>
-        )}
         {location && (
           <p className="text-xs text-gray-400 truncate">{location}</p>
         )}

--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
@@ -53,11 +53,10 @@ describe('ServiceProviderCard optional fields', () => {
     c2.remove();
   });
 
-  it('shows location and tagline truncated', () => {
+  it('shows location but omits subtitle', () => {
     const { container, root } = setup({ location: 'NYC', subtitle: 'Best service provider ever in the world' });
     expect(container.textContent).toContain('NYC');
-    const subtitleEl = container.querySelector('p.text-sm');
-    expect(subtitleEl?.className).toContain('line-clamp-2');
+    expect(container.textContent).not.toContain('Best service provider');
     const locEl = container.querySelector('span.text-sm');
     expect(locEl?.textContent).toContain('NYC');
     act(() => root.unmount());
@@ -161,29 +160,10 @@ describe('ServiceProviderCard optional fields', () => {
     container.remove();
   });
 
-  it('shows at most two specialty tags', () => {
-    const { container, root } = setup({
-      specialties: ['a', 'b', 'c', 'd', 'e', 'f'],
-    });
+  it('does not render specialty tags when provided', () => {
+    const { container, root } = setup({ specialties: ['a', 'b'] });
     const tagContainer = container.querySelector('div.flex.flex-nowrap');
-    const tags = tagContainer?.querySelectorAll('span');
-    expect(tags?.length).toBeLessThanOrEqual(2);
-    tags?.forEach((tag) => {
-      expect(tag.className).toContain('text-[10px]');
-      expect(tag.className).toContain('px-1.5');
-      expect(tag.className).toContain('py-0.5');
-    });
-    act(() => root.unmount());
-    container.remove();
-  });
-
-  it('always limits specialty tags to two', () => {
-    const { container, root } = setup({ specialties: ['x', 'y', 'z'] });
-    const tagDiv = container.querySelector('div.flex.flex-nowrap');
-    expect(tagDiv).not.toBeNull();
-    const tags = tagDiv?.querySelectorAll('span');
-    expect(tags?.length).toBe(2);
-
+    expect(tagContainer).toBeNull();
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
@@ -30,4 +30,15 @@ describe('ServiceProviderCardCompact', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('ignores subtitle and categories props', () => {
+    const { container, root, allProps } = setup({ subtitle: 'DJ', categories: ['Photographer'] });
+    act(() => {
+      root.render(React.createElement(ServiceProviderCardCompact, allProps));
+    });
+    expect(container.textContent).not.toContain('DJ');
+    expect(container.textContent).not.toContain('Photographer');
+    act(() => root.unmount());
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- stop rendering subtitle and category labels on compact service provider cards
- remove subtitle and specialty tag display on full service provider cards
- adjust related tests

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npx jest src/components/service-provider/__tests__/ServiceProviderCard.test.tsx src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689892e360e0832ead14e2c518313662