### PR TITLE
Fix attachment upload Content-Type handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,7 @@ keeps the current view, e.g.
 * Bottom nav auto-hides when you scroll down and reappears when scrolling up.
 * Unread message counts badge on Messages icon. Badge now sits snugly over the icon on all devices.
 * Chat attachment button stays inline with the message input and send button on all screens.
-* Message attachments now upload reliably by letting Axios set multipart boundaries automatically.
+* Message and booking request attachments now upload reliably by clearing the default JSON `Content-Type` so Axios can set multipart boundaries automatically.
 * Tap feedback on icons via `active:bg-gray-100`.
 * **Inbox** page redesigned with a sticky "Messages" header and search icon. The left column lists conversations while the right shows the selected chat with booking details. Message notifications open directly to this page so clients can read and respond without hunting for the correct thread.
 * URL parameters on `/inbox` include `requestId` to select a conversation. Artists receive an inline quote summary bubble instead of a modal, so the previous `sendQuote` flag has been removed.

--- a/frontend/src/lib/__tests__/uploadBookingAttachment.test.ts
+++ b/frontend/src/lib/__tests__/uploadBookingAttachment.test.ts
@@ -1,0 +1,15 @@
+import api, { uploadBookingAttachment } from '../api';
+
+describe('uploadBookingAttachment', () => {
+  it('omits manual Content-Type header so the browser adds the boundary', () => {
+    const formData = new FormData();
+    const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+    formData.append('file', file);
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: { url: '/file' } } as ReturnType<typeof api.post>);
+    uploadBookingAttachment(formData);
+    const config = spy.mock.calls[0][2];
+    expect(config?.headers?.['Content-Type']).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -452,7 +452,7 @@ export const uploadMessageAttachment = (
   return api.post<{ url: string }>(
     `${API_V1}/booking-requests/${bookingRequestId}/attachments`,
     formData,
-    { onUploadProgress },
+    { onUploadProgress, headers: { 'Content-Type': undefined } },
   );
 };
 
@@ -463,7 +463,7 @@ export const uploadBookingAttachment = (
   api.post<{ url: string }>(
     `${API_V1}/booking-requests/attachments`,
     formData,
-    { onUploadProgress }
+    { onUploadProgress, headers: { 'Content-Type': undefined } }
   );
 
 export const parseBookingText = (text: string) =>


### PR DESCRIPTION
## Summary
- ensure attachment uploads clear default JSON Content-Type so multipart boundaries are set correctly
- document that both message and booking attachments now upload reliably
- add tests verifying form uploads omit manual Content-Type header

## Testing
- `./scripts/test-all.sh` *(fails: Network access is disabled in unit tests. Mock requests instead.)*

------
https://chatgpt.com/codex/tasks/task_e_6899a7bf635c832ea86fccb8ba53adf9