### PR TITLE
Expand Redis caching across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,10 +1107,14 @@ The dashboard brings common actions to the surface with a tidy layout:
 
 ### Redis Caching
 
-* Caches `/api/v1/service-provider-profiles/` GET responses.
-* Cache keys include page number, limit, and filter parameters so each combination is stored separately.
-* Default Redis URL: `redis://localhost:6379/0`.
-* Fallback to DB if Redis is unavailable.
+* Caches heavy endpoints using Redis:
+  * `/api/v1/service-provider-profiles/` artist lists (60 s TTL).
+  * `/api/v1/sound-providers/` provider lists (10 min TTL).
+  * `/api/v1/travel-forecast` 3‑day weather by location (30 min TTL).
+  * `/api/v1/service-provider-profiles/{id}/availability` results (5 min TTL).
+* Random jitter is added to each TTL to reduce cache stampedes.
+* Cache keys include all relevant query parameters so each combination is stored separately.
+* Fallback to the database or external API if Redis is unavailable.
 * Connections close cleanly on API shutdown.
 
 ### Artist Listing Filters

--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -21,6 +21,7 @@ from .dependencies import (
     get_current_active_client,
     get_current_service_provider,
 )
+from ..utils.redis_cache import invalidate_availability_cache
 
 router = APIRouter(tags=["bookings"])
 logger = logging.getLogger(__name__)
@@ -87,6 +88,8 @@ def create_booking(
     db.add(db_booking)
     db.commit()
     db.refresh(db_booking)
+
+    invalidate_availability_cache(booking_in.artist_id)
 
     # Re‐load with relationships for the response model (if BookingResponse expects nested fields)
     reloaded = (
@@ -243,6 +246,7 @@ def update_booking_status(
 
     db.add(booking)
     db.commit()
+    invalidate_availability_cache(booking.artist_id)
 
     reloaded = (
         db.query(Booking)

--- a/backend/app/api/api_booking_request.py
+++ b/backend/app/api/api_booking_request.py
@@ -19,6 +19,7 @@ from ..utils.notifications import (
     notify_user_new_message,
 )
 from ..utils import error_response
+from ..utils.redis_cache import invalidate_availability_cache
 import os
 import uuid
 import shutil
@@ -182,6 +183,7 @@ def create_booking_request(
         visible_to=models.VisibleTo.ARTIST,
         action=models.MessageAction.REVIEW_QUOTE,
     )
+    invalidate_availability_cache(new_request.artist_id)
     return new_request
 
 
@@ -413,6 +415,7 @@ def update_booking_request_by_client(
     updated = crud.crud_booking_request.update_booking_request(
         db=db, db_booking_request=db_request, request_update=request_update
     )
+    invalidate_availability_cache(db_request.artist_id)
 
     if request_update.status and request_update.status != prev_status:
         artist_user = (
@@ -510,6 +513,7 @@ def update_booking_request_by_artist(
     updated = crud.crud_booking_request.update_booking_request(
         db=db, db_booking_request=db_request, request_update=request_update
     )
+    invalidate_availability_cache(db_request.artist_id)
 
     if request_update.status and request_update.status != prev_status:
         client_user = (

--- a/backend/tests/test_sound_provider_cache_invalidation.py
+++ b/backend/tests/test_sound_provider_cache_invalidation.py
@@ -1,0 +1,37 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.api import api_sound_provider
+from app.models.base import BaseModel
+from app.schemas.sound_provider import SoundProviderCreate
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    return Session
+
+
+def test_create_provider_invalidates_cache(monkeypatch):
+    Session = setup_db()
+    db = Session()
+    called = {"flag": False}
+
+    def fake_invalidate():
+        called["flag"] = True
+
+    monkeypatch.setattr(
+        api_sound_provider,
+        "invalidate_provider_list_cache",
+        fake_invalidate,
+    )
+    payload = SoundProviderCreate(name="Test")
+    api_sound_provider.create_provider(db=db, provider_in=payload)
+    assert called["flag"]
+    db.close()


### PR DESCRIPTION
## Summary
- add Redis caching helpers for weather forecasts, availability, and provider lists with TTL jitter
- cache weather, availability checks, and sound provider listings
- invalidate availability and provider caches on booking and provider writes

## Testing
- `./scripts/test-all.sh`
- `PYTHONPATH=backend pytest backend/tests/test_cache.py backend/tests/test_sound_provider_cache_invalidation.py`


------
https://chatgpt.com/codex/tasks/task_e_6898b6157114832eb2af3041d3cf2ffc