### PR TITLE
Estimate sound costs with provider fallback

### DIFF
--- a/backend/tests/test_sound_provisioning.py
+++ b/backend/tests/test_sound_provisioning.py
@@ -1,0 +1,130 @@
+from decimal import Decimal
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.base import BaseModel
+from app.models import Service, User, UserType
+from app.services.booking_quote import calculate_quote_breakdown
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    BaseModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return Session()
+
+
+def create_service(db, *, details=None, price=100):
+    artist = User(
+        email="artist@test.com",
+        password="x",
+        first_name="A",
+        last_name="R",
+        user_type=UserType.SERVICE_PROVIDER,
+    )
+    db.add(artist)
+    db.commit()
+    db.refresh(artist)
+
+    service = Service(
+        artist_id=artist.id,
+        title="Show",
+        price=Decimal(str(price)),
+        duration_minutes=60,
+        service_type="Live Performance",
+        media_url="x",
+        details=details or {},
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+    return service
+
+
+def create_provider(db, *, price=500):
+    provider_user = User(
+        email="provider@test.com",
+        password="x",
+        first_name="P",
+        last_name="R",
+        user_type=UserType.SERVICE_PROVIDER,
+    )
+    db.add(provider_user)
+    db.commit()
+    db.refresh(provider_user)
+
+    provider = Service(
+        artist_id=provider_user.id,
+        title="PA System",
+        price=Decimal(str(price)),
+        duration_minutes=60,
+        service_type="Other",
+        media_url="x",
+        service_category_id=None,
+    )
+    db.add(provider)
+    db.commit()
+    db.refresh(provider)
+    return provider
+
+
+def test_external_provider_fallback():
+    db = setup_db()
+    provider = create_provider(db)
+    service = create_service(
+        db,
+        details={
+            "sound_provisioning": {
+                "mode": "external_providers",
+                "city_preferences": [
+                    {"city": "CPT", "provider_ids": [provider.id]},
+                ],
+            }
+        },
+    )
+
+    breakdown = calculate_quote_breakdown(
+        Decimal("100"),
+        10,
+        service=service,
+        event_city="JNB",  # no matching city, should fallback
+        db=db,
+    )
+
+    assert breakdown["sound_cost"] == Decimal("500.00")
+    assert breakdown["sound_mode"] == "external_providers"
+    assert breakdown["sound_provider_id"] == provider.id
+
+
+def test_own_sound_flight_override():
+    db = setup_db()
+    provider = create_provider(db)
+    service = create_service(
+        db,
+        details={
+            "sound_provisioning": {
+                "mode": "own_sound_drive_only",
+                "city_preferences": [
+                    {"city": "CPT", "provider_ids": [provider.id]},
+                ],
+            }
+        },
+    )
+
+    breakdown = calculate_quote_breakdown(
+        Decimal("100"),
+        600,  # distance triggers flight mode
+        service=service,
+        event_city="CPT",
+        db=db,
+    )
+
+    assert breakdown["sound_cost"] == Decimal("500.00")
+    assert breakdown["sound_mode"] == "external_providers"
+    assert breakdown["sound_mode_overridden"] is True
+    assert breakdown["sound_provider_id"] == provider.id

--- a/docs/travel_estimator.md
+++ b/docs/travel_estimator.md
@@ -25,7 +25,14 @@ The quote calculator also estimates sound equipment costs based on the musician'
 - **Artist-arranged flat:** includes the artist's `sound_flat_price`.
 - **External providers:** picks the artist's preferred provider for the event city and uses that service's price.
 
+If no provider is configured for the event city, the estimator falls back to
+the first preferred provider with a stored price.
+
 The response now includes `sound_cost`, `sound_mode`, and `sound_mode_overridden` fields.
+
+The Booking Wizard automatically recomputes travel mode and sound estimates on
+the review step whenever the user changes the event date or location, ensuring
+the displayed quote always reflects the latest inputs.
 
 Weather forecasts for destinations are fetched asynchronously. The `/api/v1/travel-forecast`
 endpoint now returns a task identifier; clients call `/api/v1/travel-forecast/{task_id}` to

--- a/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/components/booking/__tests__/BookingWizard.test.tsx
@@ -116,5 +116,48 @@ describe('BookingWizard instructions', () => {
     expect(screen.queryByText('Location')).toBeNull();
     expect(Number(progress.getAttribute('aria-valuenow'))).toBeCloseTo(11.11, 2);
   });
+
+  it('recalculates estimates when location changes on review step', async () => {
+    render(<Wrapper />);
+
+    await act(async () => {});
+
+    await act(async () => {
+      (window as unknown as { __setDetails: (d: any) => void }).__setDetails({
+        eventType: 'Party',
+        eventDescription: 'Fun',
+        date: new Date(),
+        time: '18:00',
+        location: 'Cape Town',
+        guests: '10',
+        venueType: 'indoor',
+        sound: 'yes',
+        notes: '',
+        attachment_url: '',
+      });
+      (window as unknown as { __setStep: (s: number) => void }).__setStep(8);
+    });
+
+    expect(api.calculateQuote).toHaveBeenCalledTimes(1);
+    expect(travel.calculateTravelMode).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      (window as unknown as { __setDetails: (d: any) => void }).__setDetails({
+        eventType: 'Party',
+        eventDescription: 'Fun',
+        date: new Date(),
+        time: '18:00',
+        location: 'Johannesburg',
+        guests: '10',
+        venueType: 'indoor',
+        sound: 'yes',
+        notes: '',
+        attachment_url: '',
+      });
+    });
+
+    expect(api.calculateQuote).toHaveBeenCalledTimes(2);
+    expect(travel.calculateTravelMode).toHaveBeenCalledTimes(2);
+  });
 });
 


### PR DESCRIPTION
## Summary
- handle sound provider fallback and override in quote cost estimation
- dynamically recalc travel and sound estimates when booking details change
- add tests for sound provisioning logic and document provider fallback

## Testing
- `pytest`
- `npm test -- --maxWorkers=50% --passWithNoTests` *(fails: response interceptor fails and multiple React warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b23db7c38832eb40640745b22f3ff