### PR TITLE
fix: keep message replies clean and multiline

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -379,6 +379,10 @@ export interface Message {
 
   /** Client-side status for optimistic UI (include 'queued' for offline-first) */
   status?: 'queued' | 'sending' | 'sent' | 'failed';
+
+  /** Reply metadata */
+  reply_to_message_id?: number | null;
+  reply_to_preview?: string | null;
 }
 
 export interface MessageCreate {
@@ -393,6 +397,9 @@ export interface MessageCreate {
 
   action?: string;
   expires_at?: string;
+
+  /** Optional reply target */
+  reply_to_message_id?: number;
 }
 
 export interface TravelEstimate {


### PR DESCRIPTION
## Context
- replying to a message should not embed the original text
- messages with line breaks lost formatting

## Changes
- send replies without concatenating the parent message
- keep newline formatting in chat bubbles
- add reply metadata fields to message types

## Testing
- `./scripts/test-all.sh` *(fails: SyntaxError in css import, many frontend tests failing)*


------
https://chatgpt.com/codex/tasks/task_e_68a76afcb9f0832eb870f077d319991b