### PR TITLE
Fix booking ID retrieval after quote acceptance

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -887,7 +887,10 @@ useEffect(() => {
           const freshQuote = await getQuoteV2(quote.id);
           setQuotes((prev) => ({ ...prev, [quote.id]: freshQuote.data }));
 
-          const bookingId = bookingSimple?.id || freshQuote.data.booking_id;
+          // Use the full booking_id returned by the refreshed quote rather than the
+          // BookingSimple id, which refers to a different table and would cause a
+          // 404 when fetching booking details.
+          const bookingId = freshQuote.data.booking_id;
           if (!bookingId) {
             throw new Error('Booking not found after accepting quote');
           }

--- a/frontend/src/components/booking/__tests__/MessageThread.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThread.test.tsx
@@ -48,6 +48,7 @@ describe('MessageThread quote actions', () => {
         subtotal: 100,
         total: 100,
         status: 'pending',
+        booking_id: 99,
       },
     });
     (api.acceptQuoteV2 as jest.Mock).mockResolvedValue({ data: { id: 1 } });
@@ -76,6 +77,7 @@ describe('MessageThread quote actions', () => {
     await act(async () => { await flushPromises(); });
 
     expect(api.acceptQuoteV2).toHaveBeenCalledWith(42, undefined);
+    expect(api.getBookingDetails).toHaveBeenCalledWith(99);
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- Use booking_id from refreshed quote to fetch booking details
- Update MessageThread test to expect booking_id and verify booking details request

## Testing
- `./scripts/test-all.sh` (backend tests passed, frontend skipped)
- `cd frontend && npm test -- --maxWorkers=50% --passWithNoTests` *(fails: TypeError `(0 , _navigation.useSearchParams) is not a function` and other missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_689b775a912c832ea6a6fe2f960ee92c