### PR TITLE
Handle missing message attachments

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -46,6 +46,7 @@ import QuoteBubble from './QuoteBubble';
 import InlineQuoteForm from './InlineQuoteForm';
 import useWebSocket from '@/hooks/useWebSocket';
 import { format, isValid } from 'date-fns';
+import { AxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
 
 const MemoQuoteBubble = React.memo(QuoteBubble);
@@ -683,9 +684,11 @@ useEffect(() => {
           setMessages((prev) =>
             prev.map((m) => (m.id === tempId ? { ...m, status: 'failed' } : m)),
           );
-          setThreadError(
-            `Failed to send message. ${(err as Error).message || 'Please try again later.'}`,
-          );
+          const message =
+            err instanceof AxiosError && err.response?.status === 422
+              ? 'Attachment file missing. Please select a file before sending.'
+              : (err as Error).message || 'Please try again later.';
+          setThreadError(`Failed to send message. ${message}`);
           setIsUploadingAttachment(false);
         }
       },

--- a/frontend/src/lib/__tests__/uploadMessageAttachment.test.ts
+++ b/frontend/src/lib/__tests__/uploadMessageAttachment.test.ts
@@ -10,4 +10,10 @@ describe('uploadMessageAttachment', () => {
     const config = spy.mock.calls[0][2];
     expect(config?.headers?.['Content-Type']).toBeUndefined();
   });
+
+  it('throws an error when file is missing', async () => {
+    await expect(
+      uploadMessageAttachment(1, undefined as unknown as File),
+    ).rejects.toThrow('Attachment file is required');
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -444,12 +444,15 @@ export const uploadMessageAttachment = (
   file: File,
   onUploadProgress?: (event: AxiosProgressEvent) => void,
 ) => {
+  if (!file || file.size === 0) {
+    return Promise.reject(new Error('Attachment file is required'));
+  }
   const formData = new FormData();
   formData.append('file', file);
   return api.post<{ url: string }>(
     `${API_V1}/booking-requests/${bookingRequestId}/attachments`,
     formData,
-    { onUploadProgress }
+    { onUploadProgress },
   );
 };
 


### PR DESCRIPTION
## Summary
- Guard against empty file uploads in `uploadMessageAttachment`
- Test missing file scenario for message attachments
- Provide clearer 422 error message in `MessageThread`

## Testing
- `./scripts/test-all.sh` *(fails: src/lib/__tests__/api.test.ts, ClientBookingsPage, MobileMenuDrawer, MainLayout, and other frontend tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899a3b1f094832ea5aa7a1d8beae40f