### PR TITLE
Improve mobile gesture handling and transitions

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -67,3 +67,9 @@ The `CollapsibleSection` component replaces raw `<details>` elements in the book
   <LocationStep />
 </CollapsibleSection>
 ```
+
+## Gestures & Jank
+* Scroll and touch listeners now use passive mode to keep gesture handling off the main thread.
+* Step transitions rely on GPU-friendly `transform`/`opacity` animations with `will-change` hints for smooth 60fps updates.
+* Global `overscroll-behavior` prevents scroll chaining between the wizard and the page.
+* Heavy shadows are removed on small screens to cut compositing costs and avoid jank.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9,6 +9,18 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+  overscroll-behavior: none;
+}
+
+@media (max-width: 640px) {
+  .shadow-lg,
+  .shadow-xl,
+  .shadow-2xl {
+    box-shadow: none !important;
+  }
+}
+
 :root {
   --font-sans: var(--font-inter);
   --color-primary: #ff5a5f;

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -625,6 +625,8 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
                     exit="exit"
                     variants={stepVariants}
                     transition={stepVariants.transition}
+                    className="overscroll-contain"
+                    style={{ willChange: 'transform, opacity' }}
                   >
                     {renderStep()}
 

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -507,7 +507,7 @@ useEffect(() => {
       handleScroll();
       const container = messagesContainerRef.current;
       if (container) {
-        container.addEventListener('scroll', handleScroll);
+        container.addEventListener('scroll', handleScroll, { passive: true });
         return () => container.removeEventListener('scroll', handleScroll);
       }
       return () => {};

--- a/frontend/src/components/home/ArtistsSection.tsx
+++ b/frontend/src/components/home/ArtistsSection.tsx
@@ -74,7 +74,7 @@ export default function ArtistsSection({
     updateScrollButton();
     const el = scrollRef.current;
     if (!el) return;
-    el.addEventListener('scroll', updateScrollButton);
+    el.addEventListener('scroll', updateScrollButton, { passive: true });
     window.addEventListener('resize', updateScrollButton);
     return () => {
       el.removeEventListener('scroll', updateScrollButton);

--- a/frontend/src/components/home/CategoriesCarousel.tsx
+++ b/frontend/src/components/home/CategoriesCarousel.tsx
@@ -33,7 +33,7 @@
   updateScrollButtons();
   const el = scrollRef.current;
   if (!el) return;
-  el.addEventListener('scroll', updateScrollButtons);
+  el.addEventListener('scroll', updateScrollButtons, { passive: true });
   window.addEventListener('resize', updateScrollButtons);
   return () => {
   el.removeEventListener('scroll', updateScrollButtons);

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -167,7 +167,7 @@ export default function MainLayout({ children, headerAddon, headerFilter, fullWi
   useEffect(() => {
     if (isArtistDetail || isArtistView) return; // No scroll listener on artist detail pages or artist view
 
-    window.addEventListener('scroll', optimizedScrollHandler);
+    window.addEventListener('scroll', optimizedScrollHandler, { passive: true });
     if (window.scrollY > 0) {
       handleScroll();
     }

--- a/frontend/src/components/ui/LocationInput.tsx
+++ b/frontend/src/components/ui/LocationInput.tsx
@@ -177,7 +177,7 @@ const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
         }
       };
       document.addEventListener("mousedown", handleClickOutside);
-      document.addEventListener("touchstart", handleClickOutside);
+      document.addEventListener("touchstart", handleClickOutside, { passive: true });
       return () => {
         document.removeEventListener("mousedown", handleClickOutside);
         document.removeEventListener("touchstart", handleClickOutside);

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -23,7 +23,7 @@ export default function useClickOutside(
     };
 
     document.addEventListener('mousedown', listener);
-    document.addEventListener('touchstart', listener);
+    document.addEventListener('touchstart', listener, { passive: true });
 
     return () => {
       document.removeEventListener('mousedown', listener);

--- a/frontend/src/hooks/useKeyboardOffset.ts
+++ b/frontend/src/hooks/useKeyboardOffset.ts
@@ -18,7 +18,7 @@ export default function useKeyboardOffset(): number {
 
       update();
       vv.addEventListener('resize', update);
-      vv.addEventListener('scroll', update);
+      vv.addEventListener('scroll', update, { passive: true });
       return () => {
         vv.removeEventListener('resize', update);
         vv.removeEventListener('scroll', update);

--- a/frontend/src/hooks/useScrollDirection.ts
+++ b/frontend/src/hooks/useScrollDirection.ts
@@ -23,7 +23,7 @@ export default function useScrollDirection(): 'up' | 'down' {
       lastY = y;
     };
 
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 


### PR DESCRIPTION
## Summary
- use passive listeners for scroll and touch events to reduce jank
- add global overscroll-behavior and drop heavy shadows on small screens
- hint GPU with will-change for smoother step transitions

## Testing
- `./scripts/test-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68997d25c2c4832e9f29763970ea4050