### PR TITLE
fix: show search bar on category results

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -48,7 +48,9 @@ export default function MainLayout({
   const isArtistDetail =
     /^\/service-providers\//.test(pathname) && pathname.split('/').length > 2;
   const isArtistsRoot = pathname === '/service-providers';
-  const isArtistsPage = pathname.startsWith('/service-providers');
+  // Treat category listings the same as the service providers page
+  const isArtistsPage =
+    pathname.startsWith('/service-providers') || pathname.startsWith('/category');
   const isArtistView =
     user?.user_type === 'service_provider' && artistViewActive;
 
@@ -346,7 +348,7 @@ export default function MainLayout({
   const showSearchBar =
     !isArtistDetail &&
     !isArtistView &&
-    (pathname === '/' || pathname.startsWith('/service-providers'));
+    (pathname === '/' || pathname.startsWith('/service-providers') || pathname.startsWith('/category'));
 
   return (
     <div className="flex min-h-screen flex-col bg-white bg-gradient-to-b from-brand-light/50 to-gray-50">

--- a/frontend/src/components/layout/README.md
+++ b/frontend/src/components/layout/README.md
@@ -8,6 +8,9 @@
 - `headerFilter?: React.ReactNode` – optional filter control rendered to the right of the full search bar.
 - `fullWidthContent?: boolean` – allow content to span the full width.
 
+The search bar and mobile search pill automatically appear on the homepage and on
+service provider or category listing pages.
+
 `MainLayout` uses CSS custom properties to ensure content isn't obscured by
 fixed navigation elements:
 

--- a/frontend/src/components/layout/__tests__/MainLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/MainLayout.test.tsx
@@ -80,6 +80,21 @@ describe('MainLayout header behavior', () => {
     div.remove();
   });
 
+  it('shows search pill on category pages', async () => {
+      usePathname.mockReturnValue('/category/dj');
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: 11, email: 'cat@test.com', user_type: 'client' } as User, logout: jest.fn() });
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(React.createElement(MainLayout, null, React.createElement('div')));
+    });
+    await flushPromises();
+    expect(div.querySelector('#compact-search-trigger')).toBeTruthy();
+    act(() => { root.unmount(); });
+    div.remove();
+  });
+
   it('expands search bar when compact pill is clicked on artists listing page', async () => {
       usePathname.mockReturnValue('/service-providers');
     (useAuth as jest.Mock).mockReturnValue({ user: { id: 5, email: 'e@test.com', user_type: 'client' } as User, logout: jest.fn() });


### PR DESCRIPTION
## Summary
- show header search bar and mobile pill on `/category/*` pages
- test that category pages render the search pill
- document which pages automatically display the search UI

## Testing
- `./scripts/test-all.sh` *(fails: expect(...) toBeTruthy / toHaveBeenCalled etc)*

------
https://chatgpt.com/codex/tasks/task_e_689edbff05cc832e9fba0112a603e12c