### PR TITLE
chore: trim mobile js bundle

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -54,6 +54,11 @@ This document outlines key friction points in the current booking wizard and pro
 * Keep the hamburger menu visible so the main navigation drawer is always accessible. ✅ Implemented July 2025.
 * Simplify the hamburger menu by deduplicating links and grouping related items under clear section headings. ✅ Implemented July 2025.
 
+## JavaScript Optimization
+* Converted static layout pieces like `Footer` and `NavLink` into server components to eliminate unnecessary client-side bundles.
+* Deferred the home page category carousel with a dynamic import so non-critical widgets load after the main content.
+* Dropped heavy date utilities in favour of native `Intl` formatting for components such as `TimeAgo` and `NotificationListItem`.
+
 ## Collapsible Sections Component
 The `CollapsibleSection` component replaces raw `<details>` elements in the booking wizard. Each step header is rendered as a button with proper `aria-expanded` state so screen readers and keyboard users can toggle sections just as easily as touch users.
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,11 @@
 import MainLayout from '@/components/layout/MainLayout'
 import ArtistsSection from '@/components/home/ArtistsSection'
-import CategoriesCarousel from '@/components/home/CategoriesCarousel'
+import dynamic from 'next/dynamic'
+
+const CategoriesCarousel = dynamic(
+  () => import('@/components/home/CategoriesCarousel'),
+  { ssr: false },
+)
 
 export default function HomePage() {
   return (

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import type { ComponentProps } from 'react';
 

--- a/frontend/src/components/layout/NavLink.tsx
+++ b/frontend/src/components/layout/NavLink.tsx
@@ -1,4 +1,3 @@
-'use client';
 import Link, { LinkProps } from 'next/link';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import clsx from 'clsx';

--- a/frontend/src/components/layout/NotificationListItem.tsx
+++ b/frontend/src/components/layout/NotificationListItem.tsx
@@ -1,11 +1,17 @@
 // NotificationListItem.tsx
 'use client';
 
-import { format } from 'date-fns';
 import clsx from 'clsx';
 import TimeAgo from '../ui/TimeAgo';
 import { Avatar } from '../ui';
 import type { UnifiedNotification } from '@/types';
+
+const formatDate = (date: Date) =>
+  new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
 
 export interface ParsedNotification {
   title: string;
@@ -59,7 +65,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     const dateStr = content.match(/Date:\s*(\d{4}-\d{2}-\d{2})/)?.[1];
     const metadataParts: string[] = [];
     if (loc) metadataParts.push(`📍 ${loc}`);
-    if (dateStr) metadataParts.push(`📅 ${format(new Date(dateStr), 'MMM d, yyyy')}`);
+    if (dateStr) metadataParts.push(`📅 ${formatDate(new Date(dateStr))}`);
 
     return {
       ...base,
@@ -102,7 +108,7 @@ export function parseItem(n: UnifiedNotification): ParsedNotification {
     if (m) {
       const [, amt, by] = m;
       const parts = [`R${amt}`];
-      if (by) parts.push(`due by ${format(new Date(by), 'MMM d, yyyy')}`);
+      if (by) parts.push(`due by ${formatDate(new Date(by))}`);
       if (celebration) {
         return {
           ...base,

--- a/frontend/src/components/ui/TimeAgo.tsx
+++ b/frontend/src/components/ui/TimeAgo.tsx
@@ -1,7 +1,33 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { formatDistanceToNow } from "date-fns";
+
+function formatTimeAgo(date: Date, addSuffix: boolean): string {
+  const diffSeconds = (date.getTime() - Date.now()) / 1000;
+  const divisions = [
+    { amount: 60, unit: 'second' },
+    { amount: 60, unit: 'minute' },
+    { amount: 24, unit: 'hour' },
+    { amount: 7, unit: 'day' },
+    { amount: 4.34524, unit: 'week' },
+    { amount: 12, unit: 'month' },
+    { amount: Infinity, unit: 'year' },
+  ];
+  let duration = diffSeconds;
+  for (const division of divisions) {
+    if (Math.abs(duration) < division.amount) {
+      const rtf = new Intl.RelativeTimeFormat('en', {
+        numeric: addSuffix ? 'always' : 'auto',
+      });
+      return rtf.format(
+        Math.round(duration),
+        division.unit as Intl.RelativeTimeFormatUnit,
+      );
+    }
+    duration /= division.amount;
+  }
+  return '';
+}
 
 interface TimeAgoProps {
   timestamp: string | number | Date;
@@ -20,14 +46,14 @@ export default function TimeAgo({
   const isValid = !Number.isNaN(date.getTime());
 
   const [relative, setRelative] = useState(() =>
-    isValid ? formatDistanceToNow(date, { addSuffix }) : "",
+    isValid ? formatTimeAgo(date, addSuffix) : '',
   );
 
   useEffect(() => {
     if (!isValid) return undefined;
 
     function update() {
-      setRelative(formatDistanceToNow(date, { addSuffix }));
+      setRelative(formatTimeAgo(date, addSuffix));
     }
     const id = setInterval(update, intervalMs);
     update();


### PR DESCRIPTION
## Summary
- render Footer and NavLink as server components instead of shipping client bundles
- lazy load home page CategoriesCarousel with a dynamic import
- replace date-fns formatting in TimeAgo and NotificationListItem with native `Intl`
- document recent JavaScript optimizations for mobile

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd backend && pytest` *(fails: Interrupted: 69 errors during collection)*
- `cd frontend && npm test` *(fails: response interceptor falls back test, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68997718666c832ebfa487376ea960a9