### PR TITLE
feat: track mobile web vitals and tap anomalies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The July 2025 update bumps key dependencies and Docker base images:
 ## Observability
 
 Structured JSON logs and OpenTelemetry traces are enabled for both the FastAPI backend and the Next.js frontend. See [docs/observability.md](docs/observability.md) for SLO targets and alerting recommendations.
+- Mobile telemetry captures Web Vitals (LCP, INP), tap errors, and rage taps, segmenting events by viewport width and device pixel ratio. Alerts fire when mobile SLOs are exceeded.
 - Chat now provides optimistic send with status indicators, long message and provider lists are virtualized for smoother scrolling, and booking form validation/autosave are debounced and throttled for better responsiveness.
 - An unobtrusive marketing strip replaces the old Hero section.
 - The homepage now highlights popular, top rated, and new artists in horizontally scrollable carousels.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,6 +12,9 @@ OpenTelemetry is configured with a console exporter. Spans include a `service.na
 ## Service Level Objectives
 - **Error rate**: <1% of requests fail with 5xx responses.
 - **Latency**: 95th percentile response time under 300ms.
+- **Mobile LCP**: <2.5s largest contentful paint on coarse pointers.
+- **Mobile INP**: <200ms interaction to next paint on coarse pointers.
 
 ## Alerts
 When SLOs are breached, alerts should be sent to the on-call channel. Integration with a monitoring platform (e.g. Grafana or PagerDuty) is recommended.
+Mobile web vitals events include viewport width and device pixel ratio to segment trends across devices. Tap errors and rage taps are tracked as additional quality signals, and any SLO regression generates a dedicated alert event.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "react-swipeable-list": "^1.10.0",
         "react-window": "^1.8.7",
         "rheostat": "^4.1.1",
+        "web-vitals": "^4.2.4",
         "yup": "^1.3.2"
       },
       "devDependencies": {
@@ -14360,6 +14361,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "react-swipeable-list": "^1.10.0",
     "react-window": "^1.8.7",
     "rheostat": "^4.1.1",
+    "web-vitals": "^4.2.4",
     "yup": "^1.3.2"
   },
   "devDependencies": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter } from 'next/font/google';
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { NotificationsProvider } from '@/hooks/useNotifications';
+import MobileTelemetry from '@/components/analytics/MobileTelemetry';
 import './globals.css';
 
 
@@ -37,6 +38,7 @@ export default function RootLayout({
             <Toaster position="top-right" />
           </NotificationsProvider>
         </AuthProvider>
+        <MobileTelemetry />
         <div id="modal-root"></div>
 
       </body>

--- a/frontend/src/components/analytics/MobileTelemetry.tsx
+++ b/frontend/src/components/analytics/MobileTelemetry.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import { onINP, onLCP, Metric } from 'web-vitals/attribution';
+import { trackEvent } from '@/lib/analytics';
+
+const MOBILE_LCP_SLO = 2500;
+const MOBILE_INP_SLO = 200;
+
+const isMobile = () => window.matchMedia('(pointer: coarse)').matches;
+
+export default function MobileTelemetry(): null {
+  useEffect(() => {
+    if (!isMobile()) return;
+
+    const basePayload = () => ({
+      viewport: window.innerWidth,
+      dpr: window.devicePixelRatio,
+    });
+
+    const handleMetric = (metric: Metric) => {
+      const payload = { name: metric.name, value: metric.value, ...basePayload() };
+      trackEvent('web_vital', payload);
+      const slo = metric.name === 'LCP' ? MOBILE_LCP_SLO : metric.name === 'INP' ? MOBILE_INP_SLO : null;
+      if (slo && metric.value > slo) {
+        trackEvent('web_vital_slo_violation', { ...payload, slo });
+      }
+    };
+
+    onLCP(handleMetric);
+    onINP(handleMetric);
+
+    let taps: { x: number; y: number; t: number }[] = [];
+    const handleClick = (e: MouseEvent) => {
+      const { clientX: x, clientY: y } = e;
+      const t = Date.now();
+      taps = taps.filter((tap) => t - tap.t < 1000);
+      taps.push({ x, y, t });
+      const sameSpot = taps.filter((tap) => Math.abs(tap.x - x) < 30 && Math.abs(tap.y - y) < 30);
+      if (sameSpot.length >= 3) {
+        trackEvent('rage_tap', { x, y, ...basePayload() });
+      }
+      const target = e.target as HTMLElement | null;
+      if (target && target.matches('button:disabled, button[aria-disabled="true"], a[aria-disabled="true"]')) {
+        trackEvent('tap_error', { x, y, ...basePayload() });
+      }
+    };
+
+    document.addEventListener('click', handleClick, true);
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, []);
+
+  return null;
+}
+

--- a/frontend/src/components/analytics/__tests__/MobileTelemetry.test.tsx
+++ b/frontend/src/components/analytics/__tests__/MobileTelemetry.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import type { Metric } from 'web-vitals';
+import MobileTelemetry from '../MobileTelemetry';
+import { trackEvent } from '@/lib/analytics';
+
+jest.mock('@/lib/analytics', () => ({
+  trackEvent: jest.fn(),
+}));
+
+jest.mock('web-vitals/attribution', () => ({
+  onLCP: (cb: (metric: Metric) => void) => cb({ name: 'LCP', value: 3000 } as Metric),
+  onINP: (cb: (metric: Metric) => void) => cb({ name: 'INP', value: 250 } as Metric),
+}));
+
+describe('MobileTelemetry', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: true,
+        media: '(pointer: coarse)',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  it('reports web vitals and rage taps', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<MobileTelemetry />);
+    });
+
+    // Three taps in the same spot
+    act(() => {
+      const event = new MouseEvent('click', { clientX: 10, clientY: 10, bubbles: true });
+      document.dispatchEvent(event);
+      document.dispatchEvent(event);
+      document.dispatchEvent(event);
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      'web_vital_slo_violation',
+      expect.objectContaining({ name: 'LCP' }),
+    );
+    expect(trackEvent).toHaveBeenCalledWith(
+      'web_vital_slo_violation',
+      expect.objectContaining({ name: 'INP' }),
+    );
+    expect(trackEvent).toHaveBeenCalledWith('rage_tap', expect.any(Object));
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add MobileTelemetry component to capture mobile LCP/INP, tap errors and rage taps
- record viewport width & device pixel ratio and alert on SLO breaches
- document mobile performance SLOs and telemetry

## Testing
- `pytest`
- `npm test` *(fails: 49 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68999cf322c4832e9a19f7ed12ac9850