### PR TITLE
feat(frontend): add TTL LRU for quote cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,8 @@ Logs now include `--- STARTING setup.sh ---` and `--- STARTING test-all.sh ---`.
   the order is **Next**, **Save Draft**, **Back** but remains **Back**, **Save Draft**,
   **Next** on larger screens.
 * Next step components preload when the browser is idle for smoother navigation.
-* Quote estimates are cached locally to avoid redundant preview requests.
+* Quote estimates are cached locally for up to 5 minutes with least-recently-used
+  eviction after 50 entries to avoid redundant preview requests.
 * Guests step now matches the others with Back, Save Draft, and Next buttons.
 * Attachment uploads in the notes step display a progress bar and disable the Next button until finished.
 * Collapsible sections ensure only the active step is expanded on phones.

--- a/frontend/src/lib/__tests__/quoteCache.test.ts
+++ b/frontend/src/lib/__tests__/quoteCache.test.ts
@@ -1,8 +1,8 @@
-import api, { calculateQuote, __clearQuoteCache } from '../api';
+import api, { calculateQuote, clearQuoteCache } from '../api';
 
 describe('calculateQuote cache', () => {
   beforeEach(() => {
-    __clearQuoteCache();
+    clearQuoteCache();
   });
 
   it('reuses cached responses for identical params', async () => {
@@ -17,6 +17,42 @@ describe('calculateQuote cache', () => {
     expect(first.total).toBe(123);
     expect(second.total).toBe(123);
     expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('expires cache entries after TTL', async () => {
+    jest.useFakeTimers();
+
+    const params = { base_fee: 100, distance_km: 10 };
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: { total: 123 } });
+
+    await calculateQuote(params);
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await calculateQuote(params);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    spy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('evicts least recently used entries when max size exceeded', async () => {
+    const spy = jest
+      .spyOn(api, 'post')
+      .mockResolvedValue({ data: { total: 123 } });
+
+    const baseParams = { base_fee: 100, distance_km: 10 };
+    await calculateQuote(baseParams);
+
+    for (let i = 0; i < 50; i += 1) {
+      await calculateQuote({ base_fee: i, distance_km: i });
+    }
+
+    await calculateQuote(baseParams);
+
+    expect(spy).toHaveBeenCalledTimes(52);
     spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add TTL and LRU eviction to quote calculation cache
- expose `clearQuoteCache` helper
- document cache behavior and tests

## Testing
- `npm test` *(fails: FAIL src/lib/__tests__/api.test.ts, FAIL src/components/layout/__tests__/MobileMenuDrawer.test.tsx, ...)*
- `npm --prefix frontend test src/lib/__tests__/quoteCache.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899d92a1744832eacafcf131cc29308