### PR TITLE
feat: optimize wizard and chat performance

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -116,6 +116,13 @@ font (`--font-inter`) is provided by `next/font`. The body font size is set to
 `16px` for readability. Replace the `--font-inter` variable to use a different
 typeface across the site.
 
+### Performance Optimizations
+
+Booking wizard steps load on demand using `next/dynamic`, and heavy chat
+components are wrapped with `React.memo` to minimize re-renders. Service and
+profile requests in the wizard use App Router caching (`force-cache`) where
+safe to reduce network traffic.
+
 ### Booking Wizard URL Parameters
 
 The `/booking` page requires an `artist_id` query parameter (the service provider's ID) and accepts an optional `service_id` to pre-select a service.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import './globals.css';
 const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
+  weight: ['400', '700'],
   variable: '--font-inter',
 });
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -37,8 +37,10 @@ import QuoteBubble from './QuoteBubble';
 import InlineQuoteForm from './InlineQuoteForm';
 import useWebSocket from '@/hooks/useWebSocket';
 import { format, isValid } from 'date-fns';
-import Countdown from './Countdown';
 import { useRouter } from 'next/navigation';
+
+const MemoQuoteBubble = React.memo(QuoteBubble);
+const MemoInlineQuoteForm = React.memo(InlineQuoteForm);
 
 
 // Constants
@@ -693,7 +695,7 @@ useEffect(() => {
 
           {user?.user_type === 'service_provider' && !bookingConfirmed && !hasSentQuote && (
             <div className="mb-4" data-testid="artist-inline-quote">
-              <InlineQuoteForm
+              <MemoInlineQuoteForm
                 artistId={currentArtistId}
                 clientId={currentClientId}
                 bookingRequestId={bookingRequestId}
@@ -812,7 +814,7 @@ useEffect(() => {
                           className={`mb-0.5 w-full`}
                           ref={idx === firstUnreadIndex && msgIdx === 0 ? firstUnreadMessageRef : null}
                         >
-                          <QuoteBubble
+                          <MemoQuoteBubble
                             description={quoteData.services[0]?.description || ''}
                             price={Number(quoteData.services[0]?.price || 0)}
                             soundFee={Number(quoteData.sound_fee)}

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -39,17 +39,18 @@ describe('BookingWizard instructions', () => {
     (api.getServiceProviderAvailability as jest.Mock).mockResolvedValue({
       data: { unavailable_dates: [] },
     });
-    (api.getServiceProvider as jest.Mock).mockResolvedValue({
-      data: { location: 'NYC' },
-    });
-    (api.getService as jest.Mock).mockResolvedValue({
-      data: {
-        price: 'R100',
-        travel_rate: 2.5,
-        travel_members: 1,
-        car_rental_price: 0,
-        flight_price: 0,
-      },
+    global.fetch = jest.fn((url: RequestInfo) => {
+      const response =
+        typeof url === 'string' && url.includes('service-provider-profiles')
+          ? { location: 'NYC' }
+          : {
+              price: 'R100',
+              travel_rate: 2.5,
+              travel_members: 1,
+              car_rental_price: 0,
+              flight_price: 0,
+            };
+      return Promise.resolve({ json: () => Promise.resolve(response) }) as any;
     });
     (api.calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 100 } });
     (geo.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });


### PR DESCRIPTION
## Summary
- code-split booking wizard steps with `next/dynamic`
- memoize heavy message thread components
- prefetch review quote data and cache static fetches
- tighten Inter font loading to specific weights

## Testing
- `./scripts/test-all.sh` *(failed: Git remote 'origin' not found)*
- `pytest` *(69 errors during collection)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(44 failed, 2 skipped, 83 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898c89c1c64832e9e0fff9157e4111e