### PR TITLE
fix: prevent inbox reload and tidy emoji picker

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -72,7 +72,7 @@ so screen readers announce when data is in flight.
 
 ### Emoji Picker
 
-The chat composer now includes an emoji button that toggles a searchable picker powered by `emoji-mart` and `@emoji-mart/data`. The picker appears above the input so it never obscures the textarea, and the trigger button provides an accessible `aria-label`.
+The chat composer now includes an emoji button that toggles a searchable picker powered by `emoji-mart` and `@emoji-mart/data`. The picker appears above the input so it never obscures the textarea, and the trigger button provides an accessible `aria-label`. The preview pane has been disabled for a cleaner selection experience.
 
 ### Customizing Brand Colors
 
@@ -156,7 +156,7 @@ The `/inbox` page accepts a `requestId` to open a specific conversation. Service
 /inbox?requestId=42
 ```
 
-On small screens the inbox initially displays only the conversation list. Tapping a conversation opens the chat thread and hides the list, and a back button returns to the conversation list.
+On small screens the inbox initially displays only the conversation list. Tapping a conversation opens the chat thread and hides the list, and a back button returns to the conversation list. Selecting a conversation updates the URL using the History API so the page no longer reloads.
 
 Quote messages within the thread now render as full-width cards showing booking details alongside an itemized quote summary. Clients can accept or reject the quote directly from this bubble without opening a separate modal.
 

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -91,13 +91,15 @@ export default function InboxPage() {
       setSelectedBookingRequestId(id);
       const params = new URLSearchParams(searchParams.toString());
       params.set('requestId', String(id));
-      router.replace(`?${params.toString()}`, { scroll: false });
+      if (typeof window !== 'undefined') {
+        window.history.replaceState(null, '', `?${params.toString()}`);
+      }
 
       if (isMobile) {
         setShowList(false);
       }
     },
-    [router, searchParams, isMobile]
+    [searchParams, isMobile]
   );
 
   const handleBackToList = useCallback(() => {

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -1278,7 +1278,11 @@ useEffect(() => {
             >
               {showEmojiPicker && (
                 <div ref={emojiPickerRef} className="absolute bottom-14 left-0 z-50">
-                  <EmojiPicker data={data} onEmojiSelect={handleEmojiSelect} />
+                  <EmojiPicker
+                    data={data}
+                    onEmojiSelect={handleEmojiSelect}
+                    previewPosition="none"
+                  />
                 </div>
               )}
               <form onSubmit={handleSendMessage} className="flex items-center gap-x-2 px-3 pt-2">


### PR DESCRIPTION
## Summary
- stop inbox page from reloading when switching conversations
- hide emoji preview pane in chat composer for a cleaner UI
- document emoji picker change and smoother inbox navigation

## Testing
- `pytest` *(fails: tests could not be collected)*
- `npm test` *(fails: 51 failed, 325 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689a27e1532c832e8d82c16cf0023744