### PR TITLE
fix: handle invalid timestamps in TimeAgo

### DIFF
--- a/frontend/src/components/ui/TimeAgo.tsx
+++ b/frontend/src/components/ui/TimeAgo.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { formatDistanceToNow } from 'date-fns';
+import { useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
 
 interface TimeAgoProps {
   timestamp: string | number | Date;
@@ -16,21 +16,35 @@ export default function TimeAgo({
   intervalMs = 60000,
   className,
 }: TimeAgoProps) {
+  const date = new Date(timestamp);
+  const isValid = !Number.isNaN(date.getTime());
+
   const [relative, setRelative] = useState(() =>
-    formatDistanceToNow(new Date(timestamp), { addSuffix }),
+    isValid ? formatDistanceToNow(date, { addSuffix }) : "",
   );
 
   useEffect(() => {
+    if (!isValid) return undefined;
+
     function update() {
-      setRelative(formatDistanceToNow(new Date(timestamp), { addSuffix }));
+      setRelative(formatDistanceToNow(date, { addSuffix }));
     }
     const id = setInterval(update, intervalMs);
     update();
     return () => clearInterval(id);
-  }, [timestamp, addSuffix, intervalMs]);
+  }, [timestamp, addSuffix, intervalMs, isValid]);
 
-  const iso = new Date(timestamp).toISOString();
-  const full = new Date(timestamp).toLocaleString();
+  if (!isValid) {
+    return (
+      <time className={className} dateTime="">
+        <span className="sr-only">Invalid date</span>
+        Invalid date
+      </time>
+    );
+  }
+
+  const iso = date.toISOString();
+  const full = date.toLocaleString();
 
   return (
     <time dateTime={iso} title={full} className={className}>

--- a/frontend/src/components/ui/__tests__/TimeAgo.test.tsx
+++ b/frontend/src/components/ui/__tests__/TimeAgo.test.tsx
@@ -1,16 +1,16 @@
-import { createRoot } from 'react-dom/client';
-import React from 'react';
-import { act } from 'react-dom/test-utils';
-import TimeAgo from '../TimeAgo';
+import { createRoot } from "react-dom/client";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import TimeAgo from "../TimeAgo";
 
-describe('TimeAgo component', () => {
+describe("TimeAgo component", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
 
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-01-01T12:00:00Z'));
-    container = document.createElement('div');
+    jest.setSystemTime(new Date("2025-01-01T12:00:00Z"));
+    container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
   });
@@ -23,13 +23,13 @@ describe('TimeAgo component', () => {
     container.remove();
   });
 
-  it('updates relative time periodically', () => {
+  it("updates relative time periodically", () => {
     act(() => {
       root.render(
         <TimeAgo timestamp="2025-01-01T11:59:00Z" intervalMs={60000} />,
       );
     });
-    const timeEl = container.querySelector('time') as HTMLElement;
+    const timeEl = container.querySelector("time") as HTMLElement;
     const firstText = timeEl.textContent;
 
     act(() => {
@@ -38,5 +38,13 @@ describe('TimeAgo component', () => {
 
     const secondText = timeEl.textContent;
     expect(secondText).not.toBe(firstText);
+  });
+
+  it("renders a fallback for invalid timestamps", () => {
+    act(() => {
+      root.render(<TimeAgo timestamp="not-a-date" />);
+    });
+    const timeEl = container.querySelector("time") as HTMLElement;
+    expect(timeEl.textContent).toBe("Invalid date");
   });
 });


### PR DESCRIPTION
## Summary
- validate timestamps in `TimeAgo` and render a fallback when invalid
- test TimeAgo invalid timestamp behaviour

## Testing
- `./scripts/test-all.sh` *(fails: Test run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68995bb81754832e995d58083391cfaa