### PR TITLE
test: add mobile QA checks and performance budgets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
             ./scripts/test-all.sh
             FORCE=1 ./scripts/build-caches.sh
           fi
+      - name: Mobile performance budgets
+        run: cd frontend && npx playwright test e2e/mobile-performance.spec.ts --project=mobile-ios --project=mobile-android --reporter=line
       - name: Upload caches
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -22,3 +22,12 @@ Connecting to `/ws/notifications` without credentials resulted in immediate clos
 ## Notes
 
 These values serve as a starting point for future optimization work.
+
+## Mobile Performance Budgets
+
+The CI pipeline enforces basic mobile DOMContentLoaded budgets:
+
+| Route | Budget (ms) |
+|-------|-------------|
+| `/` | 2000 |
+| `/booking?service_provider_id=1&service_id=1` | 3000 |

--- a/frontend/e2e/mobile-performance.spec.ts
+++ b/frontend/e2e/mobile-performance.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+// Per-route mobile performance budgets. These tests run in CI.
+
+const budgets = [
+  { url: '/', dcl: 2000 },
+  { url: '/booking?service_provider_id=1&service_id=1', dcl: 3000 },
+];
+
+for (const { url, dcl } of budgets) {
+  test(`loads ${url} within ${dcl}ms @mobile-perf`, async ({ page }) => {
+    await page.route('**/api/**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+    });
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    const duration = await page.evaluate(() => {
+      const { domContentLoadedEventEnd, navigationStart } = performance.timing;
+      return domContentLoadedEventEnd - navigationStart;
+    });
+    expect(duration).toBeLessThan(dcl);
+  });
+}

--- a/frontend/e2e/mobile-ux.spec.ts
+++ b/frontend/e2e/mobile-ux.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Mobile viewport UX checks for keyboard, safe areas, and long content
+// APIs are stubbed to keep tests fully offline.
+
+test.describe('Mobile UX', () => {
+  test.beforeEach(async ({ page }) => {
+    // Generic stub for backend APIs
+    await page.route('**/api/**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+    });
+  });
+
+  test('keyboard does not cover event description', async ({ page }) => {
+    await page.goto('/booking?service_provider_id=1&service_id=1');
+    await page.getByTestId('date-next-button').click();
+    await page.getByRole('button', { name: 'Next' }).click();
+    const textarea = page.locator('#event-description');
+    await textarea.focus();
+    // Simulate virtual keyboard reducing viewport height
+    await page.setViewportSize({ width: page.viewportSize()!.width, height: 300 });
+    const box = await textarea.boundingBox();
+    expect(box && box.y + box.height).toBeLessThan(300);
+  });
+
+  test('includes viewport-fit for safe areas', async ({ page }) => {
+    await page.goto('/');
+    const content = await page.locator('meta[name="viewport"]').getAttribute('content');
+    expect(content).toContain('viewport-fit=cover');
+  });
+
+  test('handles long content in event description', async ({ page }) => {
+    await page.goto('/booking?service_provider_id=1&service_id=1');
+    await page.getByTestId('date-next-button').click();
+    await page.getByRole('button', { name: 'Next' }).click();
+    const textarea = page.locator('#event-description');
+    const longText = 'lorem ipsum '.repeat(200);
+    await textarea.fill(longText);
+    await expect(textarea).toHaveValue(longText);
+    const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+    expect(scrollHeight).toBeGreaterThan(page.viewportSize()!.height);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,9 +6,14 @@ export default defineConfig({
     { name: 'chromium', use: { browserName: 'chromium' } },
     { name: 'firefox',  use: { browserName: 'firefox'  } },
     { name: 'webkit',   use: { browserName: 'webkit'   } },
+    // Mobile emulation projects for iOS and Android
     {
-      name: 'mobile',
+      name: 'mobile-ios',
       use: { ...devices['iPhone 14 Pro'] },
+    },
+    {
+      name: 'mobile-android',
+      use: { ...devices['Pixel 5'] },
     },
   ],
   workers: 2,


### PR DESCRIPTION
## Summary
- run Playwright mobile projects for iOS and Android
- add mobile UX and performance tests
- document and run mobile performance budgets in CI

## Testing
- `npm test` *(fails: response interceptor and many others)*
- `npx --prefix frontend playwright test frontend/e2e/mobile-ux.spec.ts frontend/e2e/mobile-performance.spec.ts --project=mobile-ios --project=mobile-android --reporter=line` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_689998118fa4832ea3d04e9e15fc172a