### PR TITLE
Hide profile badge at full completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,7 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
 
 * Dashboard overview now highlights **New Inquiries**, **Total Services**, and **Earnings This Month**.
 
-* A profile completion progress bar still appears above the dashboard stats for artists.
+* A profile completion progress bar appears above the dashboard stats until the profile is 100% complete.
 * Stats cards use a simple grid layout for quick reference.
 
 * Currency values now use consistent locale formatting with `formatCurrency()`.

--- a/frontend/src/components/dashboard/__tests__/OverviewHeader.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/OverviewHeader.test.tsx
@@ -1,0 +1,52 @@
+import { createRoot } from 'react-dom/client';
+import React from 'react';
+import { act } from 'react';
+import OverviewHeader from '@/components/dashboard/artist/OverviewHeader';
+
+describe('OverviewHeader component', () => {
+  it('shows profile progress when completion below 100%', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const user = { first_name: 'A', user_type: 'service_provider' } as any;
+    const profile = { business_name: 'x' } as any;
+    act(() => {
+      root.render(
+        <OverviewHeader user={user} profile={profile} onAddService={() => {}} />,
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="profile-progress-wrapper"]'),
+    ).not.toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('hides profile progress when completion is 100%', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const user = { first_name: 'A', user_type: 'service_provider' } as any;
+    const profile = {
+      business_name: 'x',
+      description: 'd',
+      location: 'l',
+      profile_picture_url: 'p',
+      cover_photo_url: 'c',
+    } as any;
+    act(() => {
+      root.render(
+        <OverviewHeader user={user} profile={profile} onAddService={() => {}} />,
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="profile-progress-wrapper"]'),
+    ).toBeNull();
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/frontend/src/components/dashboard/artist/OverviewHeader.tsx
+++ b/frontend/src/components/dashboard/artist/OverviewHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { Button } from "@/components/ui";
-import { ProfileProgress } from "@/components/dashboard";
+import { ProfileProgress, computeProfileCompletion } from "@/components/dashboard";
 import type { ServiceProviderProfile, User } from "@/types";
 
 type Props = {
@@ -18,14 +18,21 @@ const OverviewHeader: React.FC<Props> = ({ user, profile, onAddService }) => {
         <p className="text-sm text-gray-500">Manage your requests, bookings, and services in one place.</p>
       </div>
       {user?.user_type === "service_provider" && profile && (
-        <div className="mt-5 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-          <div className="w-full md:w-1/2">
-            <ProfileProgress profile={profile} />
-          </div>
-          <Button type="button" onClick={onAddService} className="w-full md:w-auto">
-            Add New Service
-          </Button>
-        </div>
+        (() => {
+          const completion = computeProfileCompletion(profile);
+          return (
+            <div className="mt-5 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+              {completion < 100 && (
+                <div className="w-full md:w-1/2">
+                  <ProfileProgress profile={profile} />
+                </div>
+              )}
+              <Button type="button" onClick={onAddService} className="w-full md:w-auto">
+                Add New Service
+              </Button>
+            </div>
+          );
+        })()
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- Hide profile completion progress when an artist profile reaches 100%
- Document behavior and add regression test for OverviewHeader

## Testing
- `./scripts/test-all.sh` *(skipped: no changes detected)*
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fail: Network access is disabled in unit tests. Mock requests instead.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c882773c832e902f3c131bda5a93