### PR TITLE
fix: stop stepper closing between steps

### DIFF
--- a/docs/booking_wizard_layout.md
+++ b/docs/booking_wizard_layout.md
@@ -44,3 +44,5 @@ The stepper text is bright red for the active step and muted gray for the rest. 
 Navigation controls live in a sticky footer so the primary actions remain visible even when the form scrolls. Each button has a minimum tap area of 44×44 px to satisfy mobile accessibility guidelines. Heavy widgets such as the map preview and calendar picker are loaded lazily once their sections expand, keeping the initial payload light on mobile connections.
 
 To reduce visual distraction, the map preview now expands instantly without a height transition, and step changes avoid re-triggering the modal's open animation, resulting in a smoother experience.
+
+The progress stepper is rendered as a plain `nav` element with no layout animations so it no longer collapses and re-expands between steps.

--- a/frontend/src/components/ui/Stepper.tsx
+++ b/frontend/src/components/ui/Stepper.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { motion } from 'framer-motion';
 import clsx from 'clsx';
 import { CheckIcon } from '@heroicons/react/24/solid'; // Still include, though it won't be used if noCircles is true
 
@@ -34,8 +33,7 @@ export default function Stepper({
     typeof maxStepCompleted === 'number' ? maxStepCompleted + 1 : currentStep;
 
   return (
-    <motion.nav
-      layout
+    <nav
       role="list"
       aria-label={ariaLabel || 'Booking progress'}
       className={clsx(
@@ -166,6 +164,6 @@ export default function Stepper({
           </div>
         );
       })}
-    </motion.nav>
+    </nav>
   );
 }


### PR DESCRIPTION
## Summary
- avoid layout reflows by rendering booking stepper as a plain `nav`
- document the static stepper layout for the booking wizard

## Testing
- `pytest`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: several suites such as ClientBookingsPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6899d3353bbc832eb1595427914dfcd4