### PR TITLE
Improve error message for sound outreach retry

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -5,6 +5,7 @@ This project emits structured logs and OpenTelemetry traces for both the FastAPI
 ## Logging
 - **Backend**: Python logs are formatted as JSON using `python-json-logger`.
 - **Frontend**: Uses the `pino` logger for structured output.
+- HTTP 422 responses include detailed field errors to simplify debugging (e.g. missing `event_city`).
 
 ## Tracing
 OpenTelemetry is configured with a console exporter. Spans include a `service.name` of either `booking-api` or `booking-frontend`.


### PR DESCRIPTION
## Summary
- clarify event city requirement when retrying sound outreach
- document HTTP 422 field errors in observability guide
- test retry endpoint missing event city

## Testing
- `./scripts/test-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b74d736d4832ea100635fdf3526fa