### PR TITLE
Use GMT+2 for message timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Structured JSON logs and OpenTelemetry traces are enabled for both the FastAPI b
 - Backend now defines a unified `BookingStatus` enum in `backend/app/models/booking_status.py` shared by bookings and booking requests.
 - Error fallback messages now detect authentication failures and prompt users to log in.
 - Booking request API responses now include `last_message_content` and `last_message_timestamp` so inbox conversations sort by recent chats.
+- Chat message timestamps are stored in GMT+2 to provide consistent send times across regions.
 - Messages now include a `message_type` (`USER`, `QUOTE`, `SYSTEM`) and `visible_to`
   (`artist`, `client`, `both`) field so threads render and filter correctly for
   each participant. The API also accepts the legacy values `text`, `quote`, and

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -9,11 +9,14 @@ from sqlalchemy import (
     Boolean,
 )
 from sqlalchemy.orm import relationship, backref
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 import enum
 
 from .base import BaseModel
 from .types import CaseInsensitiveEnum
+
+
+TZ_GMT2 = timezone(timedelta(hours=2))
 
 class SenderType(str, enum.Enum):
     CLIENT = "client"
@@ -70,7 +73,10 @@ class Message(BaseModel):
     action = Column(Enum(MessageAction), nullable=True)
     # Optional time after which this message should be considered expired
     expires_at = Column(DateTime, nullable=True)
-    timestamp = Column(DateTime, default=datetime.utcnow)
+    # Store message timestamps in GMT+2 for consistent chat chronology
+    timestamp = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(TZ_GMT2)
+    )
     is_read = Column(Boolean, default=False)
 
     booking_request = relationship(

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -67,6 +67,12 @@ const MAX_TEXTAREA_LINES = 10;
 const isImageAttachment = (url?: string | null) =>
   !!url && /\.(jpe?g|png|gif|webp)$/i.test(url);
 
+// Generate an ISO timestamp in GMT+2 regardless of client locale
+const gmt2ISOString = ()
+  new Date(Date.now() + 2 * 60 * 60 * 1000)
+    .toISOString()
+    .replace('Z', '+02:00');
+
 // Normalize backend-provided message types for case-insensitive comparisons.
 const normalizeType = (t?: string | null) => (t ?? '').toUpperCase();
 
@@ -664,7 +670,8 @@ useEffect(() => {
             expires_at: null,
             unread: false,
             is_read: true,
-            timestamp: new Date().toISOString(),
+            // Ensure optimistic message uses GMT+2 timestamp
+            timestamp: gmt2ISOString(),
             status: 'sending',
           };
           setMessages((prev) => [...prev, optimistic]);


### PR DESCRIPTION
## Summary
- store message timestamps in GMT+2 on backend
- generate optimistic GMT+2 timestamps when sending chat messages
- document GMT+2 message times in README

## Testing
- `./scripts/test-all.sh` *(fails: Snapshot Summary \n › 6 snapshots failed from 3 test suites. Inspect your code changes or run `npm test -- -u` to update them.)*


------
https://chatgpt.com/codex/tasks/task_e_6899b65a8cf0832ea07516f292f335bf