### PR TITLE
feat: show city on artist cards

### DIFF
--- a/frontend/src/components/service-provider/ServiceProviderCard.tsx
+++ b/frontend/src/components/service-provider/ServiceProviderCard.tsx
@@ -9,7 +9,7 @@ import {
   StarIcon,
   CheckBadgeIcon,
 } from '@heroicons/react/24/solid';
-import { getFullImageUrl } from '@/lib/utils';
+import { getFullImageUrl, getCityFromAddress } from '@/lib/utils';
 
 export interface ServiceProviderCardProps extends HTMLAttributes<HTMLDivElement> {
   serviceProviderId: number;
@@ -152,7 +152,9 @@ export default function ServiceProviderCard({
         </div>
         <div className="flex justify-between items-center mt-4">
           {location ? (
-            <span className="text-sm text-gray-600 truncate">{location}</span>
+            <span className="text-sm text-gray-600 truncate">
+              {getCityFromAddress(location)}
+            </span>
           ) : (
             <span />
           )}

--- a/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
+++ b/frontend/src/components/service-provider/ServiceProviderCardCompact.tsx
@@ -7,7 +7,7 @@ import {
   StarIcon,
 } from '@heroicons/react/24/solid';
 import clsx from 'clsx';
-import { getFullImageUrl } from '@/lib/utils';
+import { getFullImageUrl, getCityFromAddress } from '@/lib/utils';
 import { BREAKPOINT_MD } from '@/lib/breakpoints';
 
 export interface ServiceProviderCardCompactProps
@@ -96,7 +96,9 @@ export default function ServiceProviderCardCompact({
       <div className="p-1 space-y-0.5">
         <p className="text-sm font-semibold truncate text-black">{name}</p>
         {location && (
-          <p className="text-xs text-gray-400 truncate">{location}</p>
+          <p className="text-xs text-gray-400 truncate">
+            {getCityFromAddress(location)}
+          </p>
         )}
       </div>
     </Link>

--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
@@ -53,12 +53,20 @@ describe('ServiceProviderCard optional fields', () => {
     c2.remove();
   });
 
-  it('shows location but omits subtitle', () => {
-    const { container, root } = setup({ location: 'NYC', subtitle: 'Best service provider ever in the world' });
-    expect(container.textContent).toContain('NYC');
+  it('shows only the city for location and omits subtitle', () => {
+    const fullAddress =
+      '123 Main St, Suburb, Johannesburg, Gauteng, South Africa';
+    const { container, root } = setup({
+      location: fullAddress,
+      subtitle: 'Best service provider ever in the world',
+    });
+    expect(container.textContent).toContain('Johannesburg');
+    expect(container.textContent).not.toContain('123 Main St');
+    expect(container.textContent).not.toContain('Suburb');
+    expect(container.textContent).not.toContain('Gauteng');
     expect(container.textContent).not.toContain('Best service provider');
     const locEl = container.querySelector('span.text-sm');
-    expect(locEl?.textContent).toContain('NYC');
+    expect(locEl?.textContent).toBe('Johannesburg');
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
@@ -41,4 +41,19 @@ describe('ServiceProviderCardCompact', () => {
     act(() => root.unmount());
     container.remove();
   });
+
+  it('shows only the city when full address is provided', () => {
+    const { container, root, allProps } = setup({
+      location: '123 Main St, Suburb, Cape Town, Western Cape, South Africa',
+    });
+    act(() => {
+      root.render(React.createElement(ServiceProviderCardCompact, allProps));
+    });
+    expect(container.textContent).toContain('Cape Town');
+    expect(container.textContent).not.toContain('123 Main St');
+    expect(container.textContent).not.toContain('Suburb');
+    expect(container.textContent).not.toContain('Western Cape');
+    act(() => root.unmount());
+    container.remove();
+  });
 });

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
   generateQuoteNumber,
   applyDisplayOrder,
   getStreetFromAddress,
+  getCityFromAddress,
 } from '../utils';
 import { DEFAULT_CURRENCY } from '../constants';
 import api from '../api';
@@ -180,6 +181,18 @@ describe('getStreetFromAddress', () => {
 
   it('returns original when no comma is present', () => {
     expect(getStreetFromAddress('Cape Town')).toBe('Cape Town');
+  });
+});
+
+describe('getCityFromAddress', () => {
+  it('returns the city portion of a full address', () => {
+    expect(
+      getCityFromAddress('123 Main St, Suburb, Cape Town, Western Cape, South Africa'),
+    ).toBe('Cape Town');
+  });
+
+  it('handles addresses without country or province', () => {
+    expect(getCityFromAddress('123 Main St, Suburb, Durban')).toBe('Durban');
   });
 });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -108,6 +108,40 @@ export const getStreetFromAddress = (address: string): string => {
   return street.trim();
 };
 
+/**
+ * Extract the city or town portion from a full address string.
+ * Known country and province segments are stripped from the end so
+ * that only the most relevant location name is returned.
+ */
+export const getCityFromAddress = (address: string): string => {
+  if (!address) return '';
+  const parts = address
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const countries = ['south africa'];
+  const provinces = [
+    'eastern cape',
+    'western cape',
+    'northern cape',
+    'gauteng',
+    'kwazulu-natal',
+    'limpopo',
+    'mpumalanga',
+    'north west',
+    'free state',
+  ];
+  while (parts.length > 1) {
+    const last = parts[parts.length - 1].toLowerCase();
+    if (countries.includes(last) || provinces.includes(last)) {
+      parts.pop();
+    } else {
+      break;
+    }
+  }
+  return parts[parts.length - 1] ?? '';
+};
+
 export const normalizeQuoteTemplate = (
   tmpl: QuoteTemplate,
 ): QuoteTemplate => ({


### PR DESCRIPTION
## Summary
- only render city/town on artist cards
- add getCityFromAddress utility and tests
- verify location handling with new unit tests

## Testing
- `./scripts/test-all.sh` *(fails: response interceptor › falls back to extracted detail and logs error; multiple frontend tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6899647cae18832ea93db8ec14e95cca