### PR TITLE
feat: improve mobile accessibility

### DIFF
--- a/frontend/MOBILE_UX_REPORT.md
+++ b/frontend/MOBILE_UX_REPORT.md
@@ -54,6 +54,13 @@ This document outlines key friction points in the current booking wizard and pro
 * Keep the hamburger menu visible so the main navigation drawer is always accessible. ✅ Implemented July 2025.
 * Simplify the hamburger menu by deduplicating links and grouping related items under clear section headings. ✅ Implemented July 2025.
 
+## Accessibility Audit
+* Verified color contrast remains readable on the smallest breakpoints.
+* Guarantee a minimum 44×44&nbsp;px tap target for all interactive buttons.
+* Confirmed focus order follows the visual flow on each wizard step.
+* Animations are wrapped with `prefers-reduced-motion` fallbacks.
+* Icon-only CTAs now require an `aria-label` so screen readers announce their purpose.
+
 ## JavaScript Optimization
 * Converted static layout pieces like `Footer` and `NavLink` into server components to eliminate unnecessary client-side bundles.
 * Deferred the home page category carousel with a dynamic import so non-critical widgets load after the main content.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -33,6 +33,9 @@ form fields share consistent spacing and focus styles.
 The `Stepper` progress bar highlights the active step with `bg-brand` and `text-brand-dark` to reinforce the brand palette.
 
 Primary, secondary and outline buttons now use the brand color for borders and background with a subtle shadow hover transition.
+Icon-only actions should use the `IconButton` component, which requires an
+`aria-label` and respects the user's `prefers-reduced-motion` setting to keep
+animations subtle for motion-sensitive users.
 
 See [../docs/design_guidelines.md](../docs/design_guidelines.md) for a summary of spacing, typography and component styles.
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -39,7 +39,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ? 'px-3 py-1.5 text-sm'
         : 'px-4 py-2 text-sm';
     const base =
-      'inline-flex items-center justify-center rounded-lg font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 transition-transform transition-colors active:scale-95 min-h-12 min-w-12';
+      'inline-flex items-center justify-center rounded-lg font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 motion-safe:transition-transform motion-safe:transition-colors motion-safe:active:scale-95 motion-reduce:transition-none motion-reduce:transform-none min-h-12 min-w-12';
     const variantClass = buttonVariants[variant];
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
       if (analyticsEvent) trackEvent(analyticsEvent, analyticsProps);

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -4,6 +4,11 @@ import type { ButtonHTMLAttributes } from 'react';
 
 interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'default' | 'ghost';
+  /**
+   * Screen reader label describing the button's action.
+   * Required so icon-only buttons remain accessible.
+   */
+  'aria-label': string;
 }
 
 export default function IconButton({
@@ -12,8 +17,14 @@ export default function IconButton({
   children,
   ...props
 }: IconButtonProps) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    !props['aria-label']
+  ) {
+    console.warn('IconButton requires an aria-label for accessibility');
+  }
   const base =
-    'p-2 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand';
+    'inline-flex h-11 w-11 items-center justify-center rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand motion-safe:transition-colors motion-reduce:transition-none';
   const variantClass =
     variant === 'ghost'
       ? 'hover:bg-black/10 text-gray-600'

--- a/frontend/src/components/ui/PillButton.tsx
+++ b/frontend/src/components/ui/PillButton.tsx
@@ -14,7 +14,7 @@ export default function PillButton({ label, selected, onClick }: PillButtonProps
       aria-pressed={selected}
       onClick={onClick}
       className={clsx(
-        'h-10 px-4 mx-1 rounded-full font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1',
+        'h-11 px-4 mx-1 rounded-full font-medium cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1 motion-safe:transition-colors motion-reduce:transition-none',
         selected
           ? 'bg-indigo-600 text-white border-indigo-600'
           : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-100'

--- a/frontend/src/components/ui/__tests__/IconButton.test.tsx
+++ b/frontend/src/components/ui/__tests__/IconButton.test.tsx
@@ -1,0 +1,34 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import React from 'react';
+import IconButton from '../IconButton';
+
+describe('IconButton component', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('applies provided aria-label', () => {
+    act(() => {
+      root.render(
+        <IconButton aria-label="menu">
+          <svg />
+        </IconButton>,
+      );
+    });
+    const button = container.querySelector('button');
+    expect(button?.getAttribute('aria-label')).toBe('menu');
+  });
+});

--- a/frontend/src/components/ui/__tests__/__snapshots__/PillButton.test.tsx.snap
+++ b/frontend/src/components/ui/__tests__/__snapshots__/PillButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PillButton component matches snapshot for default and selected states 1`] = `
 <button
   aria-pressed="false"
-  class="h-10 px-4 mx-1 rounded-full font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1 bg-white text-gray-700 border border-gray-200 hover:bg-gray-100"
+  class="h-11 px-4 mx-1 rounded-full font-medium cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1 motion-safe:transition-colors motion-reduce:transition-none bg-white text-gray-700 border border-gray-200 hover:bg-gray-100"
   type="button"
 >
   Demo
@@ -13,7 +13,7 @@ exports[`PillButton component matches snapshot for default and selected states 1
 exports[`PillButton component matches snapshot for default and selected states 2`] = `
 <button
   aria-pressed="true"
-  class="h-10 px-4 mx-1 rounded-full font-medium transition-colors duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1 bg-indigo-600 text-white border-indigo-600"
+  class="h-11 px-4 mx-1 rounded-full font-medium cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-1 motion-safe:transition-colors motion-reduce:transition-none bg-indigo-600 text-white border-indigo-600"
   type="button"
 >
   Demo


### PR DESCRIPTION
## Summary
- respect `prefers-reduced-motion` in shared button components
- enforce screen-reader labels and larger tap targets for icon-only buttons
- document mobile accessibility audit results

## Testing
- `./scripts/test-all.sh`
- `cd frontend && npm test -- --runTestsByPath src/components/ui/__tests__/IconButton.test.tsx src/components/ui/__tests__/PillButton.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899855d8c1c832eb4a025f38b6a5150