### PR TITLE
fix: display city instead of postal code on artist cards

### DIFF
--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCard.test.tsx
@@ -55,18 +55,19 @@ describe('ServiceProviderCard optional fields', () => {
 
   it('shows only the city for location and omits subtitle', () => {
     const fullAddress =
-      '123 Main St, Suburb, Johannesburg, Gauteng, South Africa';
+      '123 Main St, Suburb, Worcester, 6850, Western Cape, South Africa';
     const { container, root } = setup({
       location: fullAddress,
       subtitle: 'Best service provider ever in the world',
     });
-    expect(container.textContent).toContain('Johannesburg');
+    expect(container.textContent).toContain('Worcester');
     expect(container.textContent).not.toContain('123 Main St');
     expect(container.textContent).not.toContain('Suburb');
-    expect(container.textContent).not.toContain('Gauteng');
+    expect(container.textContent).not.toContain('6850');
+    expect(container.textContent).not.toContain('Western Cape');
     expect(container.textContent).not.toContain('Best service provider');
     const locEl = container.querySelector('span.text-sm');
-    expect(locEl?.textContent).toBe('Johannesburg');
+    expect(locEl?.textContent).toBe('Worcester');
     act(() => root.unmount());
     container.remove();
   });

--- a/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
+++ b/frontend/src/components/service-provider/__tests__/ServiceProviderCardCompact.test.tsx
@@ -44,14 +44,15 @@ describe('ServiceProviderCardCompact', () => {
 
   it('shows only the city when full address is provided', () => {
     const { container, root, allProps } = setup({
-      location: '123 Main St, Suburb, Cape Town, Western Cape, South Africa',
+      location: '123 Main St, Suburb, Worcester, 6850, Western Cape, South Africa',
     });
     act(() => {
       root.render(React.createElement(ServiceProviderCardCompact, allProps));
     });
-    expect(container.textContent).toContain('Cape Town');
+    expect(container.textContent).toContain('Worcester');
     expect(container.textContent).not.toContain('123 Main St');
     expect(container.textContent).not.toContain('Suburb');
+    expect(container.textContent).not.toContain('6850');
     expect(container.textContent).not.toContain('Western Cape');
     act(() => root.unmount());
     container.remove();

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -194,6 +194,11 @@ describe('getCityFromAddress', () => {
   it('handles addresses without country or province', () => {
     expect(getCityFromAddress('123 Main St, Suburb, Durban')).toBe('Durban');
   });
+
+  it('removes trailing postal codes and returns the city', () => {
+    const addr = '123 Main St, Suburb, Worcester, 6850, Western Cape, South Africa';
+    expect(getCityFromAddress(addr)).toBe('Worcester');
+  });
 });
 
 describe('generateQuoteNumber', () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -132,8 +132,13 @@ export const getCityFromAddress = (address: string): string => {
     'free state',
   ];
   while (parts.length > 1) {
-    const last = parts[parts.length - 1].toLowerCase();
-    if (countries.includes(last) || provinces.includes(last)) {
+    const lastRaw = parts[parts.length - 1];
+    const last = lastRaw.toLowerCase();
+    if (
+      countries.includes(last) ||
+      provinces.includes(last) ||
+      /^\d{4,}$/.test(last)
+    ) {
       parts.pop();
     } else {
       break;


### PR DESCRIPTION
## Summary
- strip postal codes when extracting cities from addresses
- cover postal code edge cases in location helpers and card tests

## Testing
- `./scripts/test-all.sh` *(fails: response interceptor falls back to detail but spy not called, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689967935dc4832e9107c4af0fd78d4c