### PR TITLE
feat: preview chat images

### DIFF
--- a/frontend/src/components/booking/MessageThread.tsx
+++ b/frontend/src/components/booking/MessageThread.tsx
@@ -69,6 +69,7 @@ import BookingSummaryCard from './BookingSummaryCard';
 import { t } from '@/lib/i18n';
 import { FEATURE_EVENT_PREP } from '@/lib/constants';
 import EventPrepCard from './EventPrepCard';
+import { ImagePreviewModal } from '@/components/ui';
 
 const EmojiPicker = dynamic(() => import('@emoji-mart/react'), { ssr: false });
 const MemoQuoteBubble = React.memo(QuoteBubble);
@@ -305,6 +306,7 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(functi
   const [isPortalReady, setIsPortalReady] = useState(false);
   const [paymentInfo, setPaymentInfo] = useState<{ status: string | null; amount: number | null; receiptUrl: string | null }>({ status: null, amount: null, receiptUrl: null });
   const [isPaymentOpen, setIsPaymentOpen] = useState(false);
+  const [imageModalUrl, setImageModalUrl] = useState<string | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // ---- Offline queue
@@ -1834,7 +1836,20 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(functi
                                 const isAudio = /\.(webm|mp3|m4a|ogg)$/i.test(url);
                                 if (isImageAttachment(msg.attachment_url)) {
                                   return (
-                                    <a href={url} target="_blank" className="block text-indigo-400 underline mt-1 text-xs hover:text-indigo-300" rel="noopener noreferrer">View image</a>
+                                    <button
+                                      type="button"
+                                      onClick={() => setImageModalUrl(url)}
+                                      className="block mt-1"
+                                    >
+                                      <Image
+                                        src={url}
+                                        alt="Image attachment"
+                                        width={200}
+                                        height={200}
+                                        loading="lazy"
+                                        className="rounded-md max-w-xs h-auto"
+                                      />
+                                    </button>
                                   );
                                 }
                                 if (isAudio) {
@@ -2303,9 +2318,15 @@ const MessageThread = forwardRef<MessageThreadHandle, MessageThreadProps>(functi
               </div>
             )}
 
-          {paymentModal}
-        </>
-      )}
+      {paymentModal}
+
+      <ImagePreviewModal
+        open={Boolean(imageModalUrl)}
+        src={imageModalUrl ?? ''}
+        onClose={() => setImageModalUrl(null)}
+      />
+    </>
+  )}
 
       {/* Quote Drawer removed */}
 

--- a/frontend/src/components/booking/__tests__/MessageThreadImagePreview.test.tsx
+++ b/frontend/src/components/booking/__tests__/MessageThreadImagePreview.test.tsx
@@ -1,0 +1,48 @@
+import { render, fireEvent } from '@testing-library/react';
+import MessageThread from '../MessageThread';
+import * as api from '@/lib/api';
+
+jest.mock('@/hooks/useWebSocket', () => () => ({ send: jest.fn(), onMessage: jest.fn(), updatePresence: jest.fn() }));
+jest.mock('@/lib/api');
+
+function flushPromises() {
+  return new Promise((res) => setTimeout(res, 0));
+}
+
+describe('MessageThread image attachments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (api.useAuth as jest.Mock).mockReturnValue({ user: { id: 1, user_type: 'client', email: 'c@example.com' } });
+    (api.getQuoteV2 as jest.Mock).mockResolvedValue({ data: null });
+    (api.getBookingDetails as jest.Mock).mockResolvedValue({
+      data: { id: 1, service: { title: 'Gig' }, start_time: '2024-01-01T00:00:00Z' },
+    });
+    (api as any).defaults = { baseURL: 'http://localhost:8000' };
+  });
+
+  it('renders image preview and opens modal on click', async () => {
+    (api.getMessagesForBookingRequest as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          booking_request_id: 1,
+          sender_id: 1,
+          sender_type: 'client',
+          content: '',
+          attachment_url: '/static/attachments/pic.jpg',
+          is_read: true,
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const { findByAltText, queryByRole } = render(<MessageThread bookingRequestId={1} />);
+    const img = await findByAltText('Image attachment');
+    expect(img).toBeInTheDocument();
+
+    expect(queryByRole('dialog')).toBeNull();
+    fireEvent.click(img);
+    await flushPromises();
+    expect(queryByRole('dialog')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/ui/ImagePreviewModal.tsx
+++ b/frontend/src/components/ui/ImagePreviewModal.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import Image from 'next/image';
+
+interface ImagePreviewModalProps {
+  open: boolean;
+  src: string;
+  alt?: string;
+  onClose: () => void;
+}
+
+export default function ImagePreviewModal({ open, src, alt = 'Image preview', onClose }: ImagePreviewModalProps) {
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Dialog.Overlay className="fixed inset-0 bg-black/60" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <Dialog.Panel className="relative">
+              <Image
+                src={src}
+                alt={alt}
+                width={800}
+                height={800}
+                className="max-h-[80vh] max-w-full object-contain rounded-md"
+              />
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -24,3 +24,4 @@ export { default as LocationMapModal } from './LocationMapModal';
 export { default as ProgressBar } from './ProgressBar';
 export { default as DateInput } from './DateInput';
 export { default as TravelSummaryCard } from '../booking/TravelSummaryCard';
+export { default as ImagePreviewModal } from './ImagePreviewModal';


### PR DESCRIPTION
## Context
Users couldn't view image attachments inline in chat threads.

## Changes
- render image attachments inline with click-to-enlarge modal
- add reusable `ImagePreviewModal` component and export
- cover image preview with unit test

## Testing
- `./scripts/test-all.sh` *(no tests executed)*
- `cd frontend && npm test` *(fails: Jest failed to parse CSS modules and numerous existing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a7714b57c8832e9c6c4009518efdb3