### PR TITLE
feat: add events and messages to client menu

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -282,29 +282,69 @@ const Header = forwardRef<HTMLElement, HeaderProps>(function Header(
                   </Menu.Button>
                   <Transition as={Fragment} enter="transition ease-out duration-100" enterFrom="opacity-0 scale-95" enterTo="opacity-100 scale-100" leave="transition ease-in duration-75" leaveFrom="opacity-100 scale-100" leaveTo="opacity-0 scale-95">
                     <Menu.Items className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5">
+                      {user.user_type === 'service_provider' ? (
+                        <>
+                          <Menu.Item>
+                            {({ active }) => (
+                              <Link
+                                href="/dashboard/artist"
+                                className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                              >
+                                Dashboard
+                              </Link>
+                            )}
+                          </Menu.Item>
+                          <Menu.Item>
+                            {({ active }) => (
+                              <Link
+                                href="/dashboard/profile/edit"
+                                className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                              >
+                                Edit Profile
+                              </Link>
+                            )}
+                          </Menu.Item>
+                        </>
+                      ) : (
+                        <>
+                          <Menu.Item>
+                            {({ active }) => (
+                              <Link
+                                href="/dashboard/client"
+                                className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                              >
+                                Events
+                              </Link>
+                            )}
+                          </Menu.Item>
+                          <Menu.Item>
+                            {({ active }) => (
+                              <Link
+                                href="/messages"
+                                className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                              >
+                                Messages
+                              </Link>
+                            )}
+                          </Menu.Item>
+                          <Menu.Item>
+                            {({ active }) => (
+                              <Link
+                                href="/account"
+                                className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                              >
+                                Edit Profile
+                              </Link>
+                            )}
+                          </Menu.Item>
+                        </>
+                      )}
                       <Menu.Item>
                         {({ active }) => (
-                      <Link
-                        href={user.user_type === 'service_provider' ? '/dashboard/artist' : '/dashboard/client'}
-                        className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
-                      >
-                        Dashboard
-                      </Link>
-                        )}
-                      </Menu.Item>
-                      <Menu.Item>
-                        {({ active }) => (
-                          <Link
-                            href={user.user_type === 'service_provider' ? '/dashboard/profile/edit' : '/account'}
-                            className={clsx('block px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
+                          <button
+                            onClick={logout}
+                            className={clsx('block w-full text-left px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}
                           >
-                            Edit Profile
-                          </Link>
-                        )}
-                      </Menu.Item>
-                      <Menu.Item>
-                        {({ active }) => (
-                          <button onClick={logout} className={clsx('block w-full text-left px-4 py-2 text-sm text-gray-700', { 'bg-gray-100': active })}>
                             Sign out
                           </button>
                         )}

--- a/frontend/src/components/layout/MobileMenuDrawer.tsx
+++ b/frontend/src/components/layout/MobileMenuDrawer.tsx
@@ -32,27 +32,22 @@ const useMobileNavItems = (user: User | null): NavItem[] => {
         { name: 'Sign up', href: '/register' },
       ];
     }
-    const accountLinks: NavItem[] = [
-      {
-        name: 'Dashboard',
-        href: user.user_type === 'service_provider' ? '/dashboard/artist' : '/dashboard/client',
-      },
-      { name: 'Sign out', href: '#' },
-    ];
     if (user.user_type === 'service_provider') {
-      accountLinks.splice(1, 0,
+      return [
+        { name: 'Dashboard', href: '/dashboard/artist' },
         { name: 'Edit Profile', href: '/dashboard/profile/edit' },
         { name: 'Quotes', href: '/dashboard/quotes' },
-        { name: 'Quote Templates', href: '/dashboard/profile/quote-templates' }
-      );
-    } else if (user.user_type === 'client') {
-      accountLinks.splice(1, 0,
-        { name: 'My Bookings', href: '/dashboard/client/bookings' },
-        { name: 'My Quotes', href: '/dashboard/client/quotes' },
-        { name: 'Account', href: '/account' }
-      );
+        { name: 'Quote Templates', href: '/dashboard/profile/quote-templates' },
+        { name: 'Sign out', href: '#' },
+      ];
     }
-    return accountLinks;
+    // client
+    return [
+      { name: 'Events', href: '/dashboard/client' },
+      { name: 'Messages', href: '/messages' },
+      { name: 'Edit Profile', href: '/account' },
+      { name: 'Sign out', href: '#' },
+    ];
   }, [user]);
 };
 

--- a/frontend/src/components/layout/__tests__/HeaderProfileMenu.test.tsx
+++ b/frontend/src/components/layout/__tests__/HeaderProfileMenu.test.tsx
@@ -27,4 +27,20 @@ describe('Header profile menu', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Account menu' }));
     expect(await screen.findByText('Edit Profile')).toBeTruthy();
   });
+
+  it('shows client links without dashboard', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, user_type: 'client', email: 'b', first_name: 'B' },
+      logout: jest.fn(),
+      artistViewActive: false,
+      toggleArtistView: jest.fn(),
+    });
+
+    render(<Header headerState="initial" onForceHeaderState={jest.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Account menu' }));
+    expect(screen.queryByText('Dashboard')).toBeNull();
+    expect(await screen.findByText('Events')).toBeTruthy();
+    expect(await screen.findByText('Messages')).toBeTruthy();
+  });
 });

--- a/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileMenuDrawer.test.tsx
@@ -201,7 +201,7 @@ describe('MobileMenuDrawer', () => {
     expect(body).toContain('Quote Templates');
   });
 
-  it('shows My Bookings link for clients', async () => {
+  it('shows Events and Messages links for clients', async () => {
     await act(async () => {
       root.render(
         React.createElement(MobileMenuDrawer, {
@@ -216,8 +216,8 @@ describe('MobileMenuDrawer', () => {
     });
     await flushPromises();
     const body = document.body.textContent || '';
-    expect(body).toContain('My Bookings');
-    expect(body).toContain('Account');
+    expect(body).toContain('Events');
+    expect(body).toContain('Messages');
   });
 
   it('deduplicates items across navigation sections', async () => {


### PR DESCRIPTION
## Summary
- add Events and Messages to client header dropdown and mobile menu
- test client-specific menu items

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `cd backend && pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `cd frontend && npm test` *(fails: response interceptor and MobileMenuDrawer tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899a94b1d08832e8d30ae24a7202ab3