### PR TITLE
feat(home): add carousel to artist sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - Category popup now includes an provider name search input for quick navigation to
   individual profiles.
 - An unobtrusive marketing strip replaces the old Hero section.
-- The homepage now highlights popular, top rated, and new artists using a compact card grid similar to Airbnb.
+- The homepage now highlights popular, top rated, and new artists in horizontally scrollable carousels.
 - The "Services Near You" category carousel adds previous/next buttons so desktop users can page through service types.
 - Service categories are assigned when adding services; service providers no longer choose a category during onboarding. The `/api/v1/service-categories` endpoint lists the seeded categories.
 - Newly registered service providers start with no default category, ensuring they aren't automatically labeled (e.g., as photographers) until they add a service.

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import Link from 'next/link';
+import { ChevronRightIcon } from '@heroicons/react/24/solid';
 import ServiceProviderCardCompact from '@/components/service-provider/ServiceProviderCardCompact';
 import { getServiceProviders } from '@/lib/api';
 import { getFullImageUrl } from '@/lib/utils';
@@ -34,8 +35,16 @@ export default function ArtistsSection({
 }: ArtistsSectionProps) {
   const [artists, setArtists] = useState<ServiceProviderProfile[]>([]);
   const [loading, setLoading] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollRight, setCanScrollRight] = useState(false);
 
   const serializedQuery = useMemo(() => JSON.stringify(query), [query]);
+
+  const updateScrollButton = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth);
+  };
 
   useEffect(() => {
     let isMounted = true;
@@ -61,6 +70,18 @@ export default function ArtistsSection({
     };
   }, [serializedQuery, limit]);
 
+  useEffect(() => {
+    updateScrollButton();
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateScrollButton);
+    window.addEventListener('resize', updateScrollButton);
+    return () => {
+      el.removeEventListener('scroll', updateScrollButton);
+      window.removeEventListener('resize', updateScrollButton);
+    };
+  }, [artists.length]);
+
   if (!loading && artists.length === 0 && hideIfEmpty) {
     return null;
   }
@@ -79,35 +100,53 @@ export default function ArtistsSection({
         )}
       </div>
       {loading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-2 md:gap-2">
+        <div className="flex gap-2 overflow-x-auto pb-2">
           {Array.from({ length: limit }).map((_, i) => (
-            <CardSkeleton key={i} />
+            <div key={i} className="w-40 flex-shrink-0">
+              <CardSkeleton />
+            </div>
           ))}
         </div>
       ) : artists.length > 0 ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 gap-2 md:gap-2">
-          {artists.map((a) => {
-            const name = a.business_name || `${a.user.first_name} ${a.user.last_name}`;
-            return (
-              <ServiceProviderCardCompact
-                key={a.id}
-                serviceProviderId={a.id}
-                name={name}
-                subtitle={a.custom_subtitle || undefined}
-                imageUrl={
-                  getFullImageUrl(a.profile_picture_url || a.portfolio_urls?.[0]) || undefined
-                }
-                price={
-                  a.hourly_rate && a.price_visible ? Number(a.hourly_rate) : undefined
-                }
-                rating={a.rating ?? undefined}
-                ratingCount={a.rating_count ?? undefined}
-                location={a.location}
-                categories={a.service_categories}
-                href={`/service-providers/${a.id}`}
-              />
-            );
-          })}
+        <div className="relative">
+          <div
+            ref={scrollRef}
+            data-testid="artists-scroll"
+            className="flex gap-2 overflow-x-auto scroll-smooth pb-2 scrollbar-hide"
+          >
+            {artists.map((a) => {
+              const name = a.business_name || `${a.user.first_name} ${a.user.last_name}`;
+              return (
+                <ServiceProviderCardCompact
+                  key={a.id}
+                  serviceProviderId={a.id}
+                  name={name}
+                  subtitle={a.custom_subtitle || undefined}
+                  imageUrl={
+                    getFullImageUrl(a.profile_picture_url || a.portfolio_urls?.[0]) || undefined
+                  }
+                  price={
+                    a.hourly_rate && a.price_visible ? Number(a.hourly_rate) : undefined
+                  }
+                  rating={a.rating ?? undefined}
+                  ratingCount={a.rating_count ?? undefined}
+                  location={a.location}
+                  categories={a.service_categories}
+                  href={`/service-providers/${a.id}`}
+                  className="w-40 flex-shrink-0"
+                />
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            aria-label="Next"
+            className="absolute right-0 top-1 z-10 hidden -translate-y-1 rounded-full border bg-white p-2 opacity-50 shadow disabled:opacity-50 sm:block"
+            disabled={!canScrollRight}
+            onClick={() => scrollRef.current?.scrollBy({ left: 200, behavior: 'smooth' })}
+          >
+            <ChevronRightIcon className="h-2 w-2" />
+          </button>
         </div>
       ) : (
         <p>No service providers found.</p>

--- a/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
+++ b/frontend/src/components/home/__tests__/ArtistsSection.test.tsx
@@ -1,0 +1,84 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ArtistsSection from '../ArtistsSection';
+import { getServiceProviders } from '@/lib/api';
+
+jest.mock('@/lib/api');
+
+const mockedGetServiceProviders = getServiceProviders as jest.MockedFunction<typeof getServiceProviders>;
+
+const MOCK_ARTISTS = [
+  {
+    id: 1,
+    business_name: 'Artist One',
+    profile_picture_url: '/a.jpg',
+    rating: 4.5,
+    rating_count: 10,
+    hourly_rate: 100,
+    price_visible: true,
+    location: 'Cape Town',
+    service_categories: [],
+  },
+  {
+    id: 2,
+    business_name: 'Artist Two',
+    profile_picture_url: '/b.jpg',
+    rating: 4.0,
+    rating_count: 5,
+    hourly_rate: 200,
+    price_visible: true,
+    location: 'Johannesburg',
+    service_categories: [],
+  },
+];
+
+describe('ArtistsSection carousel', () => {
+  beforeEach(() => {
+    mockedGetServiceProviders.mockResolvedValue({ data: MOCK_ARTISTS } as any);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  it('renders artists and scrolls when clicking next', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(ArtistsSection, { title: 'Popular' }));
+    });
+
+    const scroller = container.querySelector('[data-testid="artists-scroll"]') as HTMLDivElement;
+    expect(scroller).not.toBeNull();
+    Object.defineProperty(scroller, 'scrollWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scroller, 'clientWidth', {
+      configurable: true,
+      value: 500,
+    });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    const next = container.querySelector('button[aria-label="Next"]') as HTMLButtonElement;
+    expect(next).not.toBeNull();
+    expect(next.disabled).toBe(false);
+    const mock = jest.fn();
+    scroller.scrollBy = mock;
+    act(() => {
+      next.click();
+    });
+    expect(mock).toHaveBeenCalled();
+
+    const first = scroller.querySelector('a');
+    expect(first?.className).toContain('w-40');
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- turn Popular, Top Rated, and New on Booka sections into horizontal carousels
- document carousel layout in README

## Testing
- `./scripts/test-all.sh` *(fails: Test Suites: 44 failed, 2 skipped, 83 passed, 127 of 129 total)*

------
https://chatgpt.com/codex/tasks/task_e_6898ae865c98832eae2e6e04767a433b