### PR TITLE
test: add emoji picker selection test

### DIFF
--- a/frontend/src/components/booking/__tests__/MessageThreadEmojiPicker.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThreadEmojiPicker.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import MessageThread from '../MessageThread';
+import * as api from '@/lib/api';
+
+jest.mock('@emoji-mart/data', () => ({}));
+
+// Mock emoji picker to provide deterministic emoji selection
+jest.mock('next/dynamic', () => () => {
+  const React = require('react');
+  return ({ onEmojiSelect }: { onEmojiSelect: (emoji: { native: string }) => void }) => (
+    <div data-testid="emoji-picker">
+      <button onClick={() => onEmojiSelect({ native: '😀' })}>😀</button>
+    </div>
+  );
+});
+
+jest.mock('@/hooks/useWebSocket', () => () => ({ send: jest.fn(), onMessage: jest.fn(), updatePresence: jest.fn() }));
+jest.mock('@/lib/api');
+
+describe('MessageThread emoji picker', () => {
+  beforeEach(() => {
+    (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client' } });
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({ data: [] });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({ data: null });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({ data: { id: 1, service: { title: 'Gig' } } });
+  });
+
+  it('appends selected emoji to the message input', async () => {
+    const { findByLabelText, findByTestId, findByPlaceholderText } = render(
+      <MessageThread bookingRequestId={1} />,
+    );
+
+    const emojiButton = await findByLabelText('Add emoji');
+    fireEvent.click(emojiButton);
+
+    const picker = await findByTestId('emoji-picker');
+    const textarea = (await findByPlaceholderText('Type your message...')) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+
+    fireEvent.click(picker.querySelector('button') as HTMLButtonElement);
+
+    expect(textarea.value).toBe('Hello😀');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add MessageThread emoji picker test verifying that selected emoji is appended to text input

## Testing
- `npm --prefix frontend test src/components/booking/__tests__/MessageThreadEmojiPicker.test.tsx -- -u`
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `npm --prefix frontend test` *(fails: 49 failed, 84 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899a640f744832e855130c52a7b147c