### PR TITLE
Fix message attachment uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,7 @@ keeps the current view, e.g.
 * Bottom nav auto-hides when you scroll down and reappears when scrolling up.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Chat attachment button stays inline with the message input and send button on all screens.
+* Message attachments now upload reliably by letting Axios set multipart boundaries automatically.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details. Message notifications open directly to this page so clients can read and respond without hunting for the correct thread.
 * URL parameters on `/inbox` include `requestId` to select a conversation. Artists receive an inline quote summary bubble instead of a modal, so the previous `sendQuote` flag has been removed.

--- a/frontend/src/lib/__tests__/uploadMessageAttachment.test.ts
+++ b/frontend/src/lib/__tests__/uploadMessageAttachment.test.ts
@@ -1,0 +1,13 @@
+import api, { uploadMessageAttachment } from '../api';
+
+describe('uploadMessageAttachment', () => {
+  it('omits manual Content-Type header so the browser adds the boundary', () => {
+    const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: { url: '/file' } } as ReturnType<typeof api.post>);
+    uploadMessageAttachment(1, file);
+    const config = spy.mock.calls[0][2];
+    expect(config?.headers?.['Content-Type']).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -449,7 +449,7 @@ export const uploadMessageAttachment = (
   return api.post<{ url: string }>(
     `${API_V1}/booking-requests/${bookingRequestId}/attachments`,
     formData,
-    { headers: { 'Content-Type': 'multipart/form-data' }, onUploadProgress }
+    { onUploadProgress }
   );
 };
 
@@ -460,7 +460,7 @@ export const uploadBookingAttachment = (
   api.post<{ url: string }>(
     `${API_V1}/booking-requests/attachments`,
     formData,
-    { headers: { 'Content-Type': 'multipart/form-data' }, onUploadProgress }
+    { onUploadProgress }
   );
 
 export const parseBookingText = (text: string) =>


### PR DESCRIPTION
## Summary
- allow Axios to set multipart headers when uploading message or booking attachments
- cover attachment uploading in MessageThread tests and add low-level API regression test
- document reliable attachment uploads

## Testing
- `./scripts/test-all.sh` *(fails: network access disabled in unit tests)*
- `cd frontend && npx eslint src/lib/api.ts src/components/booking/__tests__/MessageThreadSend.test.tsx src/lib/__tests__/uploadMessageAttachment.test.ts`
- `cd frontend && npm test src/components/booking/__tests__/MessageThreadSend.test.tsx src/lib/__tests__/uploadMessageAttachment.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68999d20cfe0832eb2d920e2dfddf670