### PR TITLE
feat(quote): show dynamic sound cost tooltip

### DIFF
--- a/frontend/src/components/booking/InlineQuoteForm.tsx
+++ b/frontend/src/components/booking/InlineQuoteForm.tsx
@@ -16,6 +16,8 @@ interface Props {
   initialTravelCost?: number;
   initialSoundNeeded?: boolean;
   initialSoundCost?: number;
+  drivingSoundCost?: number;
+  flyingSoundCost?: number;
   onDecline?: () => void;
   eventDetails?: EventDetails;
   calculationParams?: {
@@ -43,6 +45,8 @@ const InlineQuoteForm: React.FC<Props> = ({
   initialTravelCost,
   initialSoundNeeded,
   initialSoundCost,
+  drivingSoundCost,
+  flyingSoundCost,
   onDecline,
   eventDetails,
   calculationParams,
@@ -102,6 +106,15 @@ const InlineQuoteForm: React.FC<Props> = ({
       estimatedTotal: calcEstimatedTotal,
     };
   }, [services, serviceFee, soundFee, travelFee, discount]);
+
+  const soundTooltipText = useMemo(() => {
+    if (typeof drivingSoundCost === 'number' || typeof flyingSoundCost === 'number') {
+      const drive = formatCurrency(drivingSoundCost ?? 0);
+      const fly = formatCurrency(flyingSoundCost ?? 0);
+      return `drive mode: ${drive} (price when driving), flight mode: ${fly} (price when flying)`;
+    }
+    return 'Sound equipment cost varies with travel mode';
+  }, [drivingSoundCost, flyingSoundCost]);
 
   const addService = () => setServices([...services, { description: '', price: 0 }]);
   const removeService = (idx: number) => setServices(services.filter((_, i) => i !== idx));
@@ -207,7 +220,7 @@ const InlineQuoteForm: React.FC<Props> = ({
                   <span className="has-tooltip relative ml-1.5 text-blue-500 cursor-pointer">
                     ⓘ
                     <div className="tooltip absolute bottom-full mb-2 w-48 bg-gray-800 text-white text-xs rounded-md p-2 text-center z-10 hidden group-hover:block">
-                      drive mode: R1000 (price when driving), flight mode: R7500 (price when flying)
+                      {soundTooltipText}
                     </div>
                   </span>
                 </span>

--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -245,6 +245,8 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
     const [travelFee, setTravelFee] = useState(initialTravelCost ?? 0);
     const [initialSound, setInitialSound] = useState<boolean | undefined>(initialSoundNeeded);
     const [initialSoundCost, setInitialSoundCost] = useState<number | undefined>(undefined);
+    const [driveSoundCost, setDriveSoundCost] = useState<number | undefined>(undefined);
+    const [flySoundCost, setFlySoundCost] = useState<number | undefined>(undefined);
     const [calculationParams, setCalculationParams] = useState<
       | {
           base_fee: number;
@@ -311,11 +313,17 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(
             const drive = Number(soundProv.price_driving_sound_zar || soundProv.price_driving_sound || 0);
             const fly = Number(soundProv.price_flying_sound_zar || soundProv.price_flying_sound || 0);
             const mode = tb.travel_mode || tb.mode;
+            setDriveSoundCost(drive);
+            setFlySoundCost(fly);
             setInitialSoundCost(mode === 'fly' ? fly : drive);
           } else if (tb.sound_required && tb.sound_cost) {
             setInitialSoundCost(Number(tb.sound_cost));
+            setDriveSoundCost(undefined);
+            setFlySoundCost(undefined);
           } else {
             setInitialSoundCost(undefined);
+            setDriveSoundCost(undefined);
+            setFlySoundCost(undefined);
           }
           const distance = Number(tb.distance_km ?? tb.distanceKm);
           const eventCity = tb.event_city || parsedBookingDetails?.location || '';
@@ -1086,6 +1094,8 @@ useEffect(() => {
         initialTravelCost={travelFee}
         initialSoundNeeded={initialSound}
         initialSoundCost={initialSoundCost}
+        drivingSoundCost={driveSoundCost}
+        flyingSoundCost={flySoundCost}
         calculationParams={calculationParams}
         onSubmit={handleSendQuote}
         onDecline={handleDeclineRequest}

--- a/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
+++ b/frontend/src/components/booking/__tests__/InlineQuoteForm.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import InlineQuoteForm from '../InlineQuoteForm';
 import type { QuoteV2Create } from '@/types';
+import { formatCurrency } from '@/lib/utils';
 
 jest.mock('@/lib/api', () => ({
   ...(jest.requireActual('@/lib/api')),
@@ -121,6 +122,33 @@ describe('InlineQuoteForm', () => {
 
     expect(travelInput?.value).toBe('111');
     expect(soundInput?.value).toBe('222');
+
+    root.unmount();
+    div.remove();
+  });
+
+  it('displays sound cost tooltip with provided prices', async () => {
+    const div = document.createElement('div');
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(
+        <InlineQuoteForm
+          artistId={1}
+          clientId={2}
+          bookingRequestId={3}
+          drivingSoundCost={1000}
+          flyingSoundCost={7500}
+          onSubmit={jest.fn()}
+        />,
+      );
+    });
+
+    const soundSpan = Array.from(div.querySelectorAll('span')).find((s) =>
+      s.textContent?.includes('Sound Equipment'),
+    );
+    const tooltip = soundSpan?.querySelector('.tooltip');
+    expect(tooltip?.textContent).toContain(formatCurrency(1000));
+    expect(tooltip?.textContent).toContain(formatCurrency(7500));
 
     root.unmount();
     div.remove();


### PR DESCRIPTION
## Summary
- show real driving and flying sound prices in inline quote tooltip
- extract sound provisioning costs from booking request details
- add unit test for sound tooltip pricing

## Testing
- `./scripts/test-all.sh` *(fails: response interceptor falls back error, header layout, and many other existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c5139ff08832e92f5ca76ace62f03