### PR TITLE
Normalize service category slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Structured JSON logs and OpenTelemetry traces are enabled for both the FastAPI b
 - Service categories are assigned when adding services; service providers no longer choose a category during onboarding. The `/api/v1/service-categories` endpoint lists the seeded categories.
 - Newly registered service providers start with no default category, ensuring they aren't automatically labeled (e.g., as photographers) until they add a service.
 - Frontend components now fetch service categories dynamically via the `useServiceCategories` hook rather than relying on a static map.
+- The `categorySlug` helper normalizes irregular names (e.g., "DJ's", "Sound Services") to canonical slugs so newly added services route to the correct homepage categories.
 - Seeded categories include Musician, DJ, Photographer, Videographer, Speaker, Sound Service, Wedding Venue, Caterer, Bartender, and MC & Host.
 - Services may optionally include a `service_category_id` and JSON `details` object for category-specific attributes, enabling tailored service data.
 - Artist profile responses now include a `service_categories` array listing all categories the artist offers.

--- a/frontend/src/lib/__tests__/categoryMap.test.ts
+++ b/frontend/src/lib/__tests__/categoryMap.test.ts
@@ -4,5 +4,7 @@ describe('categoryMap helpers', () => {
   it('slugifies names consistently', () => {
     expect(categorySlug('MC & Host')).toBe('mc_host');
     expect(categorySlug('Wedding Venue')).toBe('wedding_venue');
+    expect(categorySlug("DJ's")).toBe('dj');
+    expect(categorySlug('Sound Services')).toBe('sound_service');
   });
 });

--- a/frontend/src/lib/categoryMap.ts
+++ b/frontend/src/lib/categoryMap.ts
@@ -39,7 +39,33 @@ export const ID_TO_UI_CATEGORY: Record<number, string> = Object.fromEntries(
   Object.entries(UI_CATEGORY_TO_ID).map(([slug, id]) => [id, slug]),
 );
 
-// Convert a backend category name to a URL-friendly slug. This mirrors the
-// previous hard-coded mapping but works for future categories as well.
-export const categorySlug = (name: string): string =>
-  name.toLowerCase().replace(/&/g, '').replace(/\s+/g, '_');
+// Mapping from backend category names to canonical frontend slugs. This
+// accounts for punctuation and pluralization so that dynamic categories
+// consistently route to the correct homepage sections (e.g., "DJ's" →
+// "dj", "Sound Services" → "sound_service").
+const NAME_TO_SLUG: Record<string, string> = {
+  Musician: 'musician',
+  DJ: 'dj',
+  "DJ's": 'dj',
+  Photographer: 'photographer',
+  Videographer: 'videographer',
+  Speaker: 'speaker',
+  'Sound Service': 'sound_service',
+  'Sound Services': 'sound_service',
+  'Wedding Venue': 'wedding_venue',
+  Caterer: 'caterer',
+  Bartender: 'bartender',
+  'MC & Host': 'mc_host',
+  'MC & Hosts': 'mc_host',
+};
+
+// Convert a backend category name to a URL-friendly slug. Known categories
+// are looked up via NAME_TO_SLUG; others fall back to a sanitized slug.
+export const categorySlug = (name: string): string => {
+  const mapped = NAME_TO_SLUG[name];
+  if (mapped) return mapped;
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+};


### PR DESCRIPTION
## Summary
- Normalize backend category names like "DJ's" and "Sound Services" to canonical slugs
- Verify slug mapping with unit tests
- Document slug normalization in README

## Testing
- `./scripts/test-all.sh` *(no tests executed)*
- `npm test` *(failed: response interceptor falls back)*
- `npm test src/lib/__tests__/categoryMap.test.ts`
- `npm run lint` *(failed: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_689b188b40d0832ebc474a89b4c5d767