### PR TITLE
feat(ws): harden realtime chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 - After accepting a quote, clients see quick links in the chat to view that booking, pay the deposit, and add it to a calendar.
 - Inbox conversations feature a **Show Details** button that opens a slide-out booking details panel. On mobile the panel overlays the chat, while on desktop it appears side-by-side with smooth Tailwind transitions.
 - The chat thread now expands or contracts horizontally as the side panel is toggled, keeping date divider lines perfectly aligned across both sections.
+- Chat WebSocket connections send periodic ping/pong heartbeats, batch typing indicators, and close slow clients after a one-second send timeout. A `reconnect_hint` message guides exponential retries and Redis pub/sub is used when `WEBSOCKET_REDIS_URL` is set.
 - Artists can upload multiple portfolio images and reorder them via drag-and-drop. Use `POST /api/v1/service-provider-profiles/me/portfolio-images` to upload and `PUT /api/v1/service-provider-profiles/me/portfolio-images` to save the order.
 - Artists can also drag and drop service cards on the dashboard to set their display order.
 - Heavy tasks like NLP parsing, notification delivery, and weather lookups now run

--- a/backend/tests/test_ws_features.py
+++ b/backend/tests/test_ws_features.py
@@ -1,0 +1,93 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.models.base import BaseModel
+from app.api.dependencies import get_db
+from app.api.auth import create_access_token
+from app.models import User, UserType, BookingRequest, BookingStatus
+
+
+def setup_app():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def override_db():
+        db = Session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return Session
+
+
+def create_data(Session):
+    db = Session()
+    artist = User(
+        email="artist@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.SERVICE_PROVIDER,
+    )
+    client = User(
+        email="client@test.com",
+        password="x",
+        first_name="C",
+        last_name="L",
+        user_type=UserType.CLIENT,
+    )
+    db.add_all([artist, client])
+    db.commit()
+    db.refresh(artist)
+    db.refresh(client)
+    br = BookingRequest(
+        client_id=client.id, artist_id=artist.id, status=BookingStatus.PENDING_QUOTE
+    )
+    db.add(br)
+    db.commit()
+    db.refresh(br)
+    db.close()
+    return br, artist, client
+
+
+def test_reconnect_hint():
+    Session = setup_app()
+    br, artist, _ = create_data(Session)
+    client = TestClient(app)
+    token = create_access_token({"sub": artist.email})
+    with client.websocket_connect(
+        f"/api/v1/ws/booking-requests/{br.id}?token={token}&attempt=2"
+    ) as ws:
+        data = ws.receive_json()
+        assert data == {"type": "reconnect_hint", "delay": 4}
+        ws.close()
+    app.dependency_overrides.clear()
+
+
+def test_batched_typing():
+    Session = setup_app()
+    br, artist, _ = create_data(Session)
+    client = TestClient(app)
+    token = create_access_token({"sub": artist.email})
+    with client.websocket_connect(
+        f"/api/v1/ws/booking-requests/{br.id}?token={token}"
+    ) as ws:
+        ws.receive_json()  # reconnect hint
+        ws.send_json({"type": "typing", "user_id": artist.id})
+        ws.send_json({"type": "typing", "user_id": artist.id + 1})
+        data = ws.receive_json()
+        assert data["type"] == "typing"
+        assert set(data["users"]) == {artist.id, artist.id + 1}
+        ws.close()
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add ping/pong heartbeats, reconnect hints, backpressure, and typing batches for WebSockets
- support per-request Redis pub/sub channels
- document chat WebSocket hardening

## Testing
- `pytest`
- `npm test` *(fails: 74 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6898c598b2c0832eaa30795fb7cc0489