### PR TITLE
Fix chat composer layout to avoid message overlap

### DIFF
--- a/frontend/src/components/booking/ChatThreadView.tsx
+++ b/frontend/src/components/booking/ChatThreadView.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react';
+
+interface ChatThreadViewProps {
+  contactName: string;
+  children: ReactNode;
+  inputBar: ReactNode;
+}
+
+export default function ChatThreadView({ contactName, children, inputBar }: ChatThreadViewProps) {
+  return (
+    <div className="h-screen flex flex-col" data-testid="chat-thread-view">
+      <header
+        className="flex-shrink-0 p-4 border-b border-gray-200"
+        data-testid="contact-name"
+      >
+        Chat with {contactName}
+      </header>
+      <div className="flex-1 overflow-y-auto" data-testid="message-container">
+        {children}
+      </div>
+      <div className="flex-shrink-0" data-testid="input-bar">
+        {inputBar}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -1273,8 +1273,9 @@ useEffect(() => {
             {/* Message Input Form */}
             <div
               ref={composerRef}
-              className="sticky bottom-0 max-sm:sticky max-sm:bottom-0 max-sm:left-0 max-sm:right-0 max-sm:z-20 bg-white border-t border-gray-100 shadow-lg pb-safe relative"
-              style={{ bottom: 'var(--mobile-bottom-nav-offset, var(--mobile-bottom-nav-height,56px))' }}
+              data-testid="composer-container"
+              className="bg-white border-t border-gray-100 shadow-lg pb-safe relative flex-shrink-0"
+              style={{ paddingBottom: 'var(--mobile-bottom-nav-offset, var(--mobile-bottom-nav-height,56px))' }}
             >
               {showEmojiPicker && (
                 <div ref={emojiPickerRef} className="absolute bottom-14 left-0 z-50">

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -208,9 +208,11 @@ describe('MessageThread composer positioning', () => {
     });
     await act(async () => { await flushPromises(); });
 
-    const form = container.querySelector('form');
-    expect(form).not.toBeNull();
-    expect((form as HTMLFormElement).style.bottom).toBe('var(--mobile-bottom-nav-height,56px)');
+    const composer = container.querySelector('[data-testid="composer-container"]');
+    expect(composer).not.toBeNull();
+    expect((composer as HTMLElement).style.paddingBottom).toBe(
+      'var(--mobile-bottom-nav-offset, var(--mobile-bottom-nav-height,56px))',
+    );
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- ensure chat composer sits within thread and pushes messages up
- add ChatThreadView wrapper for consistent chat layout
- adjust tests for new composer padding

## Testing
- `./scripts/test-all.sh` *(fails: snapshots and other test suites)*

------
https://chatgpt.com/codex/tasks/task_e_689a3334c868832ebb17b359d6323b84