### PR TITLE
Optimize DB queries and add pagination

### DIFF
--- a/backend/alembic/versions/d7c6e1f2a9b3_add_indexes_for_filters.py
+++ b/backend/alembic/versions/d7c6e1f2a9b3_add_indexes_for_filters.py
@@ -1,0 +1,38 @@
+"""add indexes for frequent filters
+
+Revision ID: d7c6e1f2a9b3
+Revises: b9ce27413121
+Create Date: 2025-09-15 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7c6e1f2a9b3'
+down_revision: Union[str, None] = 'b9ce27413121'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add indexes for common booking queries."""
+    op.create_index(op.f('ix_bookings_artist_id'), 'bookings', ['artist_id'])
+    op.create_index(op.f('ix_bookings_status'), 'bookings', ['status'])
+    op.create_index(op.f('ix_bookings_start_time'), 'bookings', ['start_time'])
+    op.create_index(op.f('ix_booking_requests_artist_id'), 'booking_requests', ['artist_id'])
+    op.create_index(op.f('ix_booking_requests_status'), 'booking_requests', ['status'])
+    op.create_index(op.f('ix_booking_requests_proposed_datetime_1'), 'booking_requests', ['proposed_datetime_1'])
+    op.create_index(op.f('ix_booking_requests_proposed_datetime_2'), 'booking_requests', ['proposed_datetime_2'])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_booking_requests_proposed_datetime_2'), table_name='booking_requests')
+    op.drop_index(op.f('ix_booking_requests_proposed_datetime_1'), table_name='booking_requests')
+    op.drop_index(op.f('ix_booking_requests_status'), table_name='booking_requests')
+    op.drop_index(op.f('ix_booking_requests_artist_id'), table_name='booking_requests')
+    op.drop_index(op.f('ix_bookings_start_time'), table_name='bookings')
+    op.drop_index(op.f('ix_bookings_status'), table_name='bookings')
+    op.drop_index(op.f('ix_bookings_artist_id'), table_name='bookings')

--- a/backend/app/api/v1/api_service_provider.py
+++ b/backend/app/api/v1/api_service_provider.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, File, UploadFile, HTTPException, Query
 from fastapi.params import Query as QueryParam
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func, desc, or_
 from collections import defaultdict
 from datetime import datetime, timedelta, date
@@ -494,6 +494,7 @@ def read_all_service_provider_profiles(
             booking_subq.c.book_count,
             category_subq.c.service_categories,
         )
+        .options(joinedload(Artist.user))
         .outerjoin(rating_subq, rating_subq.c.artist_id == Artist.user_id)
         .outerjoin(booking_subq, booking_subq.c.artist_id == Artist.user_id)
         .outerjoin(category_subq, category_subq.c.artist_id == Artist.user_id)

--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -10,12 +10,12 @@ class Booking(BaseModel):
     __tablename__ = "bookings"
 
     id         = Column(Integer, primary_key=True, index=True)
-    artist_id  = Column(Integer, ForeignKey("artist_profiles.user_id"))
+    artist_id  = Column(Integer, ForeignKey("artist_profiles.user_id"), index=True)
     client_id  = Column(Integer, ForeignKey("users.id"))
     service_id = Column(Integer, ForeignKey("services.id", ondelete="CASCADE"))
-    start_time = Column(DateTime, nullable=False)
+    start_time = Column(DateTime, nullable=False, index=True)
     end_time   = Column(DateTime, nullable=False)
-    status     = Column(Enum(BookingStatus), default=BookingStatus.PENDING)
+    status     = Column(Enum(BookingStatus), default=BookingStatus.PENDING, index=True)
     total_price= Column(Numeric(10, 2), nullable=False)  # ← Numeric is now imported
     notes      = Column(String)
     quote_id   = Column(Integer, ForeignKey("quotes.id"), nullable=True)

--- a/backend/app/models/request_quote.py
+++ b/backend/app/models/request_quote.py
@@ -19,19 +19,19 @@ class BookingRequest(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     client_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    artist_id = Column(Integer, ForeignKey("users.id"), nullable=False) # The artist's user_id
+    artist_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True) # The artist's user_id
     service_id = Column(Integer, ForeignKey("services.id", ondelete="CASCADE"), nullable=True) # Optional
 
     message = Column(Text, nullable=True)
     attachment_url = Column(String, nullable=True)
-    proposed_datetime_1 = Column(DateTime, nullable=True)
-    proposed_datetime_2 = Column(DateTime, nullable=True)
+    proposed_datetime_1 = Column(DateTime, nullable=True, index=True)
+    proposed_datetime_2 = Column(DateTime, nullable=True, index=True)
 
     travel_mode = Column(String, nullable=True)
     travel_cost = Column(Numeric(10, 2), nullable=True)
     travel_breakdown = Column(JSON, nullable=True)
     
-    status = Column(SQLAlchemyEnum(BookingStatus), nullable=False, default=BookingStatus.PENDING_QUOTE)
+    status = Column(SQLAlchemyEnum(BookingStatus), nullable=False, default=BookingStatus.PENDING_QUOTE, index=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/tests/test_sound_provider_list.py
+++ b/backend/tests/test_sound_provider_list.py
@@ -1,0 +1,29 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.base import BaseModel
+from app.models import SoundProvider
+from app.api import api_sound_provider
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False})
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def test_list_providers_pagination_and_fields():
+    db = setup_db()
+    db.add_all([
+        SoundProvider(name='A', contact_info='a'),
+        SoundProvider(name='B', contact_info='b'),
+        SoundProvider(name='C', contact_info='c'),
+    ])
+    db.commit()
+
+    result = api_sound_provider.list_providers(db, skip=1, limit=1, fields='name')
+    assert len(result) == 1
+    item = result[0]
+    assert item['name'] == 'B'
+    assert 'contact_info' not in item

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2087,6 +2087,39 @@
               "type": "integer",
               "title": "Request Id"
             }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Skip",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Limit",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Fields"
+            },
+            "description": "Comma-separated fields to include in the response"
           }
         ],
         "responses": {
@@ -2127,17 +2160,50 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
+          "parameters": [
+            {
+              "name": "request_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "integer",
+                "title": "Request Id"
+              }
+            },
+            {
+              "name": "skip",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "title": "Skip",
+                "default": 0,
+                "minimum": 0
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "title": "Limit",
+                "default": 100,
+                "minimum": 1,
+                "maximum": 100
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "title": "Fields"
+              },
+              "description": "Comma-separated fields to include in the response"
             }
-          }
-        ],
+          ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2576,6 +2642,39 @@
               "type": "integer",
               "title": "Request Id"
             }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Skip",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Limit",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Fields"
+            },
+            "description": "Comma-separated fields to include in the response"
           }
         ],
         "responses": {
@@ -3099,30 +3198,63 @@
         }
       }
     },
-    "/api/v1/booking-requests/{request_id}/messages": {
-      "get": {
-        "tags": [
-          "messages",
-          "messages"
-        ],
-        "summary": "Read Messages",
-        "operationId": "read_messages_api_v1_booking_requests__request_id__messages_get",
-        "security": [
-          {
-            "OAuth2PasswordBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "request_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Request Id"
+      "/api/v1/booking-requests/{request_id}/messages": {
+        "get": {
+          "tags": [
+            "messages",
+            "messages"
+          ],
+          "summary": "Read Messages",
+          "operationId": "read_messages_api_v1_booking_requests__request_id__messages_get",
+          "security": [
+            {
+              "OAuth2PasswordBearer": []
             }
-          }
-        ],
+          ],
+          "parameters": [
+            {
+              "name": "request_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "integer",
+                "title": "Request Id"
+              }
+            },
+            {
+              "name": "skip",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "title": "Skip",
+                "default": 0,
+                "minimum": 0
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "title": "Limit",
+                "default": 100,
+                "minimum": 1,
+                "maximum": 100
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "title": "Fields"
+              },
+              "description": "Comma-separated fields to include in the response"
+            }
+          ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3536,6 +3668,41 @@
         ],
         "summary": "List Providers",
         "operationId": "list_providers_api_v1_sound_providers__get",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Skip",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Limit",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Fields"
+            },
+            "description": "Comma-separated fields to include in the response"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",


### PR DESCRIPTION
## Summary
- add indexes to bookings and booking requests for common filters
- avoid N+1 queries in message listing and service provider lookups
- add pagination and field selection to message and sound provider list endpoints

## Testing
- `PYTHONPATH=. pytest tests/test_message_flow.py::test_read_messages_pagination_and_fields tests/test_sound_provider_list.py::test_list_providers_pagination_and_fields`
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898b1c89e7c832eb9d95c178d51920d