### PR TITLE
refactor: simplify quote calculation response handling

### DIFF
--- a/frontend/src/app/quote-calculator/page.tsx
+++ b/frontend/src/app/quote-calculator/page.tsx
@@ -32,7 +32,7 @@ export default function QuoteCalculatorPage() {
         provider_id: providerId ? Number(providerId) : undefined,
         accommodation_cost: accommodation ? Number(accommodation) : undefined,
       });
-      setResult(res.data);
+      setResult(res);
     } catch (err) {
       console.error(err);
     }

--- a/frontend/src/components/booking/BookingWizard.tsx
+++ b/frontend/src/components/booking/BookingWizard.tsx
@@ -366,11 +366,11 @@ export default function BookingWizard({ artistId, serviceId, isOpen, onClose }: 
       const directDistanceKm = metrics.distanceKm;
       const drivingEstimateCost = directDistanceKm * travelRate * 2;
 
-      const quoteResponse = await calculateQuote({
+      const quote = await calculateQuote({
         base_fee: basePrice, // Use the fetched base price
         distance_km: directDistanceKm,
       });
-      setCalculatedPrice(Number(quoteResponse.data.total));
+      setCalculatedPrice(Number(quote.total));
 
       const travelModeResult = await calculateTravelMode({
         artistLocation: artistLocation,

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -52,7 +52,7 @@ describe('BookingWizard instructions', () => {
             };
       return Promise.resolve({ json: () => Promise.resolve(response) }) as any;
     });
-    (api.calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 100 } });
+    (api.calculateQuote as jest.Mock).mockResolvedValue({ total: 100 });
     (geo.geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
     (travel.getDrivingMetrics as jest.Mock).mockResolvedValue({
       distanceKm: 10,

--- a/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
+++ b/frontend/src/components/booking/steps/__tests__/ReviewStep.test.tsx
@@ -21,7 +21,7 @@ describe('ReviewStep summary', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     (getService as jest.Mock).mockResolvedValue({ data: { price: 100, car_rental_price: 1000, flight_price: 2780 } });
-    (calculateQuote as jest.Mock).mockResolvedValue({ data: { total: 150 } });
+    (calculateQuote as jest.Mock).mockResolvedValue({ total: 150 });
     (geocodeAddress as jest.Mock).mockResolvedValue({ lat: 0, lng: 0 });
     (getDrivingMetrics as jest.Mock).mockResolvedValue({ distanceKm: 10, durationHrs: 1 });
     (calculateTravelMode as jest.Mock).mockResolvedValue({

--- a/frontend/src/lib/__tests__/quoteCache.test.ts
+++ b/frontend/src/lib/__tests__/quoteCache.test.ts
@@ -7,13 +7,15 @@ describe('calculateQuote cache', () => {
 
   it('reuses cached responses for identical params', async () => {
     const params = { base_fee: 100, distance_km: 10 };
-    const spy = jest.spyOn(api, 'post').mockResolvedValue({ data: { total: 123 } });
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: { total: 123 } });
 
     const first = await calculateQuote(params);
     const second = await calculateQuote(params);
 
-    expect(first.data.total).toBe(123);
-    expect(second.data.total).toBe(123);
+    expect(first.total).toBe(123);
+    expect(second.total).toBe(123);
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 // frontend/src/lib/api.ts
 
-import axios, { AxiosProgressEvent, type AxiosResponse } from 'axios';
+import axios, { AxiosProgressEvent } from 'axios';
 import logger from './logger';
 import { format } from 'date-fns';
 import { extractErrorMessage, normalizeQuoteTemplate } from './utils';
@@ -535,14 +535,17 @@ export const calculateQuote = async (params: {
   distance_km: number;
   provider_id?: number;
   accommodation_cost?: number;
-}): Promise<AxiosResponse<QuoteCalculationResponse>> => {
+}): Promise<QuoteCalculationResponse> => {
   const cacheKey = JSON.stringify(params);
   if (quoteCache.has(cacheKey)) {
-    return { data: quoteCache.get(cacheKey)! } as AxiosResponse<QuoteCalculationResponse>;
+    return quoteCache.get(cacheKey)!;
   }
-  const res = await api.post<QuoteCalculationResponse>(`${API_V1}/quotes/calculate`, params);
+  const res = await api.post<QuoteCalculationResponse>(
+    `${API_V1}/quotes/calculate`,
+    params,
+  );
   quoteCache.set(cacheKey, res.data);
-  return res;
+  return res.data;
 };
 
 // Exposed for tests to clear the cache between runs


### PR DESCRIPTION
## Summary
- return only quote data from `calculateQuote`
- update callers and tests for new quote calculation return type

## Testing
- `npm test src/lib/__tests__/quoteCache.test.ts`
- `npm test` *(fails: response interceptor – falls back to extracted detail and logs error; MobileMenuDrawer – Dialog.Panel includes overflow and safe-area classes; BookingDetailsPage – shows receipt link when payment_id is present; MobileTelemetry – reports web vitals and rage taps; QuoteReviewModal – disables buttons and shows spinner on accept; TimeAgo component – renders a fallback for invalid timestamps; AddServiceModalSpeaker – follows step flow and sends details payload; Avatar component – matches snapshot for default placeholder; ClientDashboardPage – loads client data; NavLink – applies touch target size and active styles; ChatThreadView.test.tsx cannot find module '../ChatThreadView'; and many others)*

------
https://chatgpt.com/codex/tasks/task_e_6899d763901c832e99b92db18b3b86a2