### PR TITLE
Fix carousel card sizing for large screens

### DIFF
--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -119,7 +119,7 @@ export default function ArtistsSection({
             <div className="relative hidden xl:block">
               <div
                 ref={scrollRef}
-                className="flex gap-2 overflow-x-auto scroll-smooth pb-2"
+                className="flex items-stretch gap-2 overflow-x-auto scroll-smooth pb-2"
               >
                 {artists.map((a) => {
                   const name = a.business_name || `${a.user.first_name} ${a.user.last_name}`;
@@ -140,7 +140,7 @@ export default function ArtistsSection({
                         location={a.location}
                         categories={a.service_categories}
                         href={`/service-providers/${a.id}`}
-                        className="w-full"
+                        className="h-full w-full"
                       />
                     </div>
                   );

--- a/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
+++ b/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
@@ -46,7 +46,7 @@ export default function ServiceProviderCardCompact({
     <Link
       href={href}
       className={clsx(
-        'group block rounded-xl overflow-hidden bg-gray-50 hover:shadow-md transition',
+        'group flex h-full flex-col rounded-xl overflow-hidden bg-gray-50 hover:shadow-md transition',
         'no-underline hover:no-underline',
         className,
       )}
@@ -93,7 +93,7 @@ export default function ServiceProviderCardCompact({
           </span>
         )}
       </div>
-      <div className="p-1 space-y-0.5">
+      <div className="p-1 space-y-0.5 flex-grow">
         <p className="text-sm font-semibold truncate text-black">{name}</p>
         {location && (
           <p className="text-xs text-gray-400 truncate">{location}</p>

--- a/frontend/src/components/service-provider/__tests__/__snapshots__/ServiceProviderCardCompact.test.tsx.snap
+++ b/frontend/src/components/service-provider/__tests__/__snapshots__/ServiceProviderCardCompact.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ServiceProviderCardCompact matches snapshot 1`] = `
     />
   </div>
   <div
-    class="p-1 space-y-0.5"
+    class="p-1 space-y-0.5 flex-grow"
   >
     <p
       class="text-sm font-semibold truncate text-black"


### PR DESCRIPTION
## Summary
- ensure carousel cards stretch evenly on xl screens
- make service provider cards flex to fill vertical space

## Testing
- `npx jest src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx -u`
- `./scripts/test-all.sh` *(fails: TypeError: (0 , _navigation.useSearchParams) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6898a7e28d24832ea898830edbdbbba4