### PR TITLE
Log missing booking details

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -62,3 +62,9 @@ name *and* lack any profile details (e.g., description or profile picture).
 This keeps legacy imports from appearing while allowing real DJs who perform
 under their own names to show up in search results.
 
+### Booking detail endpoint
+
+The `/api/v1/bookings/{booking_id}` endpoint logs a warning when a requested
+booking is missing and returns a descriptive `404` message. This makes it easier
+to diagnose why a booking failed to load in development and production logs.
+

--- a/backend/app/api/api_booking.py
+++ b/backend/app/api/api_booking.py
@@ -300,8 +300,14 @@ def read_booking_details(
         .first()
     )
     if not booking_row:
+        logger.warning(
+            "Booking %s not found for user %s",
+            booking_id,
+            getattr(current_user, "id", "anonymous"),
+        )
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Booking not found."
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Booking with id {booking_id} not found.",
         )
 
     (


### PR DESCRIPTION
## Summary
- log a warning when a booking cannot be found and include booking id in the 404 message
- document the new warning for the booking detail endpoint

## Testing
- `./scripts/test-all.sh` *(fails: Git remote 'origin' not found)*
- `./scripts/test-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b5925bfa0832eab080b1909688947